### PR TITLE
ci: add dependabot auto-merge and skip bot checks

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -19,7 +19,8 @@ jobs:
     name: Claude Automated Review
     if: |
       github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:
@@ -111,7 +112,8 @@ jobs:
     name: Claude Security Review
     if: |
       github.event_name == 'pull_request' &&
-      github.event.pull_request.draft == false
+      github.event.pull_request.draft == false &&
+      github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     continue-on-error: true
     permissions:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,31 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    name: Auto-merge Dependabot PRs
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve PR
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge
+        run: gh pr merge --auto --squash --delete-branch "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -31,6 +31,7 @@ jobs:
 
   branch-name:
     name: Branch naming convention
+    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Validate branch name


### PR DESCRIPTION
## Summary
- Add `dependabot-auto-merge.yml` workflow: auto-approve + squash merge + delete branch for all dependabot PRs
- Skip Claude Automated Review and Security Review for dependabot PRs (Dependabot cannot access repo secrets like `ANTHROPIC_API_KEY`)
- Skip branch naming convention check for dependabot PRs (`dependabot/pip/...` does not match `feat/|fix/|...` pattern)

## Test plan
- [ ] Verify existing dependabot PRs (#27-#34) get re-evaluated after merge
- [ ] Confirm Claude review only runs on non-dependabot PRs
- [ ] Confirm branch naming check skips dependabot PRs