### PR TITLE
ci: fix dependabot auto-merge blocking and branch check

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -18,12 +18,6 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Approve PR
-        run: gh pr review --approve "$PR_URL"
-        env:
-          PR_URL: ${{ github.event.pull_request.html_url }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
       - name: Enable auto-merge
         run: gh pr merge --auto --squash --delete-branch "$PR_URL"
         env:

--- a/.github/workflows/pr-lint.yml
+++ b/.github/workflows/pr-lint.yml
@@ -31,12 +31,16 @@ jobs:
 
   branch-name:
     name: Branch naming convention
-    if: github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Validate branch name
         run: |
           BRANCH="${{ github.head_ref }}"
+          ACTOR="${{ github.actor }}"
+          if [ "$ACTOR" = "dependabot[bot]" ]; then
+            echo "Skipping branch name check for Dependabot"
+            exit 0
+          fi
           PATTERN='^(feat|fix|docs|refactor|test|chore)\/[a-z0-9][a-z0-9\-]*$'
           if ! echo "$BRANCH" | grep -qE "$PATTERN"; then
             echo "::error::Branch name '$BRANCH' does not match pattern: <type>/<kebab-case-scope>"


### PR DESCRIPTION
## Summary
- Remove `approve` step from dependabot-auto-merge workflow (GITHUB_TOKEN cannot self-approve PRs)
- Change branch naming convention job to **pass** (not skip) for dependabot PRs — GitHub required status checks treat `skipped` as not passed, which was blocking auto-merge

## Test plan
- [ ] Dependabot PRs (#27-#34) should no longer be BLOCKED
- [ ] Branch naming convention shows `pass` (not `skipping`) on dependabot PRs
- [ ] Auto-merge workflow completes without error on dependabot PRs