### PR TITLE
feat: implement LLM client and tool system (Wave 1)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,4 +68,4 @@ jobs:
         with:
           enable-cache: true
       - run: uv sync --frozen --all-extras --dev
-      - run: uv run vulture src --min-confidence 80
+      - run: uv run vulture src vulture_whitelist.py --min-confidence 80

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,0 +1,1 @@
+{"feature_directory": "specs/004-llm-client"}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,3 +11,12 @@ This project's agent instructions live in [`AGENTS.md`](./AGENTS.md). Read that 
 - **Model**: Opus (Lead/planning), Sonnet (Teammates/implementation). `effortLevel: high`.
 - **Agent Teams**: Enabled. At `/speckit-implement`, spawn Teammates (Sonnet) for parallel task execution. See `AGENTS.md § Agent Teams` for rules.
 - **TodoWrite**: In-session task tracking only during `/speckit-implement`. Do not persist to disk.
+
+## Active Technologies
+- Python 3.12+ + httpx >=0.27 (async HTTP), pydantic >=2.0 (models), pydantic-settings >=2.0 (config) (spec/wave-1)
+- N/A (in-memory session state only) (spec/wave-1)
+- Python 3.12+ + pydantic >=2.0 (models + validation) (spec/wave-1)
+- N/A (in-memory registry) (spec/wave-1)
+
+## Recent Changes
+- spec/wave-1: Added Python 3.12+ + httpx >=0.27 (async HTTP), pydantic >=2.0 (models), pydantic-settings >=2.0 (config)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ init_typed = true
 warn_required_dynamic_aliases = true
 
 [tool.vulture]
-paths = ["src"]
+paths = ["src", "vulture_whitelist.py"]
 min_confidence = 80
 
 [tool.commitizen]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,7 @@ authors = [{ name = "umyunsang" }]
 dependencies = [
     "httpx>=0.27",
     "pydantic>=2.0",
+    "pydantic-settings>=2.0",
     "typer>=0.24.1",
     "rich>=13.0",
 ]

--- a/specs/004-llm-client/checklists/requirements.md
+++ b/specs/004-llm-client/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: LLM Client Integration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-001 mentions "OpenAI-compatible chat completions API" — this is an interface contract, not an implementation detail, as it defines the external API the system must interoperate with.
+- FR-005 specifies exponential backoff parameters — these are behavioral requirements, not implementation constraints.
+- All items pass validation. Spec is ready for `/speckit-plan`.

--- a/specs/004-llm-client/contracts/llm-client-api.md
+++ b/specs/004-llm-client/contracts/llm-client-api.md
@@ -1,0 +1,131 @@
+# Contract: LLM Client API
+
+**Module**: `kosmos.llm`
+**Date**: 2026-04-12
+
+## Public Interface
+
+### LLMClient
+
+```python
+class LLMClient:
+    """Async LLM client for FriendliAI Serverless endpoint."""
+
+    def __init__(self, config: LLMClientConfig | None = None) -> None:
+        """Initialize with config. Loads from env vars if config is None.
+
+        Raises:
+            ConfigurationError: If KOSMOS_FRIENDLI_TOKEN is missing.
+        """
+
+    async def complete(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
+        stop: list[str] | None = None,
+    ) -> ChatCompletionResponse:
+        """Send a non-streaming chat completion request.
+
+        Raises:
+            BudgetExceededError: If session token budget is exhausted.
+            AuthenticationError: If API returns 401/403.
+            LLMConnectionError: If endpoint is unreachable after retries.
+            LLMResponseError: If API returns non-retryable error.
+        """
+
+    async def stream(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
+        stop: list[str] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Send a streaming chat completion request.
+
+        Yields StreamEvent objects as they arrive. Final event contains usage stats.
+
+        Raises:
+            BudgetExceededError: If session token budget is exhausted.
+            AuthenticationError: If API returns 401/403.
+            LLMConnectionError: If endpoint is unreachable after retries.
+            StreamInterruptedError: If stream is interrupted mid-response.
+        """
+
+    @property
+    def usage(self) -> UsageTracker:
+        """Current session usage tracker."""
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+
+    async def __aenter__(self) -> "LLMClient": ...
+    async def __aexit__(self, *args) -> None: ...
+```
+
+### UsageTracker
+
+```python
+class UsageTracker:
+    """Tracks cumulative token usage against a session budget."""
+
+    def __init__(self, budget: int) -> None: ...
+
+    def can_afford(self, estimated_input_tokens: int) -> bool:
+        """Pre-flight check: is there likely enough budget for this call?"""
+
+    def debit(self, usage: TokenUsage) -> None:
+        """Record usage from a completed call."""
+
+    @property
+    def remaining(self) -> int:
+        """Remaining token budget."""
+
+    @property
+    def is_exhausted(self) -> bool:
+        """Whether the budget is fully consumed."""
+```
+
+## Error Hierarchy
+
+```python
+class KosmosLLMError(Exception):
+    """Base exception for all LLM client errors."""
+
+class ConfigurationError(KosmosLLMError):
+    """Missing or invalid configuration (e.g., missing KOSMOS_FRIENDLI_TOKEN)."""
+
+class BudgetExceededError(KosmosLLMError):
+    """Session token budget exhausted."""
+
+class AuthenticationError(KosmosLLMError):
+    """API authentication failed (401/403)."""
+
+class LLMConnectionError(KosmosLLMError):
+    """Endpoint unreachable after retry exhaustion."""
+
+class LLMResponseError(KosmosLLMError):
+    """Non-retryable API error (400, 404, 500)."""
+
+class StreamInterruptedError(KosmosLLMError):
+    """Streaming response interrupted mid-delivery."""
+```
+
+## Module Layout
+
+```
+src/kosmos/llm/
+├── __init__.py          # Public exports: LLMClient, models, errors
+├── client.py            # LLMClient implementation
+├── models.py            # Pydantic v2 models (ChatMessage, StreamEvent, etc.)
+├── config.py            # LLMClientConfig (pydantic-settings)
+├── errors.py            # Error hierarchy
+├── retry.py             # RetryPolicy and retry logic
+└── usage.py             # UsageTracker
+```

--- a/specs/004-llm-client/contracts/llm-client-api.md
+++ b/specs/004-llm-client/contracts/llm-client-api.md
@@ -54,8 +54,8 @@ class LLMClient:
         Raises:
             BudgetExceededError: If session token budget is exhausted.
             AuthenticationError: If API returns 401/403.
-            LLMConnectionError: If endpoint is unreachable after retries.
-            StreamInterruptedError: If stream is interrupted mid-response.
+            StreamInterruptedError: If the streaming request cannot be established
+                or the stream is interrupted before completion.
         """
 
     @property

--- a/specs/004-llm-client/data-model.md
+++ b/specs/004-llm-client/data-model.md
@@ -1,0 +1,184 @@
+# Data Model: LLM Client Integration
+
+**Feature**: Epic #4 — LLM Client Integration
+**Date**: 2026-04-12
+
+## Entities
+
+### 1. LLMClientConfig
+
+Configuration for the LLM client, loaded from environment variables.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `token` | `SecretStr` | Yes | — | FriendliAI API token (`KOSMOS_FRIENDLI_TOKEN`) |
+| `base_url` | `HttpUrl` | No | `https://api.friendli.ai/v1` | API base URL |
+| `model` | `str` | No | `dep89a2fde0e09` | Model identifier |
+| `session_budget` | `int` | No | `100000` | Max tokens per session |
+| `timeout` | `float` | No | `60.0` | Request timeout in seconds |
+| `max_retries` | `int` | No | `3` | Max retry attempts for transient errors |
+
+**Validation**: `token` must not be empty. `session_budget` must be > 0. `timeout` must be > 0.
+
+---
+
+### 2. ChatMessage
+
+A message in the conversation. Follows OpenAI format.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `role` | `Literal["system", "user", "assistant", "tool"]` | Yes | — | Message role |
+| `content` | `str \| None` | No | `None` | Text content |
+| `name` | `str \| None` | No | `None` | Name for tool messages |
+| `tool_calls` | `list[ToolCall] \| None` | No | `None` | Tool calls (assistant only) |
+| `tool_call_id` | `str \| None` | No | `None` | Tool call ID (tool role only) |
+
+**Validation**: `tool` role requires `tool_call_id`. `assistant` role may have `tool_calls`. `system` and `user` roles must have `content`.
+
+---
+
+### 3. ToolCall
+
+A tool invocation requested by the model.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | `str` | Yes | — | Unique call identifier |
+| `type` | `Literal["function"]` | Yes | `"function"` | Always "function" |
+| `function` | `FunctionCall` | Yes | — | Function name and arguments |
+
+---
+
+### 4. FunctionCall
+
+Function name and serialized arguments within a tool call.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | `str` | Yes | — | Function/tool name |
+| `arguments` | `str` | Yes | — | JSON-serialized arguments |
+
+---
+
+### 5. ToolDefinition
+
+Tool schema sent to the model for function calling.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | `Literal["function"]` | Yes | `"function"` | Always "function" |
+| `function` | `FunctionSchema` | Yes | — | Function metadata and parameters |
+
+---
+
+### 6. FunctionSchema
+
+Schema definition for a function/tool.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `name` | `str` | Yes | — | Function name |
+| `description` | `str` | Yes | — | Human-readable description |
+| `parameters` | `dict[str, Any]` | Yes | — | JSON Schema for parameters |
+
+**Note**: `parameters` uses `dict[str, Any]` because it holds a JSON Schema object. This is the one case where `Any` is acceptable — it represents an external schema, not internal I/O.
+
+---
+
+### 7. TokenUsage
+
+Token counts from a single LLM call.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `input_tokens` | `int` | Yes | `0` | Prompt/input tokens |
+| `output_tokens` | `int` | Yes | `0` | Completion/output tokens |
+| `cache_read_tokens` | `int` | No | `0` | Cache read tokens |
+| `cache_write_tokens` | `int` | No | `0` | Cache write tokens |
+| `total_tokens` | `int` | computed | — | `input_tokens + output_tokens` |
+
+---
+
+### 8. ChatCompletionResponse
+
+Complete response from a non-streaming LLM call.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | `str` | Yes | — | Response identifier |
+| `content` | `str \| None` | No | `None` | Text content |
+| `tool_calls` | `list[ToolCall]` | No | `[]` | Tool calls if any |
+| `usage` | `TokenUsage` | Yes | — | Token usage statistics |
+| `model` | `str` | Yes | — | Model that generated the response |
+| `finish_reason` | `Literal["stop", "tool_calls", "length"]` | Yes | — | Why generation stopped |
+
+---
+
+### 9. StreamEvent
+
+A single event from a streaming LLM response.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `type` | `Literal["content_delta", "tool_call_delta", "usage", "done", "error"]` | Yes | — | Event type |
+| `content` | `str \| None` | No | `None` | Content delta text |
+| `tool_call_index` | `int \| None` | No | `None` | Index of tool call being built |
+| `tool_call_id` | `str \| None` | No | `None` | Tool call ID (first chunk only) |
+| `function_name` | `str \| None` | No | `None` | Function name (first chunk only) |
+| `function_args_delta` | `str \| None` | No | `None` | Partial function arguments JSON |
+| `usage` | `TokenUsage \| None` | No | `None` | Final usage (last event only) |
+
+---
+
+### 10. UsageTracker
+
+Session-level token budget tracker (not persisted).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `budget` | `int` | Yes | — | Max tokens for this session |
+| `input_tokens_used` | `int` | No | `0` | Cumulative input tokens |
+| `output_tokens_used` | `int` | No | `0` | Cumulative output tokens |
+| `call_count` | `int` | No | `0` | Number of LLM calls made |
+
+**Methods**:
+- `can_afford(estimated_input: int) -> bool`: Pre-flight budget check
+- `debit(usage: TokenUsage) -> None`: Record usage after a call
+- `remaining -> int`: Computed remaining budget
+- `is_exhausted -> bool`: Whether budget is fully consumed
+
+**State transitions**:
+```
+Created(budget=N) → debit() → Active(used < budget) → debit() → Exhausted(used >= budget)
+                                                                    ↓
+                                                               Rejects further calls
+```
+
+---
+
+### 11. RetryPolicy
+
+Configuration for retry behavior.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `max_retries` | `int` | No | `3` | Maximum retry attempts |
+| `base_delay` | `float` | No | `1.0` | Base delay in seconds |
+| `multiplier` | `float` | No | `2.0` | Backoff multiplier |
+| `max_delay` | `float` | No | `60.0` | Maximum delay cap |
+| `retryable_status_codes` | `frozenset[int]` | No | `{429, 503}` | HTTP status codes to retry |
+
+## Relationships
+
+```
+LLMClientConfig ──configures──→ LLMClient
+LLMClient ──uses──→ RetryPolicy
+LLMClient ──tracks──→ UsageTracker
+LLMClient ──sends──→ list[ChatMessage] + list[ToolDefinition]
+LLMClient ──receives──→ ChatCompletionResponse | AsyncIterator[StreamEvent]
+ChatMessage ──contains──→ ToolCall? (assistant role)
+ChatCompletionResponse ──contains──→ TokenUsage
+StreamEvent ──final──→ TokenUsage
+UsageTracker ──debits──→ TokenUsage
+```

--- a/specs/004-llm-client/plan.md
+++ b/specs/004-llm-client/plan.md
@@ -1,0 +1,96 @@
+# Implementation Plan: LLM Client Integration (FriendliAI K-EXAONE)
+
+**Branch**: `spec/wave-1` | **Date**: 2026-04-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/004-llm-client/spec.md`
+
+## Summary
+
+Implement an async LLM client for FriendliAI Serverless endpoint serving K-EXAONE, with streaming SSE support, token usage tracking, session budget enforcement, and exponential backoff retry logic. The client uses httpx for HTTP, Pydantic v2 for all I/O models, and async generators for streaming — following the Claude Agent SDK communication protocol pattern.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+
+**Primary Dependencies**: httpx >=0.27 (async HTTP), pydantic >=2.0 (models), pydantic-settings >=2.0 (config)
+**Storage**: N/A (in-memory session state only)
+**Testing**: pytest + pytest-asyncio + respx (httpx mocking)
+**Target Platform**: Cross-platform (macOS, Linux) CLI
+**Project Type**: Library module within KOSMOS (`src/kosmos/llm/`)
+**Performance Goals**: Streaming TTFT overhead < 50ms (client-side processing only); non-streaming latency bound by model generation time
+**Constraints**: No hardcoded API keys; session budget enforcement; KOSMOS_ env var prefix; fail-closed security posture
+**Scale/Scope**: Single concurrent session for Phase 1; design for future multi-session support
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Reference-Driven Development | PASS | All design decisions mapped to Claude Agent SDK (async generator), OpenAI Agents SDK (retry matrix), vision.md Layer 1/6 |
+| II. Fail-Closed Security | PASS | N/A for LLM client (no citizen PII). Config requires explicit token. |
+| III. Pydantic v2 Strict Typing | PASS | All models use Pydantic v2. `Any` only in JSON Schema parameters (external format). |
+| IV. Government API Compliance | N/A | LLM client does not call data.go.kr APIs |
+| V. Policy Alignment | PASS | Budget enforcement supports taxpayer-funded cost control |
+
+**Post-Phase 1 re-check**: PASS. Data model uses Pydantic v2 throughout. No `Any` in I/O schemas (JSON Schema `parameters` field uses `dict[str, Any]` which represents an external schema definition, not internal KOSMOS I/O). All config via `KOSMOS_`-prefixed env vars.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/004-llm-client/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — 6 research tasks resolved
+├── data-model.md        # Phase 1 output — 11 entities defined
+├── quickstart.md        # Phase 1 output — usage examples
+├── contracts/
+│   └── llm-client-api.md  # Public API contract
+└── tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/kosmos/
+├── __init__.py           # Existing
+└── llm/
+    ├── __init__.py       # Public exports
+    ├── client.py         # LLMClient (complete + stream methods)
+    ├── models.py         # Pydantic v2 models (ChatMessage, StreamEvent, etc.)
+    ├── config.py         # LLMClientConfig (pydantic-settings)
+    ├── errors.py         # Error hierarchy (KosmosLLMError and subclasses)
+    ├── retry.py          # RetryPolicy and exponential backoff logic
+    └── usage.py          # UsageTracker with budget enforcement
+
+tests/
+└── llm/
+    ├── __init__.py
+    ├── conftest.py       # Shared fixtures (mock client, respx routes)
+    ├── test_client.py    # LLMClient unit tests
+    ├── test_models.py    # Pydantic model validation tests
+    ├── test_config.py    # Configuration loading tests
+    ├── test_retry.py     # Retry logic tests
+    ├── test_usage.py     # UsageTracker tests
+    └── test_streaming.py # SSE streaming tests
+```
+
+**Structure Decision**: Single project layout. The LLM client is a library module (`kosmos.llm`) within the KOSMOS package, not a standalone service.
+
+## Reference Mapping
+
+| Design Decision | Primary Reference | Secondary Reference |
+|----------------|-------------------|---------------------|
+| Async generator streaming | Claude Agent SDK — async generator communication protocol | vision.md Layer 1 — "No callbacks, no event buses" |
+| Mutable history + immutable snapshots | vision.md Layer 1 — prompt cache trick | Claude Code reconstructed (tool loop internals) |
+| Exponential backoff with jitter | vision.md Layer 6 — error recovery matrix | OpenAI Agents SDK — retry matrix with composable policies |
+| Token budget enforcement | vision.md Layer 1 — cost accounting as first-class | Claude Agent SDK — usage tracking |
+| Pydantic v2 models for all I/O | Constitution § III — strict typing | Pydantic AI — schema-driven tool registry |
+| Environment-based config | Constitution § IV — no hardcoded keys | AGENTS.md — KOSMOS_ prefix |
+
+## Dependency Note
+
+`pydantic-settings` (separate from `pydantic`) must be added to `pyproject.toml` dependencies for `LLMClientConfig`. This is the only new dependency beyond what's already declared.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/004-llm-client/quickstart.md
+++ b/specs/004-llm-client/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: LLM Client Integration
+
+**Feature**: Epic #4 — LLM Client Integration
+
+## Setup
+
+```bash
+# Install dependencies
+uv sync
+
+# Set required environment variable
+export KOSMOS_FRIENDLI_TOKEN="your-token-here"
+
+# Optional configuration
+export KOSMOS_FRIENDLI_BASE_URL="https://api.friendli.ai/v1"
+export KOSMOS_FRIENDLI_MODEL="dep89a2fde0e09"
+export KOSMOS_LLM_SESSION_BUDGET="100000"
+```
+
+## Basic Usage
+
+### Non-streaming completion
+
+```python
+from kosmos.llm import LLMClient, ChatMessage
+
+async with LLMClient() as client:
+    response = await client.complete([
+        ChatMessage(role="system", content="You are a helpful assistant."),
+        ChatMessage(role="user", content="Hello!"),
+    ])
+    print(response.content)
+    print(f"Tokens used: {response.usage.total_tokens}")
+```
+
+### Streaming completion
+
+```python
+from kosmos.llm import LLMClient, ChatMessage
+
+async with LLMClient() as client:
+    async for event in client.stream([
+        ChatMessage(role="user", content="Explain Python async generators."),
+    ]):
+        if event.type == "content_delta":
+            print(event.content, end="", flush=True)
+        elif event.type == "usage":
+            print(f"\nTokens: {event.usage.total_tokens}")
+```
+
+### With tool definitions
+
+```python
+from kosmos.llm import LLMClient, ChatMessage, ToolDefinition, FunctionSchema
+
+tools = [
+    ToolDefinition(
+        type="function",
+        function=FunctionSchema(
+            name="get_weather",
+            description="Get current weather for a location",
+            parameters={
+                "type": "object",
+                "properties": {
+                    "location": {"type": "string", "description": "City name"}
+                },
+                "required": ["location"],
+            },
+        ),
+    )
+]
+
+async with LLMClient() as client:
+    response = await client.complete(
+        [ChatMessage(role="user", content="What's the weather in Seoul?")],
+        tools=tools,
+    )
+    if response.tool_calls:
+        for call in response.tool_calls:
+            print(f"Tool: {call.function.name}({call.function.arguments})")
+```
+
+### Budget tracking
+
+```python
+async with LLMClient() as client:
+    print(f"Budget remaining: {client.usage.remaining}")
+
+    response = await client.complete([...])
+    print(f"Budget remaining: {client.usage.remaining}")
+    print(f"Calls made: {client.usage.call_count}")
+```
+
+## Running Tests
+
+```bash
+# Unit tests (uses recorded fixtures, no API access needed)
+uv run pytest tests/llm/
+
+# Live tests (requires valid KOSMOS_FRIENDLI_TOKEN)
+uv run pytest tests/llm/ -m live
+```

--- a/specs/004-llm-client/quickstart.md
+++ b/specs/004-llm-client/quickstart.md
@@ -97,6 +97,6 @@ async with LLMClient() as client:
 # Unit tests (uses recorded fixtures, no API access needed)
 uv run pytest tests/llm/
 
-# Live tests (requires valid KOSMOS_FRIENDLI_TOKEN)
-uv run pytest tests/llm/ -m live
+# Live tests are planned for Phase 2 (requires valid KOSMOS_FRIENDLI_TOKEN)
+# uv run pytest tests/llm/ -m live
 ```

--- a/specs/004-llm-client/research.md
+++ b/specs/004-llm-client/research.md
@@ -74,7 +74,9 @@ async def stream_chat(self, messages: list[ChatMessage], **kwargs) -> AsyncItera
 
 **Implementation**:
 ```python
-delay = min(base * (multiplier ** attempt) + random.uniform(0, 1), cap)
+# Full jitter: random between 0 and exponential ceiling
+exp_delay = min(max_delay, base_delay * (multiplier ** attempt))
+delay = random.uniform(0, exp_delay)
 ```
 
 ---
@@ -83,9 +85,9 @@ delay = min(base * (multiplier ** attempt) + random.uniform(0, 1), cap)
 
 **Question**: How should token usage be tracked across a session?
 
-**Decision**: In-memory `UsageTracker` with per-call debit and session budget enforcement. Pre-flight check using estimated input tokens before each call.
+**Decision**: In-memory `UsageTracker` with per-call debit and session budget enforcement. Pre-flight check verifies remaining budget can cover `max_tokens` (or 1 token minimum) before each call.
 
-**Rationale**: From `docs/vision.md` Layer 1 — "Every LLM call and every public API call is debited against a session budget." The tracker maintains cumulative input/output token counts and compares against a configurable budget. Pre-flight estimation uses message character count heuristic (1 token ≈ 4 chars for English, ≈ 2 chars for Korean) to reject calls that would likely exceed budget.
+**Rationale**: From `docs/vision.md` Layer 1 — "Every LLM call and every public API call is debited against a session budget." The tracker maintains cumulative input/output token counts and compares against a configurable budget. Pre-flight check uses `can_afford(max_tokens or 1)` to reject calls when budget is exhausted. Input-token estimation via message size heuristics (1 token ≈ 4 chars for English, ≈ 2 chars for Korean) is deferred to Phase 2 pending K-EXAONE tokenizer validation.
 
 **Reference**: Claude Agent SDK — usage tracking and cost accounting.
 

--- a/specs/004-llm-client/research.md
+++ b/specs/004-llm-client/research.md
@@ -1,0 +1,133 @@
+# Phase 0 Research: LLM Client Integration (FriendliAI K-EXAONE)
+
+**Feature**: Epic #4 — LLM Client Integration
+**Date**: 2026-04-12
+**Status**: Complete
+
+## Research Tasks
+
+### RT-1: FriendliAI Serverless API Compatibility
+
+**Question**: What is the exact API contract for FriendliAI Serverless with K-EXAONE?
+
+**Decision**: Use the OpenAI-compatible chat completions API (`/v1/chat/completions`) exposed by FriendliAI Serverless.
+
+**Rationale**: FriendliAI Serverless provides an OpenAI-compatible endpoint. This means standard `POST /v1/chat/completions` with `model`, `messages`, `tools`, `stream`, `temperature`, `max_tokens`, `top_p`, and `stop` parameters. The response format mirrors OpenAI's `ChatCompletion` object with `choices[].message.content`, `choices[].message.tool_calls`, and `usage` (prompt_tokens, completion_tokens, total_tokens). Streaming uses SSE with `data: {...}` lines and `data: [DONE]` terminator.
+
+**Alternatives considered**:
+- Native FriendliAI SDK: rejected — adds an unnecessary dependency when httpx can call the OpenAI-compatible endpoint directly.
+- OpenAI Python SDK with custom base_url: viable but adds ~15MB dependency for functionality we can implement in ~200 lines of httpx.
+- LiteLLM: rejected — too heavy for a focused integration; we need precise control over streaming and retry behavior.
+
+**Key findings**:
+- Auth header: `Authorization: Bearer $KOSMOS_FRIENDLI_TOKEN`
+- Base URL: configurable via `KOSMOS_FRIENDLI_BASE_URL` (default: `https://api.friendli.ai/v1`)
+- Model identifier: configurable via `KOSMOS_FRIENDLI_MODEL` (default: `dep89a2fde0e09`)
+- Streaming: `stream: true` returns SSE chunks with `delta.content` and `delta.tool_calls`
+- Tool calling: OpenAI function-calling format (`tools` parameter with `type: "function"`)
+- Token usage: returned in final chunk when streaming, or in response body for non-streaming
+
+---
+
+### RT-2: Async Streaming Pattern Selection
+
+**Question**: How should the LLM client yield streaming responses?
+
+**Decision**: Use async generators (`AsyncIterator[StreamEvent]`) as the communication protocol, following Claude Agent SDK patterns.
+
+**Rationale**: From `docs/vision.md` Layer 1 — "Async generators as the communication protocol. No callbacks, no event buses." The loop yields progress events; the caller applies backpressure by consuming at its own rate; cancellation propagates naturally when the consumer stops. This maps directly to Python's `async for chunk in client.stream(...)` pattern.
+
+**Reference**: Claude Agent SDK (`anthropics/claude-agent-sdk-python`) — async generator tool loop, context management.
+
+**Alternatives considered**:
+- Callback-based: rejected per vision.md — "No callbacks, no event buses"
+- Queue-based (asyncio.Queue): viable but async generators are simpler and cancellation is automatic
+- Observable/RxPY: rejected — over-engineered for this use case
+
+**Implementation pattern**:
+```python
+async def stream_chat(self, messages: list[ChatMessage], **kwargs) -> AsyncIterator[StreamEvent]:
+    async with self._client.stream("POST", "/chat/completions", json=payload) as response:
+        async for line in response.aiter_lines():
+            if line.startswith("data: ") and line != "data: [DONE]":
+                chunk = json.loads(line[6:])
+                yield StreamEvent.from_chunk(chunk)
+```
+
+---
+
+### RT-3: Retry Strategy for Transient Failures
+
+**Question**: What retry strategy should be used for transient API failures?
+
+**Decision**: Exponential backoff with full jitter, base 1s, multiplier 2x, cap 60s, max 3 retries. Only retry 429 and 503.
+
+**Rationale**: From `docs/vision.md` Layer 6 — "429 Rate limited → exponential backoff (base 1s, cap 60s)". From spec FR-005: "exponential backoff (base 1s, multiplier 2x, jitter, cap 60s, max 3 retries)". Full jitter (random between 0 and calculated delay) prevents thundering herd across concurrent sessions.
+
+**Reference**: OpenAI Agents SDK (`openai/openai-agents-python`) — retry matrix with composable policies. AWS architecture blog exponential backoff pattern.
+
+**Alternatives considered**:
+- Fixed delay: rejected — causes thundering herd
+- Decorrelated jitter: viable but full jitter is simpler and sufficient for our scale
+- tenacity library: rejected — adds dependency for ~30 lines of retry logic
+- httpx built-in retry: httpx does not have built-in retry; transport-level retry via httpx.AsyncHTTPTransport has limited control
+
+**Implementation**:
+```python
+delay = min(base * (multiplier ** attempt) + random.uniform(0, 1), cap)
+```
+
+---
+
+### RT-4: Token Usage Tracking Architecture
+
+**Question**: How should token usage be tracked across a session?
+
+**Decision**: In-memory `UsageTracker` with per-call debit and session budget enforcement. Pre-flight check using estimated input tokens before each call.
+
+**Rationale**: From `docs/vision.md` Layer 1 — "Every LLM call and every public API call is debited against a session budget." The tracker maintains cumulative input/output token counts and compares against a configurable budget. Pre-flight estimation uses message character count heuristic (1 token ≈ 4 chars for English, ≈ 2 chars for Korean) to reject calls that would likely exceed budget.
+
+**Reference**: Claude Agent SDK — usage tracking and cost accounting.
+
+**Alternatives considered**:
+- Post-flight only: rejected — a single large call could blow the entire budget before we know the cost
+- Persistent tracker (DB/file): rejected for Phase 1 — in-memory is sufficient for single-session CLI
+- Token counting library (tiktoken): rejected — K-EXAONE tokenizer is not publicly available; heuristic is sufficient for budget guardrails
+
+---
+
+### RT-5: httpx SSE Parsing Strategy
+
+**Question**: How to parse Server-Sent Events from httpx streaming response?
+
+**Decision**: Manual SSE line parsing from `response.aiter_lines()`. Parse `data:` prefix, skip empty lines and `[DONE]` sentinel.
+
+**Rationale**: httpx does not have built-in SSE support. The SSE format is simple enough (each event is `data: {json}\n\n` with `data: [DONE]` terminator) that manual parsing is reliable and avoids adding an SSE library dependency.
+
+**Alternatives considered**:
+- httpx-sse library: viable but adds a dependency for trivial parsing logic
+- aiohttp with SSE: rejected — we standardize on httpx per AGENTS.md
+- Custom SSE transport: over-engineered for a single endpoint
+
+---
+
+### RT-6: Configuration Management
+
+**Question**: How should the LLM client be configured?
+
+**Decision**: Environment variables with Pydantic Settings model. All env vars use `KOSMOS_` prefix per AGENTS.md.
+
+**Rationale**: Constitution requires `KOSMOS_` prefix for all env vars. Pydantic Settings (`pydantic-settings`) integrates naturally with Pydantic v2 validation and provides type-safe configuration with clear error messages for missing required fields.
+
+**Key env vars**:
+- `KOSMOS_FRIENDLI_TOKEN` (required): API authentication token
+- `KOSMOS_FRIENDLI_BASE_URL` (optional, default: `https://api.friendli.ai/v1`): API base URL
+- `KOSMOS_FRIENDLI_MODEL` (optional, default: `dep89a2fde0e09`): Model identifier
+- `KOSMOS_LLM_SESSION_BUDGET` (optional, default: `100000`): Max tokens per session
+
+**Alternatives considered**:
+- YAML/JSON config file: rejected for Phase 1 — env vars are simpler and more secure
+- python-dotenv: rejected — pydantic-settings handles .env files natively if needed
+- dataclasses: rejected — Pydantic v2 provides validation that dataclasses lack
+
+**Note**: `pydantic-settings` is a separate package from `pydantic`. It must be added to `pyproject.toml` dependencies.

--- a/specs/004-llm-client/spec.md
+++ b/specs/004-llm-client/spec.md
@@ -1,0 +1,122 @@
+# Feature Specification: LLM Client Integration (FriendliAI K-EXAONE)
+
+**Epic**: #4
+**Created**: 2026-04-12
+**Status**: Draft
+**Layer**: Cross-cutting (LLM infrastructure)
+**Input**: Async LLM client for FriendliAI Serverless endpoint serving K-EXAONE model, with streaming, token tracking, budget enforcement, and retry logic.
+
+## User Scenarios & Testing
+
+### User Story 1 - Single-turn Query Resolution (Priority: P1)
+
+A citizen asks a natural-language question through the CLI. The system sends the query to K-EXAONE via FriendliAI Serverless and streams the response back in real time, so the citizen sees progressive output rather than waiting for the entire response.
+
+**Why this priority**: This is the fundamental interaction loop. Without a working LLM client, no other layer functions.
+
+**Independent Test**: Can be fully tested by sending a prompt string and verifying that a streamed response is received with correct content and token usage metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid KOSMOS_FRIENDLI_TOKEN is configured, **When** the system sends a prompt to K-EXAONE, **Then** a streamed response is received with content and token usage counts (input tokens, output tokens).
+2. **Given** a valid configuration, **When** a prompt is sent, **Then** the response streams incrementally (chunk by chunk) rather than arriving as a single block.
+
+---
+
+### User Story 2 - Session Budget Enforcement (Priority: P2)
+
+During a conversation session, each LLM call is debited against a session token budget. When the budget is exhausted, the system stops making LLM calls and informs the citizen that the session limit has been reached.
+
+**Why this priority**: Cost control is essential for a taxpayer-funded service. Without budget enforcement, a single session could consume disproportionate resources.
+
+**Independent Test**: Can be tested by configuring a low token budget, making calls until the budget is exhausted, and verifying the system refuses further calls with an appropriate message.
+
+**Acceptance Scenarios**:
+
+1. **Given** a session budget of 1000 tokens, **When** cumulative usage reaches 1000 tokens, **Then** the next LLM call is rejected with a budget-exceeded error.
+2. **Given** a session budget, **When** each LLM call completes, **Then** the usage tracker reflects the updated remaining budget.
+
+---
+
+### User Story 3 - Transient Failure Recovery (Priority: P2)
+
+When the FriendliAI endpoint returns a transient error (429 rate limit or 503 service unavailable), the client automatically retries with exponential backoff. Permanent errors (401 unauthorized, 400 bad request) are not retried.
+
+**Why this priority**: Public API reliability is critical for citizen trust. Transient failures should be invisible to the citizen.
+
+**Independent Test**: Can be tested by simulating 429/503 responses and verifying automatic retry with backoff, and simulating 401/400 responses and verifying immediate failure.
+
+**Acceptance Scenarios**:
+
+1. **Given** the endpoint returns 429, **When** the client retries, **Then** it uses exponential backoff (base 1s, cap 60s) and succeeds when the endpoint recovers.
+2. **Given** the endpoint returns 503 three times then succeeds, **When** the client retries, **Then** it delivers the successful response to the caller.
+3. **Given** the endpoint returns 401, **When** the client processes the error, **Then** it raises an authentication error immediately without retrying.
+
+---
+
+### User Story 4 - Tool Use Message Assembly (Priority: P3)
+
+The LLM client supports assembling messages with tool definitions and tool results in the OpenAI-compatible format, enabling the query engine to run a tool loop where the model can request tool calls and receive results.
+
+**Why this priority**: The tool loop is Layer 1's core mechanism, but initial client functionality (stories 1-3) can work without tool use.
+
+**Independent Test**: Can be tested by sending a message sequence that includes tool definitions and verifying the model's response includes tool_calls in the expected format.
+
+**Acceptance Scenarios**:
+
+1. **Given** a message list with tool definitions, **When** sent to the model, **Then** the response may contain tool_calls with function name and arguments.
+2. **Given** a prior tool_call response and a tool result message, **When** the continuation is sent, **Then** the model incorporates the tool result in its next response.
+
+---
+
+### Edge Cases
+
+- What happens when KOSMOS_FRIENDLI_TOKEN is not set or empty? System raises a configuration error at startup.
+- What happens when the endpoint is completely unreachable (network down)? Client raises a connection error after retry exhaustion.
+- What happens when the response stream is interrupted mid-chunk? Client raises a stream error; the caller can retry the full call.
+- What happens when the model returns an empty response? Client returns an empty content string with zero output tokens; caller decides how to handle.
+- What happens when token counts in the response are missing? Client treats missing counts as zero and logs a warning.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST connect to FriendliAI Serverless endpoint using the OpenAI-compatible chat completions API.
+- **FR-002**: System MUST support streaming responses via Server-Sent Events (SSE), yielding chunks as they arrive.
+- **FR-003**: System MUST track token usage per call: input tokens, output tokens, and cache read/write tokens (if available).
+- **FR-004**: System MUST enforce a configurable per-session token budget. Calls that would exceed the budget MUST be rejected before sending.
+- **FR-005**: System MUST retry transient errors (HTTP 429, 503) with exponential backoff (base 1s, multiplier 2x, jitter, cap 60s, max 3 retries).
+- **FR-006**: System MUST NOT retry permanent errors (HTTP 400, 401, 403, 404).
+- **FR-007**: System MUST read the API endpoint URL and authentication token from environment variables (KOSMOS_FRIENDLI_TOKEN).
+- **FR-008**: System MUST support sending tool definitions and receiving tool_calls in the OpenAI function-calling format.
+- **FR-009**: System MUST support configurable model parameters: model name, temperature, max_tokens, top_p, stop sequences.
+- **FR-010**: System MUST provide an async interface (async/await) for all LLM operations.
+- **FR-011**: System MUST raise a clear configuration error if required environment variables are missing at initialization.
+- **FR-012**: System MUST log all LLM calls with request metadata (model, token counts, latency, status) using stdlib logging.
+
+### Key Entities
+
+- **LLMClient**: The async client that manages connections to the FriendliAI endpoint.
+- **ChatMessage**: A message in the conversation (system, user, assistant, tool roles).
+- **ChatCompletionResponse**: The model's response including content, tool_calls, and usage statistics.
+- **UsageTracker**: Tracks cumulative token usage against a session budget.
+- **RetryPolicy**: Configuration for retry behavior (max retries, backoff parameters, retryable status codes).
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A single-turn query receives a complete streamed response within the model's generation time plus network overhead (no artificial delays from client-side processing).
+- **SC-002**: Token usage tracking is accurate to within the precision reported by the FriendliAI API response.
+- **SC-003**: Session budget enforcement prevents any call from exceeding the configured token limit.
+- **SC-004**: Transient failures (429, 503) are recovered automatically in 95%+ of cases where the endpoint recovers within the retry window.
+- **SC-005**: All unit tests pass using recorded fixtures without requiring live API access.
+
+## Assumptions
+
+- FriendliAI Serverless endpoint is OpenAI-compatible (chat/completions API with tool support).
+- The K-EXAONE model supports function calling / tool use in the OpenAI format.
+- The FriendliAI API returns token usage statistics (input_tokens, output_tokens) in each response.
+- Network connectivity to FriendliAI Serverless is generally stable; transient errors are the exception, not the norm.
+- Session budget is configured per-session at initialization; dynamic budget adjustment mid-session is out of scope for Phase 1.
+- The client does not manage conversation history — that is the Query Engine's responsibility (Layer 1, Epic #5).

--- a/specs/004-llm-client/tasks.md
+++ b/specs/004-llm-client/tasks.md
@@ -1,0 +1,198 @@
+# Tasks: LLM Client Integration (FriendliAI K-EXAONE)
+
+**Input**: Design documents from `specs/004-llm-client/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4)
+- Exact file paths included in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create module structure and add dependencies
+
+- [ ] T001 Create `src/kosmos/llm/` package directory with `__init__.py` and create `tests/llm/` package directory with `__init__.py`
+- [ ] T002 Add `pydantic-settings>=2.0` to `dependencies` in `pyproject.toml`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core models, configuration, and error types that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T003 [P] Implement error hierarchy (`KosmosLLMError`, `ConfigurationError`, `BudgetExceededError`, `AuthenticationError`, `LLMConnectionError`, `LLMResponseError`, `StreamInterruptedError`) in `src/kosmos/llm/errors.py`
+- [ ] T004 [P] Implement Pydantic v2 message models (`ChatMessage`, `ToolCall`, `FunctionCall`, `TokenUsage`, `ChatCompletionResponse`, `StreamEvent`) in `src/kosmos/llm/models.py` — include role-based validation (tool role requires tool_call_id, system/user require content)
+- [ ] T005 [P] Implement `LLMClientConfig` using pydantic-settings with `KOSMOS_FRIENDLI_TOKEN` (required SecretStr), `KOSMOS_FRIENDLI_BASE_URL` (default), `KOSMOS_FRIENDLI_MODEL` (default), `KOSMOS_LLM_SESSION_BUDGET` (default 100000), `timeout`, `max_retries` in `src/kosmos/llm/config.py`
+- [ ] T006 [P] Create test infrastructure with shared fixtures (respx mock routes for chat/completions, mock SSE response generator, sample ChatMessage lists) in `tests/llm/conftest.py`
+
+**Checkpoint**: Foundation ready — models, config, and errors are importable and tested
+
+---
+
+## Phase 3: User Story 1 — Single-turn Query Resolution (Priority: P1) MVP
+
+**Goal**: Send a prompt to K-EXAONE via FriendliAI and receive a streamed response with token usage metadata
+
+**Independent Test**: Send a prompt string, verify a streamed response is received chunk-by-chunk with correct content and token usage counts
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Implement `LLMClient.__init__`, `close()`, `__aenter__`/`__aexit__` context manager, and non-streaming `complete()` method using httpx async POST to `/chat/completions` in `src/kosmos/llm/client.py`
+- [ ] T008 [US1] Implement `LLMClient.stream()` async generator method with SSE line parsing (`data:` prefix, `[DONE]` sentinel, JSON chunk → `StreamEvent`) in `src/kosmos/llm/client.py`
+- [ ] T009 [P] [US1] Write unit tests for Pydantic model validation (ChatMessage role constraints, TokenUsage computed total, StreamEvent types) in `tests/llm/test_models.py`
+- [ ] T010 [P] [US1] Write unit tests for LLMClientConfig loading from env vars (missing token raises ConfigurationError, defaults applied, override via env) in `tests/llm/test_config.py`
+- [ ] T011 [P] [US1] Write unit tests for `LLMClient.complete()` using respx (mock successful response, verify ChatCompletionResponse fields, verify token usage extracted) in `tests/llm/test_client.py`
+- [ ] T012 [P] [US1] Write unit tests for `LLMClient.stream()` SSE parsing (mock SSE lines, verify StreamEvent sequence, verify final usage event, verify content_delta assembly) in `tests/llm/test_streaming.py`
+
+**Checkpoint**: Single-turn query works end-to-end with streaming. `uv run pytest tests/llm/` passes.
+
+---
+
+## Phase 4: User Story 2 — Session Budget Enforcement (Priority: P2)
+
+**Goal**: Track cumulative token usage per session and reject calls when budget is exhausted
+
+**Independent Test**: Configure a low token budget, make calls until budget exhausted, verify the system refuses further calls with BudgetExceededError
+
+### Implementation for User Story 2
+
+- [ ] T013 [US2] Implement `UsageTracker` with `can_afford()`, `debit()`, `remaining` property, `is_exhausted` property, and `call_count` in `src/kosmos/llm/usage.py`
+- [ ] T014 [US2] Integrate `UsageTracker` into `LLMClient`: initialize from config budget, pre-flight check in `complete()`/`stream()`, post-call debit from response usage in `src/kosmos/llm/client.py`
+- [ ] T015 [US2] Write unit tests for UsageTracker (budget creation, debit, exhaustion, can_afford pre-flight, call_count increment) in `tests/llm/test_usage.py`
+
+**Checkpoint**: Budget enforcement works. Calls exceeding budget are rejected before sending.
+
+---
+
+## Phase 5: User Story 3 — Transient Failure Recovery (Priority: P2)
+
+**Goal**: Automatically retry 429/503 errors with exponential backoff; immediately fail on 401/400
+
+**Independent Test**: Simulate 429/503 responses → verify automatic retry with backoff; simulate 401/400 → verify immediate failure with AuthenticationError/LLMResponseError
+
+### Implementation for User Story 3
+
+- [ ] T016 [US3] Implement `RetryPolicy` model and `retry_with_backoff()` async function (exponential backoff, full jitter, base 1s, multiplier 2x, cap 60s, max 3 retries, retryable codes {429, 503}) in `src/kosmos/llm/retry.py`
+- [ ] T017 [US3] Integrate retry logic into `LLMClient.complete()` and `LLMClient.stream()` — wrap HTTP calls with retry, map non-retryable status codes to specific error types (401→AuthenticationError, 400→LLMResponseError) in `src/kosmos/llm/client.py`
+- [ ] T018 [US3] Write unit tests for retry logic (429 retries with backoff, 503 retries then succeeds, 401 immediate failure, retry exhaustion raises LLMConnectionError) in `tests/llm/test_retry.py`
+
+**Checkpoint**: Transient failures are recovered automatically. Permanent errors fail immediately.
+
+---
+
+## Phase 6: User Story 4 — Tool Use Message Assembly (Priority: P3)
+
+**Goal**: Support sending tool definitions and receiving tool_calls in OpenAI function-calling format
+
+**Independent Test**: Send messages with tool definitions, verify model response includes tool_calls with function name and JSON arguments; send tool result continuation, verify model incorporates it
+
+### Implementation for User Story 4
+
+- [ ] T019 [US4] Add `ToolDefinition` and `FunctionSchema` Pydantic v2 models to `src/kosmos/llm/models.py`
+- [ ] T020 [US4] Implement tool_calls support in `LLMClient.complete()` and `LLMClient.stream()` — serialize `tools` parameter, parse `tool_calls` in response/stream events, handle `tool_call_delta` StreamEvent assembly in `src/kosmos/llm/client.py`
+- [ ] T021 [US4] Write unit tests for tool use flow (request with tools parameter, response with tool_calls, streaming tool_call_delta assembly, tool result continuation message) in `tests/llm/test_client.py`
+
+**Checkpoint**: Tool loop messages assemble correctly. Ready for Query Engine (Epic #5) integration.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize public API, add logging, validate documentation
+
+- [ ] T022 Finalize public exports in `src/kosmos/llm/__init__.py` — export `LLMClient`, all models, all errors, `UsageTracker`, `RetryPolicy`, `LLMClientConfig`
+- [ ] T023 Add stdlib `logging` calls for all LLM operations (request metadata, token counts, latency, retry attempts, errors) per FR-012 in `src/kosmos/llm/client.py`
+- [ ] T024 Run `quickstart.md` code examples as validation (verify imports, API surface matches contract)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — MVP delivery target
+- **US2 (Phase 4)**: Depends on Phase 3 (needs working LLMClient to integrate UsageTracker)
+- **US3 (Phase 5)**: Depends on Phase 3 (needs working LLMClient to integrate retry)
+- **US4 (Phase 6)**: Depends on Phase 3 (extends models and client with tool support)
+- **Polish (Phase 7)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational (Phase 2) — no story dependencies
+- **US2 (P2)**: Depends on US1 (needs LLMClient to integrate budget tracking)
+- **US3 (P2)**: Depends on US1 (needs LLMClient to integrate retry) — parallel-safe with US2
+- **US4 (P3)**: Depends on US1 (extends models and client) — parallel-safe with US2/US3
+
+### Within Each User Story
+
+- Models/infrastructure before client integration
+- Client integration before tests (tests verify integrated behavior)
+- All [P] tasks within a phase can run in parallel
+
+### Parallel Opportunities
+
+- **Phase 2**: T003, T004, T005, T006 — all parallel-safe (different files)
+- **Phase 3**: T009, T010, T011, T012 — test files are parallel-safe (after T007, T008)
+- **Phase 4+5+6**: US2, US3, US4 are parallel-safe across stories (different files: usage.py, retry.py, models.py additions) — but each integrates into client.py, so client.py edits must be serialized
+
+---
+
+## Parallel Example: Foundational Phase
+
+```text
+# Launch all foundational tasks in parallel (different files):
+Agent 1: T003 — errors.py
+Agent 2: T004 — models.py
+Agent 3: T005 — config.py
+Agent 4: T006 — conftest.py
+```
+
+## Parallel Example: Cross-Story (after US1 complete)
+
+```text
+# US2, US3, US4 infrastructure tasks in parallel:
+Agent 1: T013 [US2] — usage.py (new file)
+Agent 2: T016 [US3] — retry.py (new file)
+Agent 3: T019 [US4] — models.py (additions)
+# Then serialize client.py integrations: T014, T017, T020
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only)
+
+1. Complete Phase 1: Setup (T001-T002)
+2. Complete Phase 2: Foundational (T003-T006) — parallel
+3. Complete Phase 3: US1 (T007-T012)
+4. **STOP and VALIDATE**: `uv run pytest tests/llm/` passes
+5. LLM client is usable for basic queries
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 → Streaming LLM calls work (MVP!)
+3. Add US2 → Budget enforcement active
+4. Add US3 → Transient errors auto-recovered
+5. Add US4 → Tool loop ready for Query Engine
+6. Polish → Production-grade logging and exports
+
+---
+
+## Notes
+
+- Total tasks: 24 (T001-T024)
+- Parallel-safe tasks: 10 (marked [P])
+- New dependency: `pydantic-settings>=2.0` (T002)
+- All tests use respx for httpx mocking — no live API calls
+- US2 and US3 are both P2 priority but parallel-safe
+- client.py is the integration point — edits from different stories must be serialized

--- a/specs/006-tool-system/checklists/requirements.md
+++ b/specs/006-tool-system/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Tool System & Registry
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-12
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- FR-001 mentions "Pydantic v2" — this is a project-level constraint from AGENTS.md, not an implementation choice. The spec must reference it since it defines the tool schema contract.
+- FR-012 mentions "OpenAI function-calling format" — this is an interoperability requirement for LLM consumption, not an implementation detail.
+- All items pass validation. Spec is ready for `/speckit-plan`.

--- a/specs/006-tool-system/contracts/tool-registry-api.md
+++ b/specs/006-tool-system/contracts/tool-registry-api.md
@@ -1,0 +1,153 @@
+# Contract: Tool System & Registry API
+
+**Module**: `kosmos.tools`
+**Date**: 2026-04-12
+
+## Public Interface
+
+### GovAPITool
+
+```python
+class GovAPITool(BaseModel):
+    """Government API tool definition with fail-closed defaults."""
+
+    id: str                                          # snake_case identifier
+    name_ko: str                                     # Korean display name
+    provider: str                                    # Ministry/agency
+    category: list[str]                              # Topic tags
+    endpoint: str                                    # API base URL
+    auth_type: Literal["public", "api_key", "oauth"] # Auth method
+    input_schema: type[BaseModel]                    # Request params model
+    output_schema: type[BaseModel]                   # Response data model
+    search_hint: str                                 # Bilingual discovery keywords
+
+    # Fail-closed defaults (Constitution § II)
+    requires_auth: bool = True
+    is_concurrency_safe: bool = False
+    is_personal_data: bool = True
+    cache_ttl_seconds: int = 0
+    rate_limit_per_minute: int = 10
+    is_core: bool = False
+
+    def to_openai_tool(self) -> dict:
+        """Export as OpenAI function-calling tool definition."""
+```
+
+### ToolRegistry
+
+```python
+class ToolRegistry:
+    """Central registry for government API tools."""
+
+    def __init__(self) -> None: ...
+
+    def register(self, tool: GovAPITool) -> None:
+        """Register a tool. Raises DuplicateToolError if id already registered."""
+
+    def lookup(self, tool_id: str) -> GovAPITool:
+        """Look up tool by id. Raises ToolNotFoundError if not found."""
+
+    def search(self, query: str, max_results: int = 5) -> list[ToolSearchResult]:
+        """Search tools by Korean or English keywords in search_hint."""
+
+    def core_tools(self) -> list[GovAPITool]:
+        """Return core tools sorted by id (deterministic for prompt caching)."""
+
+    def situational_tools(self) -> list[GovAPITool]:
+        """Return non-core tools."""
+
+    def export_core_tools_openai(self) -> list[dict]:
+        """Export core tools as OpenAI function-calling definitions."""
+
+    def all_tools(self) -> list[GovAPITool]:
+        """Return all registered tools."""
+
+    def __len__(self) -> int: ...
+    def __contains__(self, tool_id: str) -> bool: ...
+```
+
+### ToolExecutor
+
+```python
+class ToolExecutor:
+    """Dispatches tool calls with input/output validation and rate limiting."""
+
+    def __init__(self, registry: ToolRegistry) -> None: ...
+
+    async def dispatch(self, tool_name: str, arguments_json: str) -> ToolResult:
+        """Full dispatch pipeline.
+
+        Steps:
+        1. Lookup tool in registry
+        2. Validate arguments against input_schema
+        3. Check rate limit
+        4. Execute tool adapter
+        5. Validate result against output_schema
+        6. Return ToolResult
+
+        Returns ToolResult with success=False for any failure (never raises).
+        """
+```
+
+### RateLimiter
+
+```python
+class RateLimiter:
+    """Sliding-window rate limiter for per-tool call throttling."""
+
+    def __init__(self, limit: int, window_seconds: float = 60.0) -> None: ...
+
+    def check(self) -> bool:
+        """Can a call be made right now?"""
+
+    def record(self) -> None:
+        """Record a call timestamp."""
+
+    @property
+    def remaining(self) -> int:
+        """Remaining calls in current window."""
+
+    def reset(self) -> None:
+        """Clear all timestamps."""
+```
+
+## Error Hierarchy
+
+```python
+class KosmosToolError(Exception):
+    """Base exception for tool system errors."""
+
+class DuplicateToolError(KosmosToolError):
+    """Tool with this id is already registered."""
+
+class ToolNotFoundError(KosmosToolError):
+    """No tool with this id in the registry."""
+
+class ToolValidationError(KosmosToolError):
+    """Input or output validation failed against schema."""
+
+class RateLimitExceededError(KosmosToolError):
+    """Tool's rate limit has been exceeded."""
+
+class ToolExecutionError(KosmosToolError):
+    """Tool adapter raised an error during execution."""
+```
+
+## Module Layout
+
+```
+src/kosmos/tools/
+├── __init__.py          # Public exports: GovAPITool, ToolRegistry, ToolExecutor
+├── models.py            # GovAPITool, ToolResult, ToolSearchResult, SearchToolsInput/Output
+├── registry.py          # ToolRegistry implementation
+├── executor.py          # ToolExecutor dispatch logic
+├── rate_limiter.py      # RateLimiter sliding window
+├── errors.py            # Error hierarchy
+└── search.py            # search_tools meta-tool and search logic
+```
+
+## Integration Points
+
+- **Epic #4 (LLM Client)**: `GovAPITool.to_openai_tool()` produces `ToolDefinition` dicts consumed by `LLMClient.complete(tools=...)` and `LLMClient.stream(tools=...)`.
+- **Epic #5 (Query Engine)**: `ToolExecutor.dispatch()` is called when the query engine processes `tool_calls` from the LLM response.
+- **Epic #7 (API Adapters)**: Each adapter creates a `GovAPITool` instance and registers it with the `ToolRegistry`.

--- a/specs/006-tool-system/data-model.md
+++ b/specs/006-tool-system/data-model.md
@@ -1,0 +1,163 @@
+# Data Model: Tool System & Registry (Layer 2)
+
+**Feature**: Epic #6 — Tool System & Registry
+**Date**: 2026-04-12
+
+## Entities
+
+### 1. GovAPITool
+
+The central model defining a government API tool. All fields from `docs/vision.md` Layer 2.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `id` | `str` | Yes | — | Stable identifier, snake_case (e.g., `koroad_accident_search`) |
+| `name_ko` | `str` | Yes | — | Korean display name (e.g., `교통사고정보`) |
+| `provider` | `str` | Yes | — | Ministry or agency name (e.g., `도로교통공단`) |
+| `category` | `list[str]` | Yes | — | Topic tags (e.g., `["교통", "안전"]`) |
+| `endpoint` | `str` | Yes | — | API base URL |
+| `auth_type` | `Literal["public", "api_key", "oauth"]` | Yes | — | Authentication method |
+| `input_schema` | `type[BaseModel]` | Yes | — | Pydantic v2 model class for request parameters |
+| `output_schema` | `type[BaseModel]` | Yes | — | Pydantic v2 model class for response data |
+| `requires_auth` | `bool` | No | `True` | Whether citizen auth is required (FAIL-CLOSED) |
+| `is_concurrency_safe` | `bool` | No | `False` | Safe to call in parallel (FAIL-CLOSED) |
+| `is_personal_data` | `bool` | No | `True` | Whether response contains PII (FAIL-CLOSED) |
+| `cache_ttl_seconds` | `int` | No | `0` | Response cache lifetime (FAIL-CLOSED: no caching) |
+| `rate_limit_per_minute` | `int` | No | `10` | Client-side rate limit |
+| `search_hint` | `str` | Yes | — | Korean + English discovery keywords |
+| `is_core` | `bool` | No | `False` | Whether tool is in the core prompt partition |
+
+**Validation**:
+- `id` must match pattern `^[a-z][a-z0-9_]*$`
+- `category` must not be empty
+- `rate_limit_per_minute` must be > 0
+- `cache_ttl_seconds` must be >= 0
+- `search_hint` must not be empty
+
+---
+
+### 2. ToolRegistry
+
+Central registry for tool management.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `_tools` | `dict[str, GovAPITool]` | Internal | `{}` | Registered tools by id |
+| `_rate_limiters` | `dict[str, RateLimiter]` | Internal | `{}` | Per-tool rate limiters |
+
+**Methods**:
+- `register(tool: GovAPITool) -> None`: Register a tool. Raises `DuplicateToolError` if id exists.
+- `lookup(tool_id: str) -> GovAPITool`: Get tool by id. Raises `ToolNotFoundError` if missing.
+- `search(query: str) -> list[ToolSearchResult]`: Search tools by keyword. Returns ranked results.
+- `core_tools() -> list[GovAPITool]`: Get core tools, sorted by id (deterministic).
+- `situational_tools() -> list[GovAPITool]`: Get non-core tools.
+- `export_core_tools_openai() -> list[dict]`: Export core tools in OpenAI function-calling format.
+- `all_tools() -> list[GovAPITool]`: Get all registered tools.
+
+---
+
+### 3. ToolSearchResult
+
+A search result from `search_tools()`.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `tool` | `GovAPITool` | Yes | — | The matched tool |
+| `score` | `float` | Yes | — | Relevance score (higher = more relevant) |
+| `matched_tokens` | `list[str]` | Yes | — | Which query tokens matched |
+
+---
+
+### 4. RateLimiter
+
+Per-tool rate limiter using sliding window.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `limit` | `int` | Yes | — | Max calls per minute |
+| `_timestamps` | `deque[float]` | Internal | `deque()` | Call timestamps |
+| `window_seconds` | `float` | No | `60.0` | Window size |
+
+**Methods**:
+- `check() -> bool`: Can a call be made right now?
+- `record() -> None`: Record a call timestamp.
+- `remaining() -> int`: How many calls are left in the current window?
+- `reset() -> None`: Clear all timestamps.
+
+---
+
+### 5. ToolExecutor
+
+Dispatches tool calls from the LLM with validation.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `registry` | `ToolRegistry` | Yes | — | The tool registry to dispatch against |
+
+**Methods**:
+- `dispatch(tool_name: str, arguments_json: str) -> ToolResult`: Full dispatch pipeline (lookup → validate input → check rate limit → execute → validate output).
+
+---
+
+### 6. ToolResult
+
+Result from tool execution.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `tool_id` | `str` | Yes | — | Which tool was called |
+| `success` | `bool` | Yes | — | Whether execution succeeded |
+| `data` | `dict[str, object]` | No | `None` | Validated output data (if success) |
+| `error` | `str \| None` | No | `None` | Error message (if failure) |
+| `error_type` | `Literal["validation", "rate_limit", "not_found", "execution", "schema_mismatch"] \| None` | No | `None` | Error classification |
+
+---
+
+### 7. SearchToolsInput
+
+Input schema for the `search_tools` meta-tool (registered in the registry for LLM discovery).
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `query` | `str` | Yes | — | Search query (Korean or English keywords) |
+| `max_results` | `int` | No | `5` | Maximum number of results to return |
+
+---
+
+### 8. SearchToolsOutput
+
+Output schema for the `search_tools` meta-tool.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `results` | `list[SearchToolMatch]` | Yes | — | Matched tools |
+| `total_registered` | `int` | Yes | — | Total tools in registry |
+
+---
+
+### 9. SearchToolMatch
+
+A single match in `SearchToolsOutput`.
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `tool_id` | `str` | Yes | — | Tool identifier |
+| `name_ko` | `str` | Yes | — | Korean display name |
+| `provider` | `str` | Yes | — | Ministry/agency |
+| `category` | `list[str]` | Yes | — | Topic tags |
+| `description` | `str` | Yes | — | Generated from search_hint |
+| `score` | `float` | Yes | — | Relevance score |
+
+## Relationships
+
+```
+ToolRegistry ──contains──→ dict[str, GovAPITool]
+ToolRegistry ──manages──→ dict[str, RateLimiter]
+ToolExecutor ──uses──→ ToolRegistry
+ToolExecutor ──returns──→ ToolResult
+GovAPITool ──references──→ type[BaseModel] (input_schema)
+GovAPITool ──references──→ type[BaseModel] (output_schema)
+GovAPITool ──exports──→ OpenAI ToolDefinition format
+ToolRegistry.search() ──returns──→ list[ToolSearchResult]
+search_tools meta-tool ──uses──→ SearchToolsInput → ToolRegistry.search() → SearchToolsOutput
+```

--- a/specs/006-tool-system/plan.md
+++ b/specs/006-tool-system/plan.md
@@ -1,0 +1,92 @@
+# Implementation Plan: Tool System & Registry (Layer 2)
+
+**Branch**: `spec/wave-1` | **Date**: 2026-04-12 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/006-tool-system/spec.md`
+
+## Summary
+
+Implement the schema-driven tool registry for KOSMOS Layer 2 with fail-closed defaults, bilingual keyword search, prompt cache partitioning (core vs. situational), sliding-window rate limiting, and tool execution dispatch with Pydantic v2 input/output validation. The registry exports tool definitions in OpenAI function-calling format for consumption by the LLM client (Epic #4).
+
+## Technical Context
+
+**Language/Version**: Python 3.12+
+**Primary Dependencies**: pydantic >=2.0 (models + validation)
+**Storage**: N/A (in-memory registry)
+**Testing**: pytest + pytest-asyncio
+**Target Platform**: Cross-platform (macOS, Linux) CLI
+**Project Type**: Library module within KOSMOS (`src/kosmos/tools/`)
+**Performance Goals**: Tool search < 10ms for 100 tools; registry export deterministic (byte-for-byte identical)
+**Constraints**: Fail-closed defaults (Constitution § II); Pydantic v2 for all I/O; no `Any` in I/O schemas; bilingual search_hint
+**Scale/Scope**: ~10 tools in Phase 1; design for hundreds
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Reference-Driven Development | PASS | Design mapped to Pydantic AI (registry), Claude Agent SDK (tool definitions), Claude Code reconstructed (tool discovery) |
+| II. Fail-Closed Security | PASS | All security-sensitive fields default to restrictive values via Pydantic `Field(default=...)` |
+| III. Pydantic v2 Strict Typing | PASS | `GovAPITool`, `ToolResult`, `SearchToolsInput/Output` all use Pydantic v2. No `Any` in I/O. |
+| IV. Government API Compliance | PASS | Registry does not call APIs directly. Rate limiter enforces per-tool limits. |
+| V. Policy Alignment | PASS | Fail-closed defaults protect citizen PII by default. |
+
+**Post-Phase 1 re-check**: PASS. `GovAPITool.input_schema` and `output_schema` fields hold `type[BaseModel]` references (not `Any`). The `to_openai_tool()` method generates JSON Schema via Pydantic's `model_json_schema()`, which internally uses `Any` in the generated schema dict — this is acceptable because it's an export format, not KOSMOS I/O.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/006-tool-system/
+├── plan.md              # This file
+├── research.md          # Phase 0 output — 7 research tasks resolved
+├── data-model.md        # Phase 1 output — 9 entities defined
+├── quickstart.md        # Phase 1 output — usage examples
+├── contracts/
+│   └── tool-registry-api.md  # Public API contract
+└── tasks.md             # Phase 2 output (created by /speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/kosmos/
+├── __init__.py           # Existing
+└── tools/
+    ├── __init__.py       # Public exports
+    ├── models.py         # GovAPITool, ToolResult, ToolSearchResult, SearchTools I/O
+    ├── registry.py       # ToolRegistry (register, lookup, search, partition)
+    ├── executor.py       # ToolExecutor (dispatch with validation)
+    ├── rate_limiter.py   # RateLimiter (sliding window)
+    ├── errors.py         # Error hierarchy
+    └── search.py         # search_tools meta-tool, bilingual search logic
+
+tests/
+└── tools/
+    ├── __init__.py
+    ├── conftest.py       # Mock tools, sample registries
+    ├── test_models.py    # GovAPITool validation, fail-closed defaults
+    ├── test_registry.py  # Registration, lookup, search, partitioning
+    ├── test_executor.py  # Dispatch, validation, error handling
+    ├── test_rate_limiter.py  # Sliding window, reset, edge cases
+    └── test_search.py    # Bilingual search, ranking, edge cases
+```
+
+**Structure Decision**: Single project layout. The tool system is a library module (`kosmos.tools`) within the KOSMOS package, parallel to `kosmos.llm` (Epic #4).
+
+## Reference Mapping
+
+| Design Decision | Primary Reference | Secondary Reference |
+|----------------|-------------------|---------------------|
+| Schema-driven tool registry | Pydantic AI — schema-driven tool modules | vision.md Layer 2 — "Each API wrapped as a tool module" |
+| Fail-closed defaults | Constitution § II — non-negotiable security | vision.md Layer 2 — "Fail-closed posture" |
+| Bilingual keyword search | Claude Code reconstructed — tool discovery | vision.md Layer 2 — lazy tool discovery |
+| Prompt cache partitioning | Anthropic docs — prompt caching | vision.md Layer 2 — core vs. situational |
+| Rate limiting (sliding window) | OpenAI Agents SDK — rate limit handling | vision.md Layer 1 — usage tracker |
+| OpenAI tool format export | Claude Agent SDK — tool definitions | FriendliAI OpenAI-compatible API |
+| Tool execution dispatch | Pydantic AI — schema validation | Claude Code reconstructed — tool execution flow |
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/006-tool-system/quickstart.md
+++ b/specs/006-tool-system/quickstart.md
@@ -1,0 +1,102 @@
+# Quickstart: Tool System & Registry
+
+**Feature**: Epic #6 — Tool System & Registry
+
+## Setup
+
+```bash
+uv sync
+```
+
+No additional environment variables are required for the tool system itself. Individual tool adapters may require API keys.
+
+## Basic Usage
+
+### Registering a tool
+
+```python
+from pydantic import BaseModel
+from kosmos.tools import GovAPITool, ToolRegistry
+
+# Define input/output schemas
+class WeatherInput(BaseModel):
+    city: str
+    date: str | None = None
+
+class WeatherOutput(BaseModel):
+    temperature: float
+    condition: str
+    humidity: int
+
+# Create tool definition (fail-closed defaults apply)
+weather_tool = GovAPITool(
+    id="kma_weather_forecast",
+    name_ko="날씨예보",
+    provider="기상청",
+    category=["날씨", "기상"],
+    endpoint="http://apis.data.go.kr/1360000/...",
+    auth_type="api_key",
+    input_schema=WeatherInput,
+    output_schema=WeatherOutput,
+    search_hint="날씨 예보 weather forecast 기상청 KMA temperature",
+    # Explicit overrides (everything else stays fail-closed):
+    is_personal_data=False,  # weather is public data
+    cache_ttl_seconds=300,   # cache for 5 minutes
+    is_core=True,            # always loaded in prompt
+)
+
+# Register
+registry = ToolRegistry()
+registry.register(weather_tool)
+```
+
+### Searching tools
+
+```python
+results = registry.search("날씨 weather")
+for result in results:
+    print(f"{result.tool.id}: {result.tool.name_ko} (score: {result.score})")
+```
+
+### Exporting for LLM
+
+```python
+# Get deterministic core tool list for prompt caching
+openai_tools = registry.export_core_tools_openai()
+# Pass to LLM client:
+# response = await llm_client.complete(messages, tools=openai_tools)
+```
+
+### Dispatching a tool call
+
+```python
+from kosmos.tools import ToolExecutor
+
+executor = ToolExecutor(registry)
+result = await executor.dispatch(
+    tool_name="kma_weather_forecast",
+    arguments_json='{"city": "서울"}'
+)
+
+if result.success:
+    print(result.data)
+else:
+    print(f"Error: {result.error} ({result.error_type})")
+```
+
+### Rate limit checking
+
+```python
+tool = registry.lookup("kma_weather_forecast")
+# Rate limiter is managed by the registry internally
+# ToolExecutor checks rate limits before dispatching
+```
+
+## Running Tests
+
+```bash
+# Unit tests (all use mock tools, no API access)
+uv run pytest tests/tools/
+
+# No live tests needed for the registry itself
+```

--- a/specs/006-tool-system/quickstart.md
+++ b/specs/006-tool-system/quickstart.md
@@ -63,7 +63,7 @@ for result in results:
 ```python
 # Get deterministic core tool list for prompt caching
 openai_tools = registry.export_core_tools_openai()
-# Pass to LLM client:
+# LLMClient.complete() accepts both ToolDefinition models and raw dicts:
 # response = await llm_client.complete(messages, tools=openai_tools)
 ```
 

--- a/specs/006-tool-system/research.md
+++ b/specs/006-tool-system/research.md
@@ -149,11 +149,12 @@ LLM tool_call → ToolExecutor.dispatch(name, args_json)
     "type": "function",
     "function": {
         "name": tool.id,
-        "description": f"{tool.name_ko} — {tool.provider}",
+        "description": tool.name_ko,
         "parameters": tool.input_schema.model_json_schema()
     }
 }
 ```
+Note: `name_ko` alone provides a concise description for the LLM. Provider info is available via the `GovAPITool.provider` field when needed by the orchestrator.
 
 **Reference**: Claude Agent SDK — tool definitions. FriendliAI OpenAI-compatible API.
 

--- a/specs/006-tool-system/research.md
+++ b/specs/006-tool-system/research.md
@@ -1,0 +1,162 @@
+# Phase 0 Research: Tool System & Registry (Layer 2)
+
+**Feature**: Epic #6 — Tool System & Registry
+**Date**: 2026-04-12
+**Status**: Complete
+
+## Research Tasks
+
+### RT-1: Tool Registry Architecture Pattern
+
+**Question**: What registry pattern best fits KOSMOS's tool system?
+
+**Decision**: In-memory registry with decorator-based registration, similar to Pydantic AI's schema-driven approach. Tools register at import time via a `@register_tool` decorator or explicit `registry.register(tool)` call.
+
+**Rationale**: From `docs/vision.md` Layer 2 — "Each public API is wrapped as a tool module with a schema-driven registration and fail-closed defaults." Pydantic AI uses schema-driven tool definitions with Pydantic models for input/output validation. This pattern fits naturally since KOSMOS already mandates Pydantic v2 for all I/O.
+
+**Reference**: Pydantic AI (`pydantic/pydantic-ai`) — schema-driven tool registry. Claude Agent SDK (`anthropics/claude-agent-sdk-python`) — tool definitions and execution.
+
+**Alternatives considered**:
+- Plugin-based discovery (entry_points): over-engineered for Phase 1 with ~10 tools
+- YAML/JSON manifest: rejected — Pydantic models already describe schemas; a separate manifest would be redundant
+- Auto-discovery (importlib scanning): fragile and implicit; explicit registration is clearer
+
+---
+
+### RT-2: Fail-Closed Default Mechanism
+
+**Question**: How to enforce that omitted fields default to the most restrictive setting?
+
+**Decision**: Use Pydantic v2 `Field(default=...)` with conservative values. The `GovAPITool` model defines all security-sensitive fields with fail-closed defaults directly in the model definition.
+
+**Rationale**: From Constitution § II — "Every tool adapter and API integration MUST default to the most restrictive setting." Pydantic v2's `Field()` with explicit defaults ensures that any tool registered without specifying these fields automatically gets the conservative value. No additional enforcement layer is needed — the type system handles it.
+
+**Key defaults**:
+- `requires_auth: bool = True`
+- `is_personal_data: bool = True`
+- `is_concurrency_safe: bool = False`
+- `cache_ttl_seconds: int = 0`
+- `rate_limit_per_minute: int = 10`
+
+**Reference**: Constitution § II (Fail-Closed Security).
+
+**Alternatives considered**:
+- Post-registration validation hook: unnecessary when Pydantic defaults handle it
+- Separate SecurityPolicy model: over-engineering; the flags belong on the tool definition itself
+
+---
+
+### RT-3: Bilingual Search Strategy
+
+**Question**: How should `search_tools()` match Korean and English keywords?
+
+**Decision**: Token-based matching with case-insensitive substring search. Split the query into tokens (whitespace-separated), split each tool's `search_hint` into tokens, and compute a relevance score based on token overlap count.
+
+**Rationale**: Phase 1 targets ~10 tools. A simple token-overlap approach is sufficient and avoids adding NLP dependencies. Korean morphological analysis (e.g., KoNLPy) would add significant complexity and a non-trivial dependency chain for minimal benefit at this scale.
+
+**Scoring algorithm**:
+```python
+score = sum(1 for query_token in query_tokens
+            if any(query_token in hint_token or hint_token in query_token
+                   for hint_token in hint_tokens))
+```
+
+**Reference**: Claude Code reconstructed (`ChinaSiro/claude-code-sourcemap`) — tool discovery patterns, keyword-based tool matching.
+
+**Alternatives considered**:
+- Full-text search (SQLite FTS5): over-engineered for in-memory with ~10 tools
+- Embedding-based semantic search: Phase 2+ enhancement; requires embedding model
+- Regex matching: fragile for Korean text with agglutinative morphology
+- KoNLPy morphological analysis: adds ~200MB dependency (Java/JVM) for minimal benefit at Phase 1 scale
+
+---
+
+### RT-4: Prompt Cache Partitioning Design
+
+**Question**: How to partition tools for optimal prompt caching?
+
+**Decision**: Static core/situational partition defined by a `is_core: bool` field on `GovAPITool`. Core tools are exported as a deterministic, sorted list. Situational tools are discovered via `search_tools()`.
+
+**Rationale**: From `docs/vision.md` Layer 2 — "The tool registry orders tools into two partitions: core tools (always loaded, stable across sessions) form the prompt prefix, and situational tools (discovered on demand via tool search) form the suffix." Deterministic ordering (sorted by `id`) ensures byte-for-byte identical output across invocations, maximizing cache hits.
+
+**Reference**: Anthropic docs — prompt caching. Vision.md Layer 2 — prompt cache partitioning.
+
+**Phase 1 core tools**: The ~10 Phase 1 tools (KOROAD, KMA adapters) plus `search_tools` meta-tool. Dynamic promotion is deferred to Phase 2.
+
+**Alternatives considered**:
+- LRU-based dynamic partitioning: Phase 2+ complexity; requires usage analytics
+- Frequency-based auto-promotion: requires call counting infrastructure beyond rate limiting
+- No partitioning: wastes prompt tokens and cache budget
+
+---
+
+### RT-5: Rate Limiter Implementation
+
+**Question**: What rate limiting algorithm to use?
+
+**Decision**: Sliding window counter using `collections.deque` with timestamps. Each tool maintains a deque of call timestamps. On each call, expired entries (older than 1 minute) are pruned, and the call is allowed if `len(deque) < rate_limit_per_minute`.
+
+**Rationale**: Simple, memory-efficient, and accurate for Phase 1's single-process scope. No external dependencies needed. The deque naturally handles clock progression — old entries fall off as new ones are added.
+
+**Reference**: OpenAI Agents SDK — rate limit handling patterns.
+
+**Alternatives considered**:
+- Token bucket: more complex, designed for bursty traffic; government APIs have strict per-minute limits, not burst allowances
+- Fixed window: inaccurate at window boundaries (2x burst possible)
+- Redis-based distributed limiter: over-engineered for Phase 1 single-process CLI
+- leaky bucket: designed for smoothing output rate, not input throttling
+
+---
+
+### RT-6: Tool Execution Dispatch Pattern
+
+**Question**: How should the registry dispatch tool calls from the LLM?
+
+**Decision**: The `ToolExecutor` looks up the tool by name in the registry, validates input against the tool's `input_schema` using Pydantic, calls the tool's `execute()` method, and validates output against `output_schema`. The executor is a thin dispatch layer — actual API logic lives in each adapter.
+
+**Rationale**: Separation of concerns: the registry knows about tools, the executor handles dispatch + validation, and each adapter implements the API-specific logic. This maps to vision.md's statement that "tool execution is the adapter's responsibility; the registry dispatches but does not implement API-specific logic."
+
+**Reference**: Pydantic AI — schema-driven validation. Claude Agent SDK — tool execution flow.
+
+**Executor flow**:
+```
+LLM tool_call → ToolExecutor.dispatch(name, args_json)
+  → Registry.lookup(name)
+  → input_schema.model_validate_json(args_json)
+  → rate_limiter.check(tool_id)
+  → adapter.execute(validated_input)
+  → output_schema.model_validate(raw_output)
+  → return validated_output
+```
+
+**Alternatives considered**:
+- Direct registry execution (no separate executor): conflates concerns; harder to add cross-cutting logic (rate limiting, logging, permission checks)
+- Middleware chain: over-engineered for Phase 1; executor methods handle the sequential flow
+
+---
+
+### RT-7: OpenAI Function-Calling Format Export
+
+**Question**: How to export tool definitions for LLM consumption?
+
+**Decision**: Each `GovAPITool` exports to the OpenAI function-calling format via a `.to_openai_tool()` method that produces a dict matching the `ToolDefinition` schema from Epic #4.
+
+**Rationale**: The LLM client (Epic #4) sends tool definitions in OpenAI format. The registry must produce this format. Generating the JSON Schema from Pydantic models is straightforward via `model.model_json_schema()`.
+
+**Export format**:
+```python
+{
+    "type": "function",
+    "function": {
+        "name": tool.id,
+        "description": f"{tool.name_ko} — {tool.provider}",
+        "parameters": tool.input_schema.model_json_schema()
+    }
+}
+```
+
+**Reference**: Claude Agent SDK — tool definitions. FriendliAI OpenAI-compatible API.
+
+**Alternatives considered**:
+- Custom format: rejected — no reason to diverge from the OpenAI standard that the LLM client already supports
+- Anthropic tool format: rejected — FriendliAI uses OpenAI-compatible format

--- a/specs/006-tool-system/spec.md
+++ b/specs/006-tool-system/spec.md
@@ -91,10 +91,10 @@ When the query engine resolves a tool_call from the LLM, it passes the tool name
 ### Edge Cases
 
 - What happens when two tools are registered with the same id? The system rejects the duplicate with a registration error.
-- What happens when search_hint is empty? The tool is registered but never discoverable via search.
+- What happens when search_hint is empty or whitespace-only? The system rejects registration with a validation error.
 - What happens when a tool's API endpoint is unreachable during execution? The executor raises a connection error; error recovery (Layer 6) handles retry.
 - What happens when the rate limit counter overflows (e.g., clock skew)? The counter resets gracefully; stale entries are pruned.
-- What happens when a tool's output does not match the output_schema? The system logs a validation warning and returns the raw data with a schema-mismatch flag.
+- What happens when a tool's output does not match the output_schema? The system logs a validation warning and returns a schema-mismatch error result; raw output is not returned.
 
 ## Requirements
 

--- a/specs/006-tool-system/spec.md
+++ b/specs/006-tool-system/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: Tool System & Registry (Layer 2)
+
+**Epic**: #6
+**Created**: 2026-04-12
+**Status**: Draft
+**Layer**: Layer 2 — Tool System
+**Input**: Schema-driven tool registry with fail-closed defaults, prompt cache partitioning, lazy tool discovery, and rate limit tracking for government API adapters.
+
+## User Scenarios & Testing
+
+### User Story 1 - Tool Registration with Fail-Closed Defaults (Priority: P1)
+
+A developer adds a new government API adapter to KOSMOS by declaring a tool definition with only the fields that deviate from the conservative defaults. The system ensures that any omitted fields default to the most restrictive settings (requires_auth=True, is_personal_data=True, is_concurrency_safe=False, cache_ttl=0).
+
+**Why this priority**: This is the foundation of the entire tool system. Without fail-closed registration, a contributor could accidentally expose personal data APIs as public.
+
+**Independent Test**: Can be tested by registering a tool with minimal fields and verifying all defaults are fail-closed, then registering with explicit overrides and verifying overrides are respected.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tool definition with only id, name_ko, provider, category, endpoint, auth_type, input_schema, output_schema, and search_hint, **When** it is registered, **Then** requires_auth=True, is_personal_data=True, is_concurrency_safe=False, cache_ttl_seconds=0, rate_limit_per_minute=10.
+2. **Given** a tool definition with explicit `is_personal_data=False`, **When** it is registered, **Then** only that specific default is overridden; all other defaults remain fail-closed.
+3. **Given** a tool definition missing a required field (e.g., no input_schema), **When** registration is attempted, **Then** the system rejects it with a validation error.
+
+---
+
+### User Story 2 - Lazy Tool Discovery via search_tools (Priority: P1)
+
+A citizen asks about a topic (e.g., childbirth subsidies). The LLM invokes `search_tools("birth subsidy welfare")` and receives a list of matching tools ranked by relevance. The citizen does not need to know which ministry runs which API.
+
+**Why this priority**: With 5,000+ potential APIs, preloading all schemas is infeasible. Lazy discovery is the only scalable path. This is equally important as registration since neither works without the other.
+
+**Independent Test**: Can be tested by registering multiple tools with varied search_hint values, querying with Korean and English keywords, and verifying relevant tools are returned and irrelevant tools are excluded.
+
+**Acceptance Scenarios**:
+
+1. **Given** 10 registered tools with various search_hints, **When** `search_tools("교통사고 traffic accident")` is called, **Then** tools with matching Korean or English keywords in search_hint are returned, ranked by relevance.
+2. **Given** the same registry, **When** `search_tools("날씨 weather forecast")` is called, **Then** only weather-related tools are returned; traffic tools are excluded.
+3. **Given** an empty query string, **When** `search_tools("")` is called, **Then** the system returns an empty result set rather than all tools.
+
+---
+
+### User Story 3 - Prompt Cache Partitioning (Priority: P2)
+
+The tool registry separates tools into core tools (always loaded, stable across sessions) and situational tools (discovered on demand). Core tool schemas form the prompt prefix for LLM calls, enabling prompt cache hits across sessions.
+
+**Why this priority**: Cost efficiency is critical for a government-funded service. Cache partitioning can dramatically reduce per-session LLM costs.
+
+**Independent Test**: Can be tested by requesting the core tool list and situational tool list, verifying they are disjoint, and verifying the core list is stable across multiple calls.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registry with tools marked as core and situational, **When** the core tool schemas are requested, **Then** the same ordered list is returned every time (stable for caching).
+2. **Given** a citizen switches topics (transport to welfare), **When** the situational tools change, **Then** the core tool schemas remain unchanged.
+3. **Given** the core tool list, **When** exported as tool definitions for an LLM call, **Then** the output is a deterministic JSON string suitable for prompt prefix caching.
+
+---
+
+### User Story 4 - Rate Limit Tracking (Priority: P2)
+
+Each tool has a declared rate_limit_per_minute. The registry tracks call counts per tool per time window. When a tool approaches its rate limit, the system warns before blocking; when the limit is hit, calls are queued or rejected.
+
+**Why this priority**: Government APIs have strict quotas. Exceeding them causes 429 errors and potential key suspension.
+
+**Independent Test**: Can be tested by simulating rapid calls to a tool with a low rate limit and verifying calls are rejected after the limit is reached, then verifying the counter resets after the time window.
+
+**Acceptance Scenarios**:
+
+1. **Given** a tool with rate_limit_per_minute=5, **When** 5 calls are made within one minute, **Then** the 6th call is rejected with a rate-limit-exceeded error.
+2. **Given** a rate-limited tool, **When** the one-minute window expires, **Then** the call counter resets and new calls are allowed.
+3. **Given** multiple tools, **When** rate limits are tracked, **Then** each tool's counter is independent.
+
+---
+
+### User Story 5 - Tool Execution Dispatch (Priority: P3)
+
+When the query engine resolves a tool_call from the LLM, it passes the tool name and arguments to the registry. The registry looks up the tool, validates the input against the Pydantic schema, executes the API call, and validates the output.
+
+**Why this priority**: Execution dispatch connects the registry to the query engine, but the registry's core value (registration, search, rate limiting) works without it.
+
+**Independent Test**: Can be tested by registering a mock tool, dispatching a call with valid arguments and verifying a validated response, then dispatching with invalid arguments and verifying a validation error.
+
+**Acceptance Scenarios**:
+
+1. **Given** a registered tool, **When** dispatched with valid arguments matching the input_schema, **Then** the tool executes and returns output validated against the output_schema.
+2. **Given** a registered tool, **When** dispatched with invalid arguments, **Then** a validation error is returned without calling the API.
+3. **Given** a tool_call with an unknown tool name, **When** dispatched, **Then** a tool-not-found error is returned.
+
+---
+
+### Edge Cases
+
+- What happens when two tools are registered with the same id? The system rejects the duplicate with a registration error.
+- What happens when search_hint is empty? The tool is registered but never discoverable via search.
+- What happens when a tool's API endpoint is unreachable during execution? The executor raises a connection error; error recovery (Layer 6) handles retry.
+- What happens when the rate limit counter overflows (e.g., clock skew)? The counter resets gracefully; stale entries are pruned.
+- What happens when a tool's output does not match the output_schema? The system logs a validation warning and returns the raw data with a schema-mismatch flag.
+
+## Requirements
+
+### Functional Requirements
+
+- **FR-001**: System MUST define a GovAPITool model using Pydantic v2 with all fields specified in vision.md Layer 2 (id, name_ko, provider, category, endpoint, auth_type, input_schema, output_schema, requires_auth, is_concurrency_safe, is_personal_data, cache_ttl_seconds, rate_limit_per_minute, search_hint).
+- **FR-002**: System MUST enforce fail-closed defaults: requires_auth=True, is_personal_data=True, is_concurrency_safe=False, cache_ttl_seconds=0, rate_limit_per_minute=10.
+- **FR-003**: System MUST provide a ToolRegistry with register, lookup (by id), and search (by keyword) operations.
+- **FR-004**: System MUST implement `search_tools(query: str)` that matches against search_hint using bilingual (Korean + English) keyword matching.
+- **FR-005**: System MUST partition tools into core (always loaded) and situational (on-demand) categories.
+- **FR-006**: System MUST export core tool schemas as a deterministic, ordered list suitable for prompt prefix caching.
+- **FR-007**: System MUST track per-tool call counts within sliding time windows and reject calls exceeding rate_limit_per_minute.
+- **FR-008**: System MUST validate tool call arguments against the tool's input_schema before execution.
+- **FR-009**: System MUST validate tool execution results against the tool's output_schema after execution.
+- **FR-010**: System MUST reject duplicate tool registrations (same id) with a clear error.
+- **FR-011**: System MUST support the `search_tools` meta-tool as a tool itself, registrable in the registry for LLM discovery.
+- **FR-012**: System MUST expose tool definitions in OpenAI function-calling format for LLM consumption.
+
+### Key Entities
+
+- **GovAPITool**: The Pydantic v2 model defining a government API tool's metadata, schemas, and operational constraints.
+- **ToolRegistry**: The central registry managing tool registration, lookup, search, and partitioning.
+- **ToolExecutor**: Dispatches tool calls with input validation, API invocation, and output validation.
+- **RateLimiter**: Tracks per-tool call frequency and enforces rate limits.
+- **ToolPartition**: Enum or flag distinguishing core tools from situational tools.
+
+## Success Criteria
+
+### Measurable Outcomes
+
+- **SC-001**: A new tool can be registered with only required fields, and all security-sensitive defaults are fail-closed without any developer intervention.
+- **SC-002**: Bilingual tool search returns relevant results for both Korean and English queries, with zero false negatives for exact keyword matches.
+- **SC-003**: Core tool schema export produces identical output across invocations (byte-for-byte deterministic) for prompt caching effectiveness.
+- **SC-004**: Rate limiting correctly prevents calls beyond the configured threshold with zero false positives (legitimate calls within limits are never rejected).
+- **SC-005**: All unit tests pass using mock tools and recorded fixtures without requiring live API access.
+
+## Assumptions
+
+- Phase 1 targets approximately 10 high-value tools; the registry design must support scaling to hundreds but does not need to demonstrate 5,000+ tool performance in Phase 1.
+- Bilingual search uses simple keyword matching (substring/token overlap) in Phase 1; semantic search is a Phase 2+ enhancement.
+- Core tools for Phase 1 are a static list defined in configuration; dynamic core tool promotion is out of scope.
+- Tool execution is the adapter's responsibility; the registry dispatches but does not implement API-specific logic.
+- The rate limiter uses in-memory counters; persistence across process restarts is not required for Phase 1.
+- Tool definitions are registered at application startup; hot-reload of tool definitions at runtime is out of scope for Phase 1.

--- a/specs/006-tool-system/tasks.md
+++ b/specs/006-tool-system/tasks.md
@@ -1,0 +1,224 @@
+# Tasks: Tool System & Registry (Layer 2)
+
+**Input**: Design documents from `specs/006-tool-system/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (US1, US2, US3, US4, US5)
+- Exact file paths included in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create module structure
+
+- [ ] T001 Create `src/kosmos/tools/` package directory with `__init__.py` and create `tests/tools/` package directory with `__init__.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Error hierarchy and shared test infrastructure that ALL user stories depend on
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [ ] T002 [P] Implement error hierarchy (`KosmosToolError`, `DuplicateToolError`, `ToolNotFoundError`, `ToolValidationError`, `RateLimitExceededError`, `ToolExecutionError`) in `src/kosmos/tools/errors.py`
+- [ ] T003 [P] Create test infrastructure with shared fixtures (mock Pydantic input/output schemas, sample `GovAPITool` factory, mock tool adapter function) in `tests/tools/conftest.py`
+
+**Checkpoint**: Foundation ready — error types and test fixtures are importable
+
+---
+
+## Phase 3: User Story 1 — Tool Registration with Fail-Closed Defaults (Priority: P1) MVP
+
+**Goal**: Define GovAPITool model with fail-closed defaults and register tools in ToolRegistry
+
+**Independent Test**: Register a tool with only required fields, verify all defaults are fail-closed. Register with explicit overrides, verify overrides respected. Reject duplicate registrations.
+
+### Implementation for User Story 1
+
+- [ ] T004 [P] [US1] Implement `GovAPITool` Pydantic v2 model with all fields (id, name_ko, provider, category, endpoint, auth_type, input_schema, output_schema, search_hint) and fail-closed defaults (requires_auth=True, is_personal_data=True, is_concurrency_safe=False, cache_ttl_seconds=0, rate_limit_per_minute=10, is_core=False) including id pattern validation (`^[a-z][a-z0-9_]*$`), non-empty category, and `to_openai_tool()` method in `src/kosmos/tools/models.py`
+- [ ] T005 [P] [US1] Implement `ToolResult`, `ToolSearchResult`, and `SearchToolMatch` Pydantic v2 models in `src/kosmos/tools/models.py` — ToolResult with success/data/error/error_type fields, ToolSearchResult with tool/score/matched_tokens
+- [ ] T006 [US1] Implement `ToolRegistry` with `register()`, `lookup()`, `all_tools()`, `__len__()`, `__contains__()` methods in `src/kosmos/tools/registry.py` — register raises `DuplicateToolError`, lookup raises `ToolNotFoundError`
+- [ ] T007 [P] [US1] Write unit tests for GovAPITool validation (fail-closed defaults, id pattern rejection, non-empty category, explicit overrides, to_openai_tool format) in `tests/tools/test_models.py`
+- [ ] T008 [P] [US1] Write unit tests for ToolRegistry registration and lookup (register success, duplicate rejection, lookup success, not-found error, __len__, __contains__) in `tests/tools/test_registry.py`
+
+**Checkpoint**: Tool registration works with fail-closed defaults. `uv run pytest tests/tools/` passes.
+
+---
+
+## Phase 4: User Story 2 — Lazy Tool Discovery via search_tools (Priority: P1)
+
+**Goal**: Search tools by Korean and English keywords in search_hint with token-overlap scoring
+
+**Independent Test**: Register multiple tools with varied search_hints, query with Korean keywords, verify relevant tools returned. Query with English keywords, verify same. Query with empty string, verify empty results.
+
+### Implementation for User Story 2
+
+- [ ] T009 [US2] Implement bilingual search logic with token-overlap scoring (case-insensitive substring matching, query tokenization, score computation, ranking) in `src/kosmos/tools/search.py`
+- [ ] T010 [US2] Add `search()` method to `ToolRegistry` that delegates to search logic, accepts `query: str` and `max_results: int = 5`, returns `list[ToolSearchResult]` in `src/kosmos/tools/registry.py`
+- [ ] T011 [P] [US2] Implement `SearchToolsInput` and `SearchToolsOutput` Pydantic v2 models, and `create_search_meta_tool()` factory function that creates a `GovAPITool` for `search_tools` in `src/kosmos/tools/search.py`
+- [ ] T012 [P] [US2] Write unit tests for bilingual search (Korean keyword match, English keyword match, mixed query, empty query returns empty, max_results limit, score ranking, no-match returns empty) in `tests/tools/test_search.py`
+
+**Checkpoint**: Tool search works for Korean and English queries. Relevant tools are ranked correctly.
+
+---
+
+## Phase 5: User Story 3 — Prompt Cache Partitioning (Priority: P2)
+
+**Goal**: Separate core tools (always loaded) from situational tools (on-demand), export core tools deterministically
+
+**Independent Test**: Register tools with is_core=True and is_core=False, verify core_tools() returns only core tools sorted by id, verify situational_tools() returns only non-core tools, verify export_core_tools_openai() output is byte-for-byte identical across calls.
+
+### Implementation for User Story 3
+
+- [ ] T013 [US3] Add `core_tools()`, `situational_tools()`, and `export_core_tools_openai()` methods to `ToolRegistry` — core_tools sorted by id for deterministic output, export uses `to_openai_tool()` in `src/kosmos/tools/registry.py`
+- [ ] T014 [P] [US3] Write unit tests for prompt cache partitioning (core vs situational partition is disjoint, core_tools sorted by id, export_core_tools_openai deterministic across calls, empty core list, mixed registration order) in `tests/tools/test_registry.py`
+
+**Checkpoint**: Prompt cache partitioning works. Core tool export is deterministic.
+
+---
+
+## Phase 6: User Story 4 — Rate Limit Tracking (Priority: P2)
+
+**Goal**: Track per-tool call frequency with sliding-window rate limiting, reject calls exceeding limits
+
+**Independent Test**: Create a tool with rate_limit_per_minute=5, make 5 calls within one minute, verify 6th is rejected. Wait for window expiry, verify calls are allowed again.
+
+### Implementation for User Story 4
+
+- [ ] T015 [US4] Implement `RateLimiter` with sliding-window algorithm using `collections.deque` — `check()`, `record()`, `remaining` property, `reset()` method in `src/kosmos/tools/rate_limiter.py`
+- [ ] T016 [US4] Integrate `RateLimiter` into `ToolRegistry` — auto-create per-tool rate limiter on registration, expose `get_rate_limiter(tool_id: str) -> RateLimiter` method in `src/kosmos/tools/registry.py`
+- [ ] T017 [P] [US4] Write unit tests for RateLimiter (check within limit, reject at limit, window expiry reset, remaining count, manual reset, independent per-tool limiters) in `tests/tools/test_rate_limiter.py`
+
+**Checkpoint**: Rate limiting works. Per-tool call counts are tracked independently.
+
+---
+
+## Phase 7: User Story 5 — Tool Execution Dispatch (Priority: P3)
+
+**Goal**: Dispatch tool calls with input/output validation, rate limit checking, and error handling
+
+**Independent Test**: Register a mock tool, dispatch with valid arguments and verify validated response. Dispatch with invalid arguments and verify validation error. Dispatch unknown tool and verify not-found error.
+
+### Implementation for User Story 5
+
+- [ ] T018 [US5] Implement `ToolExecutor` with `dispatch(tool_name, arguments_json) -> ToolResult` pipeline — lookup → validate input → check rate limit → execute adapter → validate output — returns ToolResult with success=False for any failure (never raises) in `src/kosmos/tools/executor.py`
+- [ ] T019 [P] [US5] Write unit tests for ToolExecutor dispatch (valid call returns success, invalid input returns validation error, unknown tool returns not-found, rate limit exceeded returns rate_limit error, adapter exception returns execution error, output schema mismatch returns schema_mismatch error) in `tests/tools/test_executor.py`
+
+**Checkpoint**: Tool execution dispatch works. All error paths return ToolResult, never raise.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Finalize public API and validate documentation
+
+- [ ] T020 Finalize public exports in `src/kosmos/tools/__init__.py` — export `GovAPITool`, `ToolRegistry`, `ToolExecutor`, `ToolResult`, `ToolSearchResult`, `RateLimiter`, all error types, `SearchToolsInput`, `SearchToolsOutput`
+- [ ] T021 Run `quickstart.md` code examples as validation (verify imports, API surface matches contract)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — BLOCKS all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — MVP delivery target (with US2)
+- **US2 (Phase 4)**: Depends on Phase 3 (needs ToolRegistry to add search)
+- **US3 (Phase 5)**: Depends on Phase 3 (needs ToolRegistry to add partitioning)
+- **US4 (Phase 6)**: Depends on Phase 3 (needs ToolRegistry to integrate rate limiters)
+- **US5 (Phase 7)**: Depends on Phase 3 + Phase 6 (needs registry + rate limiters for dispatch)
+- **Polish (Phase 8)**: Depends on all user stories complete
+
+### User Story Dependencies
+
+- **US1 (P1)**: Can start after Foundational (Phase 2) — no story dependencies
+- **US2 (P1)**: Depends on US1 (extends ToolRegistry with search)
+- **US3 (P2)**: Depends on US1 (extends ToolRegistry with partitioning) — parallel-safe with US2
+- **US4 (P2)**: Depends on US1 (integrates rate limiters into registry) — parallel-safe with US2/US3
+- **US5 (P3)**: Depends on US1 + US4 (needs full registry with rate limiters for dispatch)
+
+### Within Each User Story
+
+- Models/infrastructure before registry integration
+- Registry integration before tests (tests verify integrated behavior)
+- All [P] tasks within a phase can run in parallel
+
+### Parallel Opportunities
+
+- **Phase 2**: T002, T003 — all parallel-safe (different files)
+- **Phase 3**: T004, T005 parallel (models.py additions), then T006 (registry.py); T007, T008 parallel (test files)
+- **Phase 4+5+6**: US2 search.py, US3 registry.py additions, US4 rate_limiter.py — infrastructure tasks are parallel-safe across stories, but registry.py edits must be serialized
+
+---
+
+## Parallel Example: Foundational Phase
+
+```text
+# Launch foundational tasks in parallel (different files):
+Agent 1: T002 — errors.py
+Agent 2: T003 — conftest.py
+```
+
+## Parallel Example: User Story 1 (after Foundational)
+
+```text
+# Launch model tasks in parallel (same file but additive):
+Agent 1: T004 — models.py (GovAPITool)
+Agent 2: T005 — models.py (ToolResult, ToolSearchResult)
+# Then: T006 — registry.py (depends on models)
+# Then launch test tasks in parallel:
+Agent 3: T007 — test_models.py
+Agent 4: T008 — test_registry.py
+```
+
+## Parallel Example: Cross-Story (after US1 complete)
+
+```text
+# US2, US3, US4 infrastructure tasks in parallel:
+Agent 1: T009 [US2] — search.py (new file)
+Agent 2: T015 [US4] — rate_limiter.py (new file)
+# US3 T013 edits registry.py — serialize with T010, T016
+# Then serialize registry.py integrations: T010, T013, T016
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 + 2)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete Phase 2: Foundational (T002-T003) — parallel
+3. Complete Phase 3: US1 (T004-T008)
+4. Complete Phase 4: US2 (T009-T012)
+5. **STOP and VALIDATE**: `uv run pytest tests/tools/` passes
+6. Tool system is usable for registration and search
+
+### Incremental Delivery
+
+1. Setup + Foundational → Foundation ready
+2. Add US1 → Fail-closed registration works (MVP part 1)
+3. Add US2 → Bilingual search works (MVP part 2)
+4. Add US3 → Prompt cache partitioning active
+5. Add US4 → Rate limiting enforced
+6. Add US5 → Tool execution dispatch ready for Query Engine
+7. Polish → Production-grade exports and validation
+
+---
+
+## Notes
+
+- Total tasks: 21 (T001-T021)
+- Parallel-safe tasks: 9 (marked [P])
+- No new dependencies required (pydantic already in pyproject.toml)
+- All tests use mock tools — no live API calls
+- US2 and US3 are both independent from each other (parallel-safe with different stories)
+- US5 depends on US4 (rate limit checking in dispatch pipeline)
+- registry.py is the integration point — edits from different stories must be serialized
+- models.py has additive tasks (T004, T005) that can be parallelized if working on non-overlapping sections

--- a/src/kosmos/llm/__init__.py
+++ b/src/kosmos/llm/__init__.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""LLM client integration for FriendliAI K-EXAONE."""
+
+from kosmos.llm.client import LLMClient
+from kosmos.llm.config import LLMClientConfig
+from kosmos.llm.errors import (
+    AuthenticationError,
+    BudgetExceededError,
+    ConfigurationError,
+    KosmosLLMError,
+    LLMConnectionError,
+    LLMResponseError,
+    StreamInterruptedError,
+)
+from kosmos.llm.models import (
+    ChatCompletionResponse,
+    ChatMessage,
+    FunctionCall,
+    FunctionSchema,
+    StreamEvent,
+    TokenUsage,
+    ToolCall,
+    ToolDefinition,
+)
+from kosmos.llm.retry import RetryPolicy
+from kosmos.llm.usage import UsageTracker
+
+__all__ = [
+    "AuthenticationError",
+    "BudgetExceededError",
+    "ChatCompletionResponse",
+    "ChatMessage",
+    "ConfigurationError",
+    "FunctionCall",
+    "FunctionSchema",
+    "KosmosLLMError",
+    "LLMClient",
+    "LLMClientConfig",
+    "LLMConnectionError",
+    "LLMResponseError",
+    "RetryPolicy",
+    "StreamEvent",
+    "StreamInterruptedError",
+    "TokenUsage",
+    "ToolCall",
+    "ToolDefinition",
+    "UsageTracker",
+]

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -185,9 +185,7 @@ class LLMClient:
         )
 
         try:
-            async with self._client.stream(
-                "POST", "/chat/completions", json=payload
-            ) as response:
+            async with self._client.stream("POST", "/chat/completions", json=payload) as response:
                 self._raise_for_status(response)
 
                 async for line in response.aiter_lines():
@@ -197,17 +195,11 @@ class LLMClient:
                             return
 
         except httpx.ConnectError as exc:
-            raise StreamInterruptedError(
-                f"Connection lost during streaming: {exc}"
-            ) from exc
+            raise StreamInterruptedError(f"Connection lost during streaming: {exc}") from exc
         except httpx.TimeoutException as exc:
-            raise StreamInterruptedError(
-                f"Stream timed out: {exc}"
-            ) from exc
+            raise StreamInterruptedError(f"Stream timed out: {exc}") from exc
         except httpx.RequestError as exc:
-            raise StreamInterruptedError(
-                f"Stream request failed: {exc}"
-            ) from exc
+            raise StreamInterruptedError(f"Stream request failed: {exc}") from exc
 
     async def close(self) -> None:
         """Close the underlying HTTP client."""
@@ -228,7 +220,7 @@ class LLMClient:
         if not line or not line.startswith("data: "):
             return
 
-        payload_text = line[len("data: "):]
+        payload_text = line[len("data: ") :]
 
         if payload_text == "[DONE]":
             yield StreamEvent(type="done")

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -1,0 +1,371 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Async LLM client for the KOSMOS project (FriendliAI Serverless endpoint)."""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+
+import httpx
+from pydantic import ValidationError
+
+from kosmos.llm.config import LLMClientConfig
+from kosmos.llm.errors import (
+    AuthenticationError,
+    BudgetExceededError,
+    ConfigurationError,
+    LLMResponseError,
+    StreamInterruptedError,
+)
+from kosmos.llm.models import (
+    ChatCompletionResponse,
+    ChatMessage,
+    FunctionCall,
+    StreamEvent,
+    TokenUsage,
+    ToolCall,
+    ToolDefinition,
+)
+from kosmos.llm.retry import RetryPolicy, retry_with_backoff
+from kosmos.llm.usage import UsageTracker
+
+logger = logging.getLogger(__name__)
+
+
+class LLMClient:
+    """Async LLM client for FriendliAI Serverless endpoint."""
+
+    def __init__(self, config: LLMClientConfig | None = None) -> None:
+        """Initialize with config. Loads from env vars if config is None.
+
+        Raises:
+            ConfigurationError: If KOSMOS_FRIENDLI_TOKEN is missing or invalid.
+        """
+        if config is None:
+            try:
+                config = LLMClientConfig()  # type: ignore[call-arg]
+            except ValidationError as exc:
+                raise ConfigurationError(
+                    f"Failed to load LLM client configuration from environment: {exc}"
+                ) from exc
+
+        self._config = config
+        self._client = httpx.AsyncClient(
+            base_url=config.base_url,
+            headers={"Authorization": f"Bearer {config.token.get_secret_value()}"},
+            timeout=httpx.Timeout(config.timeout),
+        )
+        self._usage = UsageTracker(budget=self._config.session_budget)
+        self._retry_policy = RetryPolicy(max_retries=self._config.max_retries)
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def usage(self) -> UsageTracker:
+        """Current session usage tracker."""
+        return self._usage
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def complete(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
+        stop: list[str] | None = None,
+    ) -> ChatCompletionResponse:
+        """Send a non-streaming chat completion request.
+
+        Args:
+            messages: Ordered list of conversation messages.
+            tools: Optional list of tool definitions for function calling.
+            temperature: Sampling temperature.
+            max_tokens: Maximum tokens in the completion.
+            top_p: Nucleus sampling parameter.
+            stop: Stop sequences.
+
+        Returns:
+            Parsed ChatCompletionResponse.
+
+        Raises:
+            BudgetExceededError: If the session token budget is exhausted.
+            AuthenticationError: On 401 or 403 responses.
+            LLMResponseError: On 400, 404, or other non-retryable HTTP errors.
+            LLMConnectionError: On network / transport failures after all retries.
+        """
+        if not self._usage.can_afford(0):
+            raise BudgetExceededError("Session token budget exhausted")
+
+        payload = self._build_payload(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            stop=stop,
+            tools=tools,
+            stream=False,
+        )
+
+        logger.debug(
+            "LLM complete request: model=%s messages=%d",
+            self._config.model,
+            len(messages),
+        )
+
+        async def _do_request() -> ChatCompletionResponse:
+            response = await self._client.post("/chat/completions", json=payload)
+            response.raise_for_status()
+            return self._parse_completion_response(response.json())
+
+        result = await retry_with_backoff(_do_request, self._retry_policy)
+        self._usage.debit(result.usage)
+        logger.info(
+            "Token usage: %d input, %d output",
+            result.usage.input_tokens,
+            result.usage.output_tokens,
+        )
+        return result
+
+    async def stream(
+        self,
+        messages: list[ChatMessage],
+        *,
+        tools: list[ToolDefinition] | None = None,
+        temperature: float = 0.7,
+        max_tokens: int | None = None,
+        top_p: float | None = None,
+        stop: list[str] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        """Send a streaming chat completion request.
+
+        Yields StreamEvent objects as they arrive from the SSE stream.
+
+        Args:
+            messages: Ordered list of conversation messages.
+            tools: Optional list of tool definitions for function calling.
+            temperature: Sampling temperature.
+            max_tokens: Maximum tokens in the completion.
+            top_p: Nucleus sampling parameter.
+            stop: Stop sequences.
+
+        Yields:
+            StreamEvent for each SSE event received.
+
+        Raises:
+            BudgetExceededError: If the session token budget is exhausted.
+            StreamInterruptedError: If the connection is lost mid-stream.
+            AuthenticationError: On 401 or 403 responses.
+            LLMResponseError: On non-retryable HTTP errors.
+        """
+        if not self._usage.can_afford(0):
+            raise BudgetExceededError("Session token budget exhausted")
+
+        payload = self._build_payload(
+            messages=messages,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            top_p=top_p,
+            stop=stop,
+            tools=tools,
+            stream=True,
+        )
+
+        logger.debug(
+            "LLM stream request: model=%s messages=%d",
+            self._config.model,
+            len(messages),
+        )
+
+        try:
+            async with self._client.stream(
+                "POST", "/chat/completions", json=payload
+            ) as response:
+                self._raise_for_status(response)
+
+                async for line in response.aiter_lines():
+                    async for event in self._parse_sse_line(line):
+                        yield event
+                        if event.type == "done":
+                            return
+
+        except httpx.ConnectError as exc:
+            raise StreamInterruptedError(
+                f"Connection lost during streaming: {exc}"
+            ) from exc
+        except httpx.TimeoutException as exc:
+            raise StreamInterruptedError(
+                f"Stream timed out: {exc}"
+            ) from exc
+        except httpx.RequestError as exc:
+            raise StreamInterruptedError(
+                f"Stream request failed: {exc}"
+            ) from exc
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        await self._client.aclose()
+
+    async def __aenter__(self) -> LLMClient:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        await self.close()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    async def _parse_sse_line(self, line: str) -> AsyncIterator[StreamEvent]:
+        """Parse a single SSE line and yield corresponding StreamEvent(s)."""
+        if not line or not line.startswith("data: "):
+            return
+
+        payload_text = line[len("data: "):]
+
+        if payload_text == "[DONE]":
+            yield StreamEvent(type="done")
+            return
+
+        try:
+            chunk = json.loads(payload_text)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse SSE chunk: %r", payload_text)
+            return
+
+        if "usage" in chunk and chunk["usage"] is not None:
+            raw_usage = chunk["usage"]
+            usage = TokenUsage(
+                input_tokens=raw_usage.get("prompt_tokens", 0),
+                output_tokens=raw_usage.get("completion_tokens", 0),
+            )
+            logger.info(
+                "LLM stream usage: input=%d output=%d",
+                usage.input_tokens,
+                usage.output_tokens,
+            )
+            self._usage.debit(usage)
+            yield StreamEvent(type="usage", usage=usage)
+
+        choices = chunk.get("choices")
+        if not choices:
+            return
+
+        choice = choices[0]
+        delta = choice.get("delta", {})
+
+        if "content" in delta and delta["content"] is not None:
+            yield StreamEvent(type="content_delta", content=delta["content"])
+
+        if "tool_calls" in delta and delta["tool_calls"]:
+            for tc_delta in delta["tool_calls"]:
+                func = tc_delta.get("function", {})
+                yield StreamEvent(
+                    type="tool_call_delta",
+                    tool_call_index=tc_delta.get("index"),
+                    tool_call_id=tc_delta.get("id"),
+                    function_name=func.get("name"),
+                    function_args_delta=func.get("arguments"),
+                )
+
+    def _build_payload(
+        self,
+        *,
+        messages: list[ChatMessage],
+        temperature: float,
+        max_tokens: int | None,
+        top_p: float | None,
+        stop: list[str] | None,
+        tools: list[ToolDefinition] | None = None,
+        stream: bool,
+    ) -> dict[str, object]:
+        """Construct the JSON payload for a chat completions request."""
+        payload: dict[str, object] = {
+            "model": self._config.model,
+            "messages": [m.model_dump(exclude_none=True) for m in messages],
+            "temperature": temperature,
+        }
+        if max_tokens is not None:
+            payload["max_tokens"] = max_tokens
+        if top_p is not None:
+            payload["top_p"] = top_p
+        if stop is not None:
+            payload["stop"] = stop
+        if tools is not None:
+            payload["tools"] = [t.model_dump() for t in tools]
+        if stream:
+            payload["stream"] = True
+            payload["stream_options"] = {"include_usage": True}
+        return payload
+
+    @staticmethod
+    def _raise_for_status(response: httpx.Response) -> None:
+        """Map HTTP error status codes to typed KOSMOS exceptions."""
+        status = response.status_code
+        if status in (401, 403):
+            raise AuthenticationError(
+                f"Authentication failed (HTTP {status})",
+                status_code=status,
+            )
+        if status in (400, 404):
+            raise LLMResponseError(
+                f"LLM API returned error (HTTP {status}): {response.text}",
+                status_code=status,
+            )
+        if status >= 500:
+            raise LLMResponseError(
+                f"LLM API server error (HTTP {status}): {response.text}",
+                status_code=status,
+            )
+
+    @staticmethod
+    def _parse_completion_response(data: dict[str, object]) -> ChatCompletionResponse:
+        """Parse a raw /chat/completions JSON response into ChatCompletionResponse."""
+        choice = data["choices"][0]  # type: ignore[index]
+        message = choice["message"]  # type: ignore[index]
+
+        # Parse tool calls if present
+        tool_calls: list[ToolCall] = []
+        if message.get("tool_calls"):
+            for tc in message["tool_calls"]:
+                func = tc["function"]
+                tool_calls.append(
+                    ToolCall(
+                        id=tc["id"],
+                        type=tc.get("type", "function"),
+                        function=FunctionCall(
+                            name=func["name"],
+                            arguments=func["arguments"],
+                        ),
+                    )
+                )
+
+        # Parse token usage
+        raw_usage = data.get("usage") or {}
+        usage = TokenUsage(
+            input_tokens=raw_usage.get("prompt_tokens", 0),  # type: ignore[arg-type]
+            output_tokens=raw_usage.get("completion_tokens", 0),  # type: ignore[arg-type]
+        )
+
+        logger.info(
+            "LLM complete usage: model=%s input=%d output=%d",
+            data.get("model"),
+            usage.input_tokens,
+            usage.output_tokens,
+        )
+
+        return ChatCompletionResponse(
+            id=data["id"],  # type: ignore[arg-type]
+            content=message.get("content"),
+            tool_calls=tool_calls,
+            usage=usage,
+            model=data["model"],  # type: ignore[arg-type]
+            finish_reason=choice["finish_reason"],  # type: ignore[arg-type]
+        )

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -292,8 +292,7 @@ class LLMClient:
             payload["stop"] = stop
         if tools is not None:
             payload["tools"] = [
-                t.model_dump() if isinstance(t, ToolDefinition) else t
-                for t in tools
+                t.model_dump() if isinstance(t, ToolDefinition) else t for t in tools
             ]
         if stream:
             payload["stream"] = True

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -76,7 +76,7 @@ class LLMClient:
         self,
         messages: list[ChatMessage],
         *,
-        tools: list[ToolDefinition] | None = None,
+        tools: list[ToolDefinition | dict[str, object]] | None = None,
         temperature: float = 0.7,
         max_tokens: int | None = None,
         top_p: float | None = None,
@@ -86,7 +86,7 @@ class LLMClient:
 
         Args:
             messages: Ordered list of conversation messages.
-            tools: Optional list of tool definitions for function calling.
+            tools: Optional tool definitions (ToolDefinition models or raw dicts).
             temperature: Sampling temperature.
             max_tokens: Maximum tokens in the completion.
             top_p: Nucleus sampling parameter.
@@ -101,7 +101,7 @@ class LLMClient:
             LLMResponseError: On 400, 404, or other non-retryable HTTP errors.
             LLMConnectionError: On network / transport failures after all retries.
         """
-        if not self._usage.can_afford(0):
+        if not self._usage.can_afford(max_tokens or 1):
             raise BudgetExceededError("Session token budget exhausted")
 
         payload = self._build_payload(
@@ -138,7 +138,7 @@ class LLMClient:
         self,
         messages: list[ChatMessage],
         *,
-        tools: list[ToolDefinition] | None = None,
+        tools: list[ToolDefinition | dict[str, object]] | None = None,
         temperature: float = 0.7,
         max_tokens: int | None = None,
         top_p: float | None = None,
@@ -150,7 +150,7 @@ class LLMClient:
 
         Args:
             messages: Ordered list of conversation messages.
-            tools: Optional list of tool definitions for function calling.
+            tools: Optional tool definitions (ToolDefinition models or raw dicts).
             temperature: Sampling temperature.
             max_tokens: Maximum tokens in the completion.
             top_p: Nucleus sampling parameter.
@@ -165,7 +165,7 @@ class LLMClient:
             AuthenticationError: On 401 or 403 responses.
             LLMResponseError: On non-retryable HTTP errors.
         """
-        if not self._usage.can_afford(0):
+        if not self._usage.can_afford(max_tokens or 1):
             raise BudgetExceededError("Session token budget exhausted")
 
         payload = self._build_payload(
@@ -275,7 +275,7 @@ class LLMClient:
         max_tokens: int | None,
         top_p: float | None,
         stop: list[str] | None,
-        tools: list[ToolDefinition] | None = None,
+        tools: list[ToolDefinition | dict[str, object]] | None = None,
         stream: bool,
     ) -> dict[str, object]:
         """Construct the JSON payload for a chat completions request."""
@@ -291,7 +291,10 @@ class LLMClient:
         if stop is not None:
             payload["stop"] = stop
         if tools is not None:
-            payload["tools"] = [t.model_dump() for t in tools]
+            payload["tools"] = [
+                t.model_dump() if isinstance(t, ToolDefinition) else t
+                for t in tools
+            ]
         if stream:
             payload["stream"] = True
             payload["stream_options"] = {"include_usage": True}
@@ -306,14 +309,19 @@ class LLMClient:
                 f"Authentication failed (HTTP {status})",
                 status_code=status,
             )
-        if status in (400, 404):
+        if status == 429:
             raise LLMResponseError(
-                f"LLM API returned error (HTTP {status}): {response.text}",
+                f"Rate limited by LLM API (HTTP 429): {response.text}",
                 status_code=status,
             )
         if status >= 500:
             raise LLMResponseError(
                 f"LLM API server error (HTTP {status}): {response.text}",
+                status_code=status,
+            )
+        if status >= 400:
+            raise LLMResponseError(
+                f"LLM API returned error (HTTP {status}): {response.text}",
                 status_code=status,
             )
 

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -186,7 +186,7 @@ class LLMClient:
 
         try:
             async with self._client.stream("POST", "/chat/completions", json=payload) as response:
-                self._raise_for_status(response)
+                await self._raise_for_status(response)
 
                 async for line in response.aiter_lines():
                     async for event in self._parse_sse_line(line):
@@ -300,9 +300,17 @@ class LLMClient:
         return payload
 
     @staticmethod
-    def _raise_for_status(response: httpx.Response) -> None:
-        """Map HTTP error status codes to typed KOSMOS exceptions."""
+    async def _raise_for_status(response: httpx.Response) -> None:
+        """Map HTTP error status codes to typed KOSMOS exceptions.
+
+        Reads the response body before accessing text to avoid
+        ``httpx.ResponseNotRead`` on streaming responses.
+        """
         status = response.status_code
+        if status < 400:
+            return
+        # Ensure body is loaded before accessing .text (safe for streaming).
+        await response.aread()
         if status in (401, 403):
             raise AuthenticationError(
                 f"Authentication failed (HTTP {status})",

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -52,7 +52,7 @@ class LLMClient:
 
         self._config = config
         self._client = httpx.AsyncClient(
-            base_url=config.base_url,
+            base_url=str(config.base_url),
             headers={"Authorization": f"Bearer {config.token.get_secret_value()}"},
             timeout=httpx.Timeout(config.timeout),
         )

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -44,7 +44,7 @@ class LLMClient:
         """
         if config is None:
             try:
-                config = LLMClientConfig()  # type: ignore[call-arg]
+                config = LLMClientConfig()
             except ValidationError as exc:
                 raise ConfigurationError(
                     f"Failed to load LLM client configuration from environment: {exc}"
@@ -321,7 +321,7 @@ class LLMClient:
     def _parse_completion_response(data: dict[str, object]) -> ChatCompletionResponse:
         """Parse a raw /chat/completions JSON response into ChatCompletionResponse."""
         choice = data["choices"][0]  # type: ignore[index]
-        message = choice["message"]  # type: ignore[index]
+        message = choice["message"]
 
         # Parse tool calls if present
         tool_calls: list[ToolCall] = []
@@ -342,8 +342,8 @@ class LLMClient:
         # Parse token usage
         raw_usage = data.get("usage") or {}
         usage = TokenUsage(
-            input_tokens=raw_usage.get("prompt_tokens", 0),  # type: ignore[arg-type]
-            output_tokens=raw_usage.get("completion_tokens", 0),  # type: ignore[arg-type]
+            input_tokens=raw_usage.get("prompt_tokens", 0),  # type: ignore[attr-defined]
+            output_tokens=raw_usage.get("completion_tokens", 0),  # type: ignore[attr-defined]
         )
 
         logger.info(
@@ -359,5 +359,5 @@ class LLMClient:
             tool_calls=tool_calls,
             usage=usage,
             model=data["model"],  # type: ignore[arg-type]
-            finish_reason=choice["finish_reason"],  # type: ignore[arg-type]
+            finish_reason=choice["finish_reason"],
         )

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -309,8 +309,9 @@ class LLMClient:
         status = response.status_code
         if status < 400:
             return
-        # Ensure body is loaded before accessing .text (safe for streaming).
+        # Read the full body first so .text is safe on streaming responses.
         await response.aread()
+        body = response.text[:500]
         if status in (401, 403):
             raise AuthenticationError(
                 f"Authentication failed (HTTP {status})",
@@ -318,17 +319,17 @@ class LLMClient:
             )
         if status == 429:
             raise LLMResponseError(
-                f"Rate limited by LLM API (HTTP 429): {response.text}",
+                f"Rate limited by LLM API (HTTP 429): {body}",
                 status_code=status,
             )
         if status >= 500:
             raise LLMResponseError(
-                f"LLM API server error (HTTP {status}): {response.text}",
+                f"LLM API server error (HTTP {status}): {body}",
                 status_code=status,
             )
         if status >= 400:
             raise LLMResponseError(
-                f"LLM API returned error (HTTP {status}): {response.text}",
+                f"LLM API returned error (HTTP {status}): {body}",
                 status_code=status,
             )
 

--- a/src/kosmos/llm/config.py
+++ b/src/kosmos/llm/config.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Configuration model for the KOSMOS LLM client."""
+
+from __future__ import annotations
+
+from pydantic import Field, SecretStr, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class LLMClientConfig(BaseSettings):
+    """Settings for the FriendliAI K-EXAONE LLM client.
+
+    Environment variables (no global prefix — each field declares its own alias):
+        KOSMOS_FRIENDLI_TOKEN       — required API token
+        KOSMOS_FRIENDLI_BASE_URL    — API base URL
+        KOSMOS_FRIENDLI_MODEL       — model identifier
+        KOSMOS_LLM_SESSION_BUDGET   — per-session token budget
+    """
+
+    model_config = SettingsConfigDict(
+        env_prefix="",          # each field uses an explicit validation_alias
+        case_sensitive=False,
+        extra="ignore",
+    )
+
+    token: SecretStr = Field(
+        ...,
+        validation_alias="KOSMOS_FRIENDLI_TOKEN",
+        description="FriendliAI API token.",
+    )
+    base_url: str = Field(
+        default="https://api.friendli.ai/v1",
+        validation_alias="KOSMOS_FRIENDLI_BASE_URL",
+        description="FriendliAI API base URL.",
+    )
+    model: str = Field(
+        default="dep89a2fde0e09",
+        validation_alias="KOSMOS_FRIENDLI_MODEL",
+        description="FriendliAI model identifier.",
+    )
+    session_budget: int = Field(
+        default=100000,
+        validation_alias="KOSMOS_LLM_SESSION_BUDGET",
+        description="Maximum tokens allowed per session.",
+    )
+    timeout: float = Field(
+        default=60.0,
+        description="HTTP request timeout in seconds.",
+    )
+    max_retries: int = Field(
+        default=3,
+        description="Maximum number of retry attempts on transient failures.",
+    )
+
+    @field_validator("token")
+    @classmethod
+    def token_must_not_be_empty(cls, value: SecretStr) -> SecretStr:
+        """Reject tokens that are blank after stripping whitespace."""
+        if not value.get_secret_value().strip():
+            raise ValueError("KOSMOS_FRIENDLI_TOKEN must not be empty")
+        return value
+
+    @field_validator("session_budget")
+    @classmethod
+    def session_budget_must_be_positive(cls, value: int) -> int:
+        """Enforce session_budget > 0."""
+        if value <= 0:
+            raise ValueError("session_budget must be > 0")
+        return value
+
+    @field_validator("timeout")
+    @classmethod
+    def timeout_must_be_positive(cls, value: float) -> float:
+        """Enforce timeout > 0."""
+        if value <= 0:
+            raise ValueError("timeout must be > 0")
+        return value
+
+    @field_validator("max_retries")
+    @classmethod
+    def max_retries_must_be_non_negative(cls, value: int) -> int:
+        """Enforce max_retries >= 0."""
+        if value < 0:
+            raise ValueError("max_retries must be >= 0")
+        return value

--- a/src/kosmos/llm/config.py
+++ b/src/kosmos/llm/config.py
@@ -18,7 +18,7 @@ class LLMClientConfig(BaseSettings):
     """
 
     model_config = SettingsConfigDict(
-        env_prefix="",          # each field uses an explicit validation_alias
+        env_prefix="",  # each field uses an explicit validation_alias
         case_sensitive=False,
         extra="ignore",
     )

--- a/src/kosmos/llm/config.py
+++ b/src/kosmos/llm/config.py
@@ -28,7 +28,7 @@ class LLMClientConfig(BaseSettings):
         validation_alias="KOSMOS_FRIENDLI_TOKEN",
         description="FriendliAI API token.",
     )
-    base_url: AnyHttpUrl = Field(
+    base_url: AnyHttpUrl = Field(  # type: ignore[assignment]
         default="https://api.friendli.ai/v1",
         validation_alias="KOSMOS_FRIENDLI_BASE_URL",
         description="FriendliAI API base URL.",

--- a/src/kosmos/llm/config.py
+++ b/src/kosmos/llm/config.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from pydantic import Field, SecretStr, field_validator
+from pydantic import AnyHttpUrl, Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -28,7 +28,7 @@ class LLMClientConfig(BaseSettings):
         validation_alias="KOSMOS_FRIENDLI_TOKEN",
         description="FriendliAI API token.",
     )
-    base_url: str = Field(
+    base_url: AnyHttpUrl = Field(
         default="https://api.friendli.ai/v1",
         validation_alias="KOSMOS_FRIENDLI_BASE_URL",
         description="FriendliAI API base URL.",

--- a/src/kosmos/llm/errors.py
+++ b/src/kosmos/llm/errors.py
@@ -1,0 +1,44 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exception hierarchy for the KOSMOS LLM client module."""
+
+from __future__ import annotations
+
+
+class KosmosLLMError(Exception):
+    """Base exception for all LLM client errors."""
+
+
+class ConfigurationError(KosmosLLMError):
+    """Missing or invalid configuration (e.g., missing KOSMOS_FRIENDLI_TOKEN)."""
+
+
+class BudgetExceededError(KosmosLLMError):
+    """Session token budget exhausted."""
+
+
+class AuthenticationError(KosmosLLMError):
+    """API authentication failed (401/403)."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class LLMConnectionError(KosmosLLMError):
+    """Endpoint unreachable after retry exhaustion."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class LLMResponseError(KosmosLLMError):
+    """Non-retryable API error (400, 404, 500)."""
+
+    def __init__(self, message: str, status_code: int | None = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+
+
+class StreamInterruptedError(KosmosLLMError):
+    """Streaming response interrupted mid-delivery."""

--- a/src/kosmos/llm/models.py
+++ b/src/kosmos/llm/models.py
@@ -58,7 +58,7 @@ class TokenUsage(BaseModel):
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
 
-    @computed_field  # type: ignore[misc]
+    @computed_field  # type: ignore[prop-decorator]
     @property
     def total_tokens(self) -> int:
         """Sum of input and output tokens."""

--- a/src/kosmos/llm/models.py
+++ b/src/kosmos/llm/models.py
@@ -45,6 +45,10 @@ class ChatMessage(BaseModel):
             raise ValueError("ChatMessage with role='tool' must provide tool_call_id")
         if self.role in ("system", "user") and self.content is None:
             raise ValueError(f"ChatMessage with role='{self.role}' must provide content")
+        if self.tool_calls is not None and self.role != "assistant":
+            raise ValueError("tool_calls is only valid on role='assistant' messages")
+        if self.tool_call_id is not None and self.role != "tool":
+            raise ValueError("tool_call_id is only valid on role='tool' messages")
         return self
 
 

--- a/src/kosmos/llm/models.py
+++ b/src/kosmos/llm/models.py
@@ -1,0 +1,116 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pydantic v2 message and response models for the KOSMOS LLM client."""
+
+from __future__ import annotations
+
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
+
+
+class FunctionCall(BaseModel):
+    """Function name and serialized arguments requested by the model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    arguments: str  # JSON-serialized string
+
+
+class ToolCall(BaseModel):
+    """Tool invocation requested by the model."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    type: Literal["function"] = "function"
+    function: FunctionCall
+
+
+class ChatMessage(BaseModel):
+    """A single message in a conversation, following the OpenAI chat format."""
+
+    model_config = ConfigDict(frozen=True)
+
+    role: Literal["system", "user", "assistant", "tool"]
+    content: str | None = None
+    name: str | None = None
+    tool_calls: list[ToolCall] | None = None
+    tool_call_id: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_role_constraints(self) -> ChatMessage:
+        """Enforce role-specific field requirements."""
+        if self.role == "tool" and self.tool_call_id is None:
+            raise ValueError("ChatMessage with role='tool' must provide tool_call_id")
+        if self.role in ("system", "user") and self.content is None:
+            raise ValueError(
+                f"ChatMessage with role='{self.role}' must provide content"
+            )
+        return self
+
+
+class TokenUsage(BaseModel):
+    """Token counts reported by a single LLM call."""
+
+    model_config = ConfigDict(frozen=True)
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+
+    @computed_field  # type: ignore[misc]
+    @property
+    def total_tokens(self) -> int:
+        """Sum of input and output tokens."""
+        return self.input_tokens + self.output_tokens
+
+
+class ChatCompletionResponse(BaseModel):
+    """Complete response from a non-streaming LLM call."""
+
+    model_config = ConfigDict(frozen=True)
+
+    id: str
+    content: str | None = None
+    tool_calls: list[ToolCall] = Field(default_factory=list)
+    usage: TokenUsage
+    model: str
+    finish_reason: Literal["stop", "tool_calls", "length"]
+
+
+class StreamEvent(BaseModel):
+    """A single event emitted during a streaming LLM response."""
+
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["content_delta", "tool_call_delta", "usage", "done", "error"]
+    content: str | None = None
+    tool_call_index: int | None = None
+    tool_call_id: str | None = None
+    function_name: str | None = None
+    function_args_delta: str | None = None
+    usage: TokenUsage | None = None
+
+
+class FunctionSchema(BaseModel):
+    """Schema definition for a function/tool."""
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    description: str
+    # dict[str, Any] is acceptable here: this field holds an external JSON Schema
+    # object whose structure is defined by the OpenAI/FriendliAI spec, not by KOSMOS
+    # internal I/O contracts. Using Any is the only correct representation.
+    parameters: dict[str, Any]
+
+
+class ToolDefinition(BaseModel):
+    """Tool schema sent to the model for function calling."""
+
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["function"] = "function"
+    function: FunctionSchema

--- a/src/kosmos/llm/models.py
+++ b/src/kosmos/llm/models.py
@@ -44,9 +44,7 @@ class ChatMessage(BaseModel):
         if self.role == "tool" and self.tool_call_id is None:
             raise ValueError("ChatMessage with role='tool' must provide tool_call_id")
         if self.role in ("system", "user") and self.content is None:
-            raise ValueError(
-                f"ChatMessage with role='{self.role}' must provide content"
-            )
+            raise ValueError(f"ChatMessage with role='{self.role}' must provide content")
         return self
 
 

--- a/src/kosmos/llm/retry.py
+++ b/src/kosmos/llm/retry.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exponential backoff retry logic for the KOSMOS LLM client module."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from kosmos.llm.errors import AuthenticationError, LLMConnectionError, LLMResponseError
+
+logger = logging.getLogger(__name__)
+
+
+class RetryPolicy(BaseModel):
+    """Configuration for retry behavior."""
+
+    model_config = ConfigDict(frozen=True)
+
+    max_retries: int = Field(default=3, ge=0)
+    base_delay: float = Field(default=1.0, gt=0)
+    multiplier: float = Field(default=2.0, ge=1.0)
+    max_delay: float = Field(default=60.0, gt=0)
+    retryable_status_codes: frozenset[int] = Field(
+        default_factory=lambda: frozenset({429, 503})
+    )
+
+
+async def retry_with_backoff[T](
+    func: Callable[[], Awaitable[T]],
+    policy: RetryPolicy,
+) -> T:
+    """Execute an async function with exponential backoff retry.
+
+    Args:
+        func: Async callable to execute (no arguments — use a closure).
+        policy: Retry configuration.
+
+    Returns:
+        The result of the successful function call.
+
+    Raises:
+        AuthenticationError: On 401/403 (immediate, no retry).
+        LLMResponseError: On non-retryable HTTP errors (immediate, no retry).
+        LLMConnectionError: After all retries exhausted.
+    """
+    last_exception: Exception | None = None
+
+    for attempt in range(policy.max_retries + 1):
+        try:
+            return await func()
+        except httpx.HTTPStatusError as exc:
+            status = exc.response.status_code
+
+            # Non-retryable: 401, 403 → AuthenticationError (immediate)
+            if status in {401, 403}:
+                raise AuthenticationError(
+                    f"Authentication failed: HTTP {status}",
+                    status_code=status,
+                ) from exc
+
+            # Non-retryable: other non-retryable codes → LLMResponseError (immediate)
+            if status not in policy.retryable_status_codes:
+                raise LLMResponseError(
+                    f"API error: HTTP {status}",
+                    status_code=status,
+                ) from exc
+
+            # Retryable: 429, 503
+            last_exception = exc
+            if attempt < policy.max_retries:
+                delay = _compute_delay(attempt, policy)
+                logger.warning(
+                    "Retryable error (HTTP %d), attempt %d/%d, retrying in %.2fs",
+                    status,
+                    attempt + 1,
+                    policy.max_retries,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+        except httpx.ConnectError as exc:
+            last_exception = exc
+            if attempt < policy.max_retries:
+                delay = _compute_delay(attempt, policy)
+                logger.warning(
+                    "Connection error, attempt %d/%d, retrying in %.2fs",
+                    attempt + 1,
+                    policy.max_retries,
+                    delay,
+                )
+                await asyncio.sleep(delay)
+
+    # All retries exhausted
+    raise LLMConnectionError(
+        f"All {policy.max_retries} retries exhausted",
+    ) from last_exception
+
+
+def _compute_delay(attempt: int, policy: RetryPolicy) -> float:
+    """Compute delay with exponential backoff and full jitter.
+
+    Formula: min(max_delay, base_delay * multiplier^attempt) * random(0, 1)
+    """
+    exp_delay = min(policy.max_delay, policy.base_delay * (policy.multiplier**attempt))
+    return random.uniform(0, exp_delay)  # noqa: S311 — not cryptographic

--- a/src/kosmos/llm/retry.py
+++ b/src/kosmos/llm/retry.py
@@ -25,9 +25,7 @@ class RetryPolicy(BaseModel):
     base_delay: float = Field(default=1.0, gt=0)
     multiplier: float = Field(default=2.0, ge=1.0)
     max_delay: float = Field(default=60.0, gt=0)
-    retryable_status_codes: frozenset[int] = Field(
-        default_factory=lambda: frozenset({429, 503})
-    )
+    retryable_status_codes: frozenset[int] = Field(default_factory=lambda: frozenset({429, 503}))
 
 
 async def retry_with_backoff[T](

--- a/src/kosmos/llm/retry.py
+++ b/src/kosmos/llm/retry.py
@@ -81,12 +81,13 @@ async def retry_with_backoff[T](
                 )
                 await asyncio.sleep(delay)
 
-        except httpx.ConnectError as exc:
+        except httpx.RequestError as exc:
             last_exception = exc
             if attempt < policy.max_retries:
                 delay = _compute_delay(attempt, policy)
                 logger.warning(
-                    "Connection error, attempt %d/%d, retrying in %.2fs",
+                    "Transport error (%s), attempt %d/%d, retrying in %.2fs",
+                    type(exc).__name__,
                     attempt + 1,
                     policy.max_retries,
                     delay,

--- a/src/kosmos/llm/usage.py
+++ b/src/kosmos/llm/usage.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Session-level token budget tracker for the KOSMOS LLM client."""
+
+from __future__ import annotations
+
+import logging
+
+from kosmos.llm.errors import BudgetExceededError
+from kosmos.llm.models import TokenUsage
+
+logger = logging.getLogger(__name__)
+
+
+class UsageTracker:
+    """Tracks cumulative token usage against a session budget."""
+
+    def __init__(self, budget: int) -> None:
+        """Initialize with a token budget.
+
+        Args:
+            budget: Maximum total tokens allowed for this session. Must be > 0.
+
+        Raises:
+            ValueError: If budget is not a positive integer.
+        """
+        if budget <= 0:
+            raise ValueError(f"budget must be > 0, got {budget}")
+        self._budget = budget
+        self._input_tokens_used = 0
+        self._output_tokens_used = 0
+        self._call_count = 0
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    def can_afford(self, estimated_input_tokens: int) -> bool:
+        """Pre-flight check: is there likely enough budget for this call?
+
+        Conservative estimate — checks if remaining budget can accommodate
+        the estimated input tokens (does not account for output tokens).
+
+        Args:
+            estimated_input_tokens: Expected number of input tokens for the
+                upcoming LLM call.
+
+        Returns:
+            True if remaining budget is greater than or equal to the estimate.
+        """
+        return self.remaining >= estimated_input_tokens
+
+    def debit(self, usage: TokenUsage) -> None:
+        """Record usage from a completed call.
+
+        Args:
+            usage: Token usage from the LLM response.
+
+        Raises:
+            BudgetExceededError: If the debit causes total consumption to
+                exceed the configured budget.
+        """
+        new_input = self._input_tokens_used + usage.input_tokens
+        new_output = self._output_tokens_used + usage.output_tokens
+        new_total = new_input + new_output
+
+        self._input_tokens_used = new_input
+        self._output_tokens_used = new_output
+        self._call_count += 1
+
+        logger.debug(
+            "Token debit: input=%d output=%d | session total=%d / budget=%d",
+            usage.input_tokens,
+            usage.output_tokens,
+            new_total,
+            self._budget,
+        )
+
+        if new_total > self._budget:
+            raise BudgetExceededError(
+                f"Session token budget exceeded: used {new_total}, budget {self._budget}"
+            )
+
+    # ------------------------------------------------------------------
+    # Properties
+    # ------------------------------------------------------------------
+
+    @property
+    def remaining(self) -> int:
+        """Remaining token budget."""
+        return max(0, self._budget - self._input_tokens_used - self._output_tokens_used)
+
+    @property
+    def is_exhausted(self) -> bool:
+        """Whether the budget is fully consumed."""
+        return self.remaining == 0
+
+    @property
+    def call_count(self) -> int:
+        """Number of LLM calls made in this session."""
+        return self._call_count
+
+    @property
+    def total_used(self) -> int:
+        """Total tokens consumed so far."""
+        return self._input_tokens_used + self._output_tokens_used

--- a/src/kosmos/tools/__init__.py
+++ b/src/kosmos/tools/__init__.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tool system and registry for government API tools."""
+
+from kosmos.tools.errors import (
+    DuplicateToolError,
+    KosmosToolError,
+    RateLimitExceededError,
+    ToolExecutionError,
+    ToolNotFoundError,
+    ToolValidationError,
+)
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.models import (
+    GovAPITool,
+    SearchToolMatch,
+    SearchToolsInput,
+    SearchToolsOutput,
+    ToolResult,
+    ToolSearchResult,
+)
+from kosmos.tools.rate_limiter import RateLimiter
+from kosmos.tools.registry import ToolRegistry
+
+__all__ = [
+    "DuplicateToolError",
+    "GovAPITool",
+    "KosmosToolError",
+    "RateLimitExceededError",
+    "RateLimiter",
+    "SearchToolMatch",
+    "SearchToolsInput",
+    "SearchToolsOutput",
+    "ToolExecutionError",
+    "ToolExecutor",
+    "ToolNotFoundError",
+    "ToolRegistry",
+    "ToolResult",
+    "ToolSearchResult",
+    "ToolValidationError",
+]

--- a/src/kosmos/tools/errors.py
+++ b/src/kosmos/tools/errors.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Exception hierarchy for the KOSMOS Tool System module."""
+
+from __future__ import annotations
+
+
+class KosmosToolError(Exception):
+    """Base exception for tool system errors."""
+
+
+class DuplicateToolError(KosmosToolError):
+    """Tool with this id is already registered."""
+
+    def __init__(self, tool_id: str) -> None:
+        super().__init__(f"Tool already registered: {tool_id!r}")
+        self.tool_id = tool_id
+
+
+class ToolNotFoundError(KosmosToolError):
+    """No tool with this id in the registry."""
+
+    def __init__(self, tool_id: str) -> None:
+        super().__init__(f"Tool not found: {tool_id!r}")
+        self.tool_id = tool_id
+
+
+class ToolValidationError(KosmosToolError):
+    """Input or output validation failed against schema."""
+
+    def __init__(
+        self,
+        tool_id: str,
+        message: str,
+        validation_errors: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.tool_id = tool_id
+        self.validation_errors = validation_errors or []
+
+
+class RateLimitExceededError(KosmosToolError):
+    """Tool's rate limit has been exceeded."""
+
+    def __init__(self, tool_id: str, limit: int | float) -> None:
+        super().__init__(
+            f"Rate limit exceeded for tool {tool_id!r}: limit={limit}"
+        )
+        self.tool_id = tool_id
+        self.limit = limit
+
+
+class ToolExecutionError(KosmosToolError):
+    """Tool adapter raised an error during execution."""
+
+    def __init__(
+        self,
+        tool_id: str,
+        message: str,
+        cause: BaseException | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.tool_id = tool_id
+        self.cause = cause

--- a/src/kosmos/tools/errors.py
+++ b/src/kosmos/tools/errors.py
@@ -42,9 +42,7 @@ class RateLimitExceededError(KosmosToolError):
     """Tool's rate limit has been exceeded."""
 
     def __init__(self, tool_id: str, limit: int | float) -> None:
-        super().__init__(
-            f"Rate limit exceeded for tool {tool_id!r}: limit={limit}"
-        )
+        super().__init__(f"Rate limit exceeded for tool {tool_id!r}: limit={limit}")
         self.tool_id = tool_id
         self.limit = limit
 

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -30,9 +30,9 @@ class ToolExecutor:
     The dispatch pipeline (in order):
     1. Lookup tool in registry.
     2. Parse and validate JSON arguments against input_schema.
-    3. Check rate limit.
-    4. Record rate-limit timestamp.
-    5. Execute the registered adapter.
+    3. Verify adapter exists (before consuming a rate-limit slot).
+    4. Check rate limit.
+    5. Record rate-limit timestamp and execute adapter.
     6. Validate adapter output against output_schema.
     7. Return ToolResult(success=True, data=...).
 
@@ -96,7 +96,18 @@ class ToolExecutor:
                 error_type="validation",
             )
 
-        # Step 3: Check rate limit
+        # Step 3: Verify adapter exists before consuming a rate-limit slot
+        adapter = self._adapters.get(tool_name)
+        if adapter is None:
+            logger.warning("No adapter registered for tool: %s", tool_name)
+            return ToolResult(
+                tool_id=tool_name,
+                success=False,
+                error=f"No adapter registered for tool {tool_name!r}",
+                error_type="execution",
+            )
+
+        # Step 4: Check rate limit
         rate_limiter = self._registry.get_rate_limiter(tool_name)
         if not rate_limiter.check():
             logger.warning("Rate limit exceeded for tool: %s", tool_name)
@@ -107,14 +118,10 @@ class ToolExecutor:
                 error_type="rate_limit",
             )
 
-        # Step 4: Record call
+        # Step 5: Record call and execute adapter
         rate_limiter.record()
 
-        # Step 5: Execute adapter
-        adapter = self._adapters.get(tool_name)
         try:
-            if adapter is None:
-                raise RuntimeError(f"No adapter registered for tool {tool_name!r}")
             result_dict = await adapter(validated_input)
         except Exception as exc:
             logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tool dispatcher for the KOSMOS Tool System module.
+
+Resolves tool calls from the LLM by name, validates input/output against
+Pydantic schemas, enforces rate limits, and returns a structured ToolResult.
+The executor never raises — all error paths are captured in ToolResult.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+from pydantic import BaseModel, ValidationError
+
+from kosmos.tools.errors import ToolNotFoundError
+from kosmos.tools.models import GovAPITool, ToolResult  # noqa: F401
+from kosmos.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+AdapterFn = Callable[[BaseModel], Awaitable[dict[str, Any]]]
+
+
+class ToolExecutor:
+    """Dispatch LLM tool calls through validation, rate-limiting, and execution.
+
+    The dispatch pipeline (in order):
+    1. Lookup tool in registry.
+    2. Parse and validate JSON arguments against input_schema.
+    3. Check rate limit.
+    4. Record rate-limit timestamp.
+    5. Execute the registered adapter.
+    6. Validate adapter output against output_schema.
+    7. Return ToolResult(success=True, data=...).
+
+    Any step failure returns ToolResult(success=False, ...) with an
+    appropriate error_type. The executor itself never raises.
+    """
+
+    def __init__(self, registry: ToolRegistry) -> None:
+        """Initialize the executor with a ToolRegistry.
+
+        Args:
+            registry: The tool registry used for lookup and rate-limit access.
+        """
+        self._registry = registry
+        self._adapters: dict[str, AdapterFn] = {}
+
+    def register_adapter(self, tool_id: str, adapter: AdapterFn) -> None:
+        """Register an async adapter function for a tool.
+
+        Args:
+            tool_id: The stable snake_case tool identifier.
+            adapter: Async callable accepting a validated Pydantic model instance
+                     and returning a plain dict matching output_schema.
+        """
+        self._adapters[tool_id] = adapter
+        logger.debug("Registered adapter for tool: %s", tool_id)
+
+    async def dispatch(self, tool_name: str, arguments_json: str) -> ToolResult:
+        """Execute a tool call end-to-end.
+
+        Args:
+            tool_name: The tool identifier to look up in the registry.
+            arguments_json: JSON string of the tool arguments.
+
+        Returns:
+            ToolResult with success=True and data on success, or
+            success=False with error/error_type on any failure.
+        """
+        # Step 1: Lookup tool
+        try:
+            tool = self._registry.lookup(tool_name)
+        except ToolNotFoundError as exc:
+            logger.warning("Tool not found: %s", tool_name)
+            return ToolResult(
+                tool_id=tool_name,
+                success=False,
+                error=str(exc),
+                error_type="not_found",
+            )
+
+        # Step 2: Parse and validate input
+        try:
+            raw_args = json.loads(arguments_json)
+            validated_input = tool.input_schema.model_validate(raw_args)
+        except (json.JSONDecodeError, ValidationError) as exc:
+            logger.warning("Input validation failed for tool %s: %s", tool_name, exc)
+            return ToolResult(
+                tool_id=tool_name,
+                success=False,
+                error=str(exc),
+                error_type="validation",
+            )
+
+        # Step 3: Check rate limit
+        rate_limiter = self._registry.get_rate_limiter(tool_name)
+        if not rate_limiter.check():
+            logger.warning("Rate limit exceeded for tool: %s", tool_name)
+            return ToolResult(
+                tool_id=tool_name,
+                success=False,
+                error=f"Rate limit exceeded for tool {tool_name!r}",
+                error_type="rate_limit",
+            )
+
+        # Step 4: Record call
+        rate_limiter.record()
+
+        # Step 5: Execute adapter
+        adapter = self._adapters.get(tool_name)
+        try:
+            if adapter is None:
+                raise RuntimeError(f"No adapter registered for tool {tool_name!r}")
+            result_dict = await adapter(validated_input)
+        except Exception as exc:
+            logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)
+            return ToolResult(
+                tool_id=tool_name,
+                success=False,
+                error=str(exc),
+                error_type="execution",
+            )
+
+        # Step 6: Validate output
+        try:
+            validated_output = tool.output_schema.model_validate(result_dict)
+        except ValidationError as exc:
+            logger.warning("Output schema mismatch for tool %s: %s", tool_name, exc)
+            return ToolResult(
+                tool_id=tool_name,
+                success=False,
+                error=str(exc),
+                error_type="schema_mismatch",
+            )
+
+        # Step 7: Return success
+        logger.info("Tool dispatch succeeded: %s", tool_name)
+        return ToolResult(
+            tool_id=tool_name,
+            success=True,
+            data=validated_output.model_dump(),
+        )

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -87,7 +87,7 @@ class ToolExecutor:
         try:
             raw_args = json.loads(arguments_json)
             validated_input = tool.input_schema.model_validate(raw_args)
-        except (json.JSONDecodeError, ValidationError) as exc:
+        except (TypeError, json.JSONDecodeError, ValidationError) as exc:
             logger.warning("Input validation failed for tool %s: %s", tool_name, exc)
             return ToolResult(
                 tool_id=tool_name,

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -16,7 +16,7 @@ from typing import Any
 from pydantic import BaseModel, ValidationError
 
 from kosmos.tools.errors import ToolNotFoundError
-from kosmos.tools.models import GovAPITool, ToolResult  # noqa: F401
+from kosmos.tools.models import ToolResult
 from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -1,0 +1,213 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Pydantic v2 data models for the KOSMOS Tool System module."""
+
+from __future__ import annotations
+
+import re
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+
+class GovAPITool(BaseModel):
+    """Government API tool definition with fail-closed security defaults.
+
+    All boolean safety fields default to the more restrictive value
+    per Constitution § II (fail-closed principle).
+    """
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    id: str
+    """Stable snake_case identifier (e.g. ``koroad_accident_search``)."""
+
+    name_ko: str
+    """Korean display name shown to users."""
+
+    provider: str
+    """Ministry or agency that owns the API."""
+
+    category: list[str]
+    """Non-empty list of topic tags."""
+
+    endpoint: str
+    """API base URL."""
+
+    auth_type: Literal["public", "api_key", "oauth"]
+    """Authentication mechanism required by the upstream API."""
+
+    input_schema: type[BaseModel]
+    """Pydantic v2 model class for request parameters."""
+
+    output_schema: type[BaseModel]
+    """Pydantic v2 model class for response data."""
+
+    search_hint: str
+    """Bilingual (Korean + English) discovery keywords for semantic search."""
+
+    # --- Fail-closed defaults (Constitution § II) ---
+    requires_auth: bool = True
+    """Whether citizen authentication is required. Defaults to True (fail-closed)."""
+
+    is_concurrency_safe: bool = False
+    """Safe to call concurrently. Defaults to False (fail-closed)."""
+
+    is_personal_data: bool = True
+    """Whether the response may contain PII. Defaults to True (fail-closed)."""
+
+    cache_ttl_seconds: int = 0
+    """Response cache lifetime in seconds. Defaults to 0 (no caching, fail-closed)."""
+
+    rate_limit_per_minute: int = 10
+    """Client-side rate limit; must be greater than zero."""
+
+    is_core: bool = False
+    """Whether the tool is included in the core prompt partition."""
+
+    # ------------------------------------------------------------------
+    # Validators
+    # ------------------------------------------------------------------
+
+    @field_validator("id")
+    @classmethod
+    def _validate_id(cls, v: str) -> str:
+        if not re.fullmatch(r"^[a-z][a-z0-9_]*$", v):
+            raise ValueError(
+                f"Tool id {v!r} must match ^[a-z][a-z0-9_]*$ "
+                "(lowercase, start with a letter, underscores only)"
+            )
+        return v
+
+    @field_validator("category")
+    @classmethod
+    def _validate_category(cls, v: list[str]) -> list[str]:
+        if not v:
+            raise ValueError("category must not be empty")
+        return v
+
+    @field_validator("rate_limit_per_minute")
+    @classmethod
+    def _validate_rate_limit(cls, v: int) -> int:
+        if v <= 0:
+            raise ValueError(
+                f"rate_limit_per_minute must be > 0, got {v}"
+            )
+        return v
+
+    @field_validator("cache_ttl_seconds")
+    @classmethod
+    def _validate_cache_ttl(cls, v: int) -> int:
+        if v < 0:
+            raise ValueError(
+                f"cache_ttl_seconds must be >= 0, got {v}"
+            )
+        return v
+
+    @field_validator("search_hint")
+    @classmethod
+    def _validate_search_hint(cls, v: str) -> str:
+        if not v.strip():
+            raise ValueError("search_hint must not be empty or whitespace-only")
+        return v
+
+    # ------------------------------------------------------------------
+    # Export helpers
+    # ------------------------------------------------------------------
+
+    def to_openai_tool(self) -> dict[str, object]:
+        """Export as an OpenAI function-calling tool definition."""
+        return {
+            "type": "function",
+            "function": {
+                "name": self.id,
+                "description": self.name_ko,
+                "parameters": self.input_schema.model_json_schema(),
+            },
+        }
+
+
+class ToolResult(BaseModel):
+    """Result returned by the tool executor after dispatching a tool call."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_id: str
+    """Identifier of the tool that was called."""
+
+    success: bool
+    """Whether the execution completed without error."""
+
+    data: dict[str, object] | None = None
+    """Validated output payload; populated only on success."""
+
+    error: str | None = None
+    """Human-readable error message; populated only on failure."""
+
+    error_type: (
+        Literal["validation", "rate_limit", "not_found", "execution", "schema_mismatch"]
+        | None
+    ) = None
+    """Structured error classification; populated only on failure."""
+
+
+class ToolSearchResult(BaseModel):
+    """A ranked search result returned by ``ToolRegistry.search()``."""
+
+    model_config = ConfigDict(frozen=True, arbitrary_types_allowed=True)
+
+    tool: GovAPITool
+    """The matched tool definition."""
+
+    score: float
+    """Relevance score; higher means more relevant."""
+
+    matched_tokens: list[str]
+    """Query tokens that contributed to this match."""
+
+
+class SearchToolMatch(BaseModel):
+    """A single lightweight match entry inside ``SearchToolsOutput``.
+
+    Carries only the fields needed by the LLM to decide whether to call a tool,
+    avoiding the heavyweight ``GovAPITool`` with embedded schema classes.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_id: str
+    """Stable snake_case tool identifier."""
+
+    name_ko: str
+    """Korean display name."""
+
+    provider: str
+    """Ministry or agency that owns the API."""
+
+    category: list[str]
+    """Topic tags."""
+
+    description: str
+    """Human-readable description derived from the tool's ``search_hint``."""
+
+    score: float
+    """Relevance score for this match."""
+
+
+class SearchToolsInput(BaseModel):
+    """Input schema for the ``search_tools`` meta-tool."""
+
+    query: str
+    """Search query in Korean or English keywords."""
+
+    max_results: int = Field(default=5, gt=0)
+    """Maximum number of results to return; must be greater than zero."""
+
+
+class SearchToolsOutput(BaseModel):
+    """Output schema for the ``search_tools`` meta-tool."""
+
+    results: list[SearchToolMatch]
+    """Ranked list of tool matches."""
+
+    total_registered: int
+    """Total number of tools currently registered in the registry."""

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -155,6 +155,9 @@ class ToolResult(BaseModel):
             if self.error is None or self.error_type is None:
                 msg = "success=False must have both error and error_type set"
                 raise ValueError(msg)
+            if self.data is not None:
+                msg = "success=False must not have data set"
+                raise ValueError(msg)
         return self
 
 

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import re
 from typing import Literal
 
-from pydantic import BaseModel, ConfigDict, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 
 class GovAPITool(BaseModel):
@@ -143,6 +143,19 @@ class ToolResult(BaseModel):
         Literal["validation", "rate_limit", "not_found", "execution", "schema_mismatch"] | None
     ) = None
     """Structured error classification; populated only on failure."""
+
+    @model_validator(mode="after")
+    def _check_success_consistency(self) -> ToolResult:
+        """Enforce invariants between success and error/data fields."""
+        if self.success:
+            if self.error is not None or self.error_type is not None:
+                msg = "success=True must not have error or error_type set"
+                raise ValueError(msg)
+        else:
+            if self.error is None or self.error_type is None:
+                msg = "success=False must have both error and error_type set"
+                raise ValueError(msg)
+        return self
 
 
 class ToolSearchResult(BaseModel):

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -89,18 +89,14 @@ class GovAPITool(BaseModel):
     @classmethod
     def _validate_rate_limit(cls, v: int) -> int:
         if v <= 0:
-            raise ValueError(
-                f"rate_limit_per_minute must be > 0, got {v}"
-            )
+            raise ValueError(f"rate_limit_per_minute must be > 0, got {v}")
         return v
 
     @field_validator("cache_ttl_seconds")
     @classmethod
     def _validate_cache_ttl(cls, v: int) -> int:
         if v < 0:
-            raise ValueError(
-                f"cache_ttl_seconds must be >= 0, got {v}"
-            )
+            raise ValueError(f"cache_ttl_seconds must be >= 0, got {v}")
         return v
 
     @field_validator("search_hint")
@@ -144,8 +140,7 @@ class ToolResult(BaseModel):
     """Human-readable error message; populated only on failure."""
 
     error_type: (
-        Literal["validation", "rate_limit", "not_found", "execution", "schema_mismatch"]
-        | None
+        Literal["validation", "rate_limit", "not_found", "execution", "schema_mismatch"] | None
     ) = None
     """Structured error classification; populated only on failure."""
 

--- a/src/kosmos/tools/rate_limiter.py
+++ b/src/kosmos/tools/rate_limiter.py
@@ -17,8 +17,15 @@ class RateLimiter:
 
         Args:
             limit: Maximum calls allowed within the window. Must be > 0.
-            window_seconds: Size of the sliding window in seconds.
+            window_seconds: Size of the sliding window in seconds. Must be > 0.
+
+        Raises:
+            ValueError: If limit or window_seconds is not positive.
         """
+        if limit <= 0:
+            raise ValueError(f"limit must be > 0, got {limit}")
+        if window_seconds <= 0:
+            raise ValueError(f"window_seconds must be > 0, got {window_seconds}")
         self._limit = limit
         self._window_seconds = window_seconds
         self._timestamps: deque[float] = deque()
@@ -39,7 +46,8 @@ class RateLimiter:
         return len(self._timestamps) < self._limit
 
     def record(self) -> None:
-        """Record a call timestamp."""
+        """Record a call timestamp and prune expired entries."""
+        self._prune()
         self._timestamps.append(time.monotonic())
 
     @property

--- a/src/kosmos/tools/rate_limiter.py
+++ b/src/kosmos/tools/rate_limiter.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+from __future__ import annotations
+
+import time
+from collections import deque
+
+
+class RateLimiter:
+    """Sliding-window rate limiter for per-tool call throttling.
+
+    Uses a deque of call timestamps. On each check/record, expired
+    timestamps (older than window_seconds) are pruned.
+    """
+
+    def __init__(self, limit: int, window_seconds: float = 60.0) -> None:
+        """Initialize rate limiter.
+
+        Args:
+            limit: Maximum calls allowed within the window. Must be > 0.
+            window_seconds: Size of the sliding window in seconds.
+        """
+        self._limit = limit
+        self._window_seconds = window_seconds
+        self._timestamps: deque[float] = deque()
+
+    def _prune(self) -> None:
+        """Remove timestamps older than the sliding window."""
+        cutoff = time.monotonic() - self._window_seconds
+        while self._timestamps and self._timestamps[0] < cutoff:
+            self._timestamps.popleft()
+
+    def check(self) -> bool:
+        """Can a call be made right now?
+
+        Returns True if the current number of calls in the window is
+        less than the limit.
+        """
+        self._prune()
+        return len(self._timestamps) < self._limit
+
+    def record(self) -> None:
+        """Record a call timestamp."""
+        self._timestamps.append(time.monotonic())
+
+    @property
+    def remaining(self) -> int:
+        """Remaining calls allowed in the current window."""
+        self._prune()
+        return max(0, self._limit - len(self._timestamps))
+
+    def reset(self) -> None:
+        """Clear all timestamps."""
+        self._timestamps.clear()
+
+    @property
+    def limit(self) -> int:
+        """The configured rate limit."""
+        return self._limit
+
+    @property
+    def window_seconds(self) -> float:
+        """The configured window size."""
+        return self._window_seconds

--- a/src/kosmos/tools/registry.py
+++ b/src/kosmos/tools/registry.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Central registry for KOSMOS government API tools."""
+
+from __future__ import annotations
+
+import logging
+
+from kosmos.tools.errors import DuplicateToolError, ToolNotFoundError
+from kosmos.tools.models import GovAPITool, ToolSearchResult
+from kosmos.tools.rate_limiter import RateLimiter
+from kosmos.tools.search import search_tools
+
+logger = logging.getLogger(__name__)
+
+
+class ToolRegistry:
+    """Central registry for government API tools."""
+
+    def __init__(self) -> None:
+        self._tools: dict[str, GovAPITool] = {}
+        self._rate_limiters: dict[str, RateLimiter] = {}
+
+    def register(self, tool: GovAPITool) -> None:
+        """Register a tool. Raises DuplicateToolError if id already registered."""
+        if tool.id in self._tools:
+            raise DuplicateToolError(tool.id)
+        self._tools[tool.id] = tool
+        self._rate_limiters[tool.id] = RateLimiter(
+            limit=tool.rate_limit_per_minute,
+        )
+        logger.info("Registered tool: %s", tool.id)
+
+    def lookup(self, tool_id: str) -> GovAPITool:
+        """Look up tool by id. Raises ToolNotFoundError if not found."""
+        try:
+            return self._tools[tool_id]
+        except KeyError:
+            raise ToolNotFoundError(tool_id) from None
+
+    def all_tools(self) -> list[GovAPITool]:
+        """Return all registered tools."""
+        return list(self._tools.values())
+
+    def search(self, query: str, max_results: int = 5) -> list[ToolSearchResult]:
+        """Search tools by Korean or English keywords in search_hint."""
+        return search_tools(self.all_tools(), query, max_results)
+
+    def core_tools(self) -> list[GovAPITool]:
+        """Return core tools sorted by id (deterministic for prompt caching)."""
+        return sorted(
+            [t for t in self._tools.values() if t.is_core],
+            key=lambda t: t.id,
+        )
+
+    def situational_tools(self) -> list[GovAPITool]:
+        """Return non-core tools."""
+        return [t for t in self._tools.values() if not t.is_core]
+
+    def export_core_tools_openai(self) -> list[dict[str, object]]:
+        """Export core tools as OpenAI function-calling definitions.
+
+        Output is deterministic (sorted by id) for prompt cache stability.
+        """
+        return [t.to_openai_tool() for t in self.core_tools()]
+
+    def get_rate_limiter(self, tool_id: str) -> RateLimiter:
+        """Get the rate limiter for a tool.
+
+        Raises ToolNotFoundError if tool_id is not registered.
+        """
+        if tool_id not in self._rate_limiters:
+            raise ToolNotFoundError(tool_id)
+        return self._rate_limiters[tool_id]
+
+    def __len__(self) -> int:
+        return len(self._tools)
+
+    def __contains__(self, tool_id: str) -> bool:
+        return tool_id in self._tools

--- a/src/kosmos/tools/search.py
+++ b/src/kosmos/tools/search.py
@@ -40,6 +40,9 @@ def search_tools(
         Ranked list of :class:`ToolSearchResult` with score > 0,
         capped at *max_results* entries.
     """
+    if max_results <= 0:
+        return []
+
     query_stripped = query.strip()
     if not query_stripped:
         return []

--- a/src/kosmos/tools/search.py
+++ b/src/kosmos/tools/search.py
@@ -72,7 +72,7 @@ def search_tools(
                 )
             )
 
-    results.sort(key=lambda r: r.score, reverse=True)
+    results.sort(key=lambda r: (-r.score, r.tool.id))
     return results[:max_results]
 
 

--- a/src/kosmos/tools/search.py
+++ b/src/kosmos/tools/search.py
@@ -22,8 +22,9 @@ def search_tools(
     1. Tokenize query into lowercase tokens (split by whitespace).
     2. If query is empty or only whitespace, return empty list.
     3. For each tool, tokenize its search_hint into lowercase tokens.
-    4. Score = number of query tokens that are substring-matched in any
-       search_hint token (case-insensitive substring matching, not exact match).
+    4. Score = number of query tokens that are bidirectionally substring-matched
+       against any search_hint token (case-insensitive, either token may contain
+       the other).
     5. If score > 0, include in results.
     6. Sort by score descending.
     7. Return top max_results.
@@ -57,8 +58,8 @@ def search_tools(
 
         matched: list[str] = []
         for q_token in query_tokens:
-            # Substring match: q_token must appear inside at least one hint token.
-            if any(q_token in h_token for h_token in hint_tokens):
+            # Bidirectional substring match: either token contains the other.
+            if any(q_token in h_token or h_token in q_token for h_token in hint_tokens):
                 matched.append(q_token)
 
         if matched:

--- a/src/kosmos/tools/search.py
+++ b/src/kosmos/tools/search.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Bilingual (Korean + English) token-overlap search for the KOSMOS Tool System."""
+
+from __future__ import annotations
+
+from kosmos.tools.models import (
+    GovAPITool,
+    SearchToolsInput,
+    SearchToolsOutput,
+    ToolSearchResult,
+)
+
+
+def search_tools(
+    tools: list[GovAPITool],
+    query: str,
+    max_results: int = 5,
+) -> list[ToolSearchResult]:
+    """Search tools by Korean or English keywords in search_hint.
+
+    Algorithm:
+    1. Tokenize query into lowercase tokens (split by whitespace).
+    2. If query is empty or only whitespace, return empty list.
+    3. For each tool, tokenize its search_hint into lowercase tokens.
+    4. Score = number of query tokens that are substring-matched in any
+       search_hint token (case-insensitive substring matching, not exact match).
+    5. If score > 0, include in results.
+    6. Sort by score descending.
+    7. Return top max_results.
+
+    Score normalization: score = matched_count / total_query_tokens
+    This gives a 0.0 to 1.0 range.
+
+    Args:
+        tools: All registered tool definitions to search over.
+        query: Freeform Korean or English search string.
+        max_results: Maximum number of results to return.
+
+    Returns:
+        Ranked list of :class:`ToolSearchResult` with score > 0,
+        capped at *max_results* entries.
+    """
+    query_stripped = query.strip()
+    if not query_stripped:
+        return []
+
+    query_tokens = query_stripped.lower().split()
+    total_query_tokens = len(query_tokens)
+
+    results: list[ToolSearchResult] = []
+
+    for tool in tools:
+        hint_tokens = tool.search_hint.lower().split()
+
+        matched: list[str] = []
+        for q_token in query_tokens:
+            # Substring match: q_token must appear inside at least one hint token.
+            if any(q_token in h_token for h_token in hint_tokens):
+                matched.append(q_token)
+
+        if matched:
+            score = len(matched) / total_query_tokens
+            results.append(
+                ToolSearchResult(
+                    tool=tool,
+                    score=score,
+                    matched_tokens=matched,
+                )
+            )
+
+    results.sort(key=lambda r: r.score, reverse=True)
+    return results[:max_results]
+
+
+def create_search_meta_tool() -> GovAPITool:
+    """Create the search_tools meta-tool for LLM discovery.
+
+    This tool is registered in the ToolRegistry so the LLM can discover
+    other tools via the search_tools function call.
+    """
+    return GovAPITool(
+        id="search_tools",
+        name_ko="도구검색",
+        provider="KOSMOS",
+        category=["시스템", "검색"],
+        endpoint="internal://search_tools",
+        auth_type="public",
+        input_schema=SearchToolsInput,
+        output_schema=SearchToolsOutput,
+        search_hint="도구 검색 찾기 search tools find discover 도구목록",
+        # Override fail-closed defaults for this internal tool.
+        requires_auth=False,
+        is_personal_data=False,
+        is_concurrency_safe=True,
+        cache_ttl_seconds=0,
+        rate_limit_per_minute=60,
+        is_core=True,
+    )

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -1,0 +1,135 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared pytest fixtures for LLM client tests."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kosmos.llm.config import LLMClientConfig
+from kosmos.llm.models import ChatMessage
+
+
+@pytest.fixture
+def sample_messages() -> list[ChatMessage]:
+    """A list of sample ChatMessage objects covering all three common roles."""
+    return [
+        ChatMessage(role="system", content="You are a helpful Korean public-data assistant."),
+        ChatMessage(role="user", content="서울 날씨를 알려주세요."),
+        ChatMessage(role="assistant", content="현재 서울의 날씨를 조회하겠습니다."),
+    ]
+
+
+@pytest.fixture
+def mock_completion_response() -> dict:
+    """A dict matching the OpenAI chat/completions non-streaming response format."""
+    return {
+        "id": "chatcmpl-test-123",
+        "object": "chat.completion",
+        "model": "dep89a2fde0e09",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Test response"},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15,
+        },
+    }
+
+
+@pytest.fixture
+def mock_sse_lines() -> list[bytes]:
+    """SSE-formatted byte strings simulating a streaming chat completion response."""
+    chunks = [
+        {
+            "id": "chatcmpl-test-123",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"role": "assistant", "content": "Hello"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-test-123",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {"content": " world"},
+                    "finish_reason": None,
+                }
+            ],
+        },
+        {
+            "id": "chatcmpl-test-123",
+            "object": "chat.completion.chunk",
+            "choices": [
+                {
+                    "index": 0,
+                    "delta": {},
+                    "finish_reason": "stop",
+                }
+            ],
+            "usage": {
+                "prompt_tokens": 10,
+                "completion_tokens": 5,
+                "total_tokens": 15,
+            },
+        },
+    ]
+    lines: list[bytes] = [
+        f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks
+    ]
+    lines.append(b"data: [DONE]\n\n")
+    return lines
+
+
+@pytest.fixture
+def mock_tool_call_response() -> dict:
+    """A dict with tool_calls in the assistant message, matching the OpenAI format."""
+    return {
+        "id": "chatcmpl-test-456",
+        "object": "chat.completion",
+        "model": "dep89a2fde0e09",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "kma_weather_forecast",
+                                "arguments": '{"city": "서울"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 15,
+            "completion_tokens": 20,
+            "total_tokens": 35,
+        },
+    }
+
+
+@pytest.fixture
+def llm_config(monkeypatch: pytest.MonkeyPatch) -> LLMClientConfig:
+    """An LLMClientConfig instance backed by test environment variables."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-12345")
+    return LLMClientConfig()

--- a/tests/llm/conftest.py
+++ b/tests/llm/conftest.py
@@ -86,9 +86,7 @@ def mock_sse_lines() -> list[bytes]:
             },
         },
     ]
-    lines: list[bytes] = [
-        f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks
-    ]
+    lines: list[bytes] = [f"data: {json.dumps(chunk)}\n\n".encode() for chunk in chunks]
     lines.append(b"data: [DONE]\n\n")
     return lines
 

--- a/tests/llm/test_client.py
+++ b/tests/llm/test_client.py
@@ -173,9 +173,7 @@ async def test_complete_connection_error(
     sample_messages: list[ChatMessage],
 ) -> None:
     """complete() raises LLMConnectionError when the transport raises ConnectError."""
-    respx.post(CHAT_COMPLETIONS_URL).mock(
-        side_effect=httpx.ConnectError("Connection refused")
-    )
+    respx.post(CHAT_COMPLETIONS_URL).mock(side_effect=httpx.ConnectError("Connection refused"))
 
     config = LLMClientConfig()
     async with LLMClient(config) as client:

--- a/tests/llm/test_client.py
+++ b/tests/llm/test_client.py
@@ -1,0 +1,392 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for LLMClient.complete() using respx for httpx mocking."""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+import respx
+
+from kosmos.llm.client import LLMClient
+from kosmos.llm.config import LLMClientConfig
+from kosmos.llm.errors import (
+    AuthenticationError,
+    BudgetExceededError,
+    ConfigurationError,
+    LLMConnectionError,
+    LLMResponseError,
+)
+from kosmos.llm.models import ChatMessage, FunctionSchema, ToolDefinition
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+CHAT_COMPLETIONS_URL = "https://api.friendli.ai/v1/chat/completions"
+
+
+@pytest.fixture
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all KOSMOS_* env vars then inject a safe test token."""
+    for key in list(os.environ):
+        if key.startswith("KOSMOS_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-12345")
+
+
+# ---------------------------------------------------------------------------
+# LLMClient initialization
+# ---------------------------------------------------------------------------
+
+
+async def test_client_init_with_config(
+    _clean_env: None,
+) -> None:
+    """Client accepts an explicit LLMClientConfig and initializes without error."""
+    config = LLMClientConfig()
+    client = LLMClient(config)
+    assert client._config is config
+    await client.close()
+
+
+async def test_client_init_from_env(
+    _clean_env: None,
+) -> None:
+    """Client reads configuration from environment variables when config=None."""
+    client = LLMClient(config=None)
+    assert client._config.token.get_secret_value() == "test-token-12345"
+    await client.close()
+
+
+async def test_client_init_missing_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Client raises ConfigurationError when KOSMOS_FRIENDLI_TOKEN is absent."""
+    for key in list(os.environ):
+        if key.startswith("KOSMOS_"):
+            monkeypatch.delenv(key, raising=False)
+
+    with pytest.raises(ConfigurationError):
+        LLMClient(config=None)
+
+
+async def test_client_context_manager(_clean_env: None) -> None:
+    """Client works correctly as an async context manager."""
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        assert client._config is config
+    # After __aexit__ the underlying httpx client should be closed (no assertion
+    # needed for the internal transport state; reaching here without error is
+    # sufficient).
+
+
+# ---------------------------------------------------------------------------
+# LLMClient.complete() — success path
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_complete_success(
+    _clean_env: None,
+    sample_messages: list[ChatMessage],
+    mock_completion_response: dict,
+) -> None:
+    """complete() parses a successful 200 response into ChatCompletionResponse."""
+    respx.post(CHAT_COMPLETIONS_URL).mock(
+        return_value=httpx.Response(200, json=mock_completion_response)
+    )
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        response = await client.complete(sample_messages)
+
+    assert response.id == "chatcmpl-test-123"
+    assert response.content == "Test response"
+    assert response.model == "dep89a2fde0e09"
+    assert response.finish_reason == "stop"
+
+
+@respx.mock
+async def test_complete_token_usage(
+    _clean_env: None,
+    sample_messages: list[ChatMessage],
+    mock_completion_response: dict,
+) -> None:
+    """complete() correctly extracts prompt_tokens / completion_tokens from usage."""
+    respx.post(CHAT_COMPLETIONS_URL).mock(
+        return_value=httpx.Response(200, json=mock_completion_response)
+    )
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        response = await client.complete(sample_messages)
+
+    assert response.usage.input_tokens == 10
+    assert response.usage.output_tokens == 5
+    assert response.usage.total_tokens == 15
+
+
+# ---------------------------------------------------------------------------
+# LLMClient.complete() — error paths
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_complete_auth_error(
+    _clean_env: None,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """complete() raises AuthenticationError on a 401 response."""
+    respx.post(CHAT_COMPLETIONS_URL).mock(
+        return_value=httpx.Response(401, json={"error": "Unauthorized"})
+    )
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        with pytest.raises(AuthenticationError) as exc_info:
+            await client.complete(sample_messages)
+
+    assert exc_info.value.status_code == 401
+
+
+@respx.mock
+async def test_complete_bad_request(
+    _clean_env: None,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """complete() raises LLMResponseError on a 400 response."""
+    respx.post(CHAT_COMPLETIONS_URL).mock(
+        return_value=httpx.Response(400, json={"error": "Bad Request"})
+    )
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        with pytest.raises(LLMResponseError) as exc_info:
+            await client.complete(sample_messages)
+
+    assert exc_info.value.status_code == 400
+
+
+@respx.mock
+async def test_complete_connection_error(
+    _clean_env: None,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """complete() raises LLMConnectionError when the transport raises ConnectError."""
+    respx.post(CHAT_COMPLETIONS_URL).mock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        with pytest.raises(LLMConnectionError):
+            await client.complete(sample_messages)
+
+
+# ---------------------------------------------------------------------------
+# LLMClient.complete() — tool-use flow
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_complete_with_tools(
+    _clean_env: None,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """complete() includes tools in the request payload and parses tool_calls in the response."""
+    tool_response = {
+        "id": "chatcmpl-tool-test",
+        "object": "chat.completion",
+        "model": "dep89a2fde0e09",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_abc123",
+                            "type": "function",
+                            "function": {
+                                "name": "get_weather",
+                                "arguments": '{"city": "Seoul"}',
+                            },
+                        }
+                    ],
+                },
+                "finish_reason": "tool_calls",
+            }
+        ],
+        "usage": {"prompt_tokens": 20, "completion_tokens": 10},
+    }
+
+    captured_request: list[httpx.Request] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_request.append(request)
+        return httpx.Response(200, json=tool_response)
+
+    respx.post(CHAT_COMPLETIONS_URL).mock(side_effect=_capture)
+
+    func_schema = FunctionSchema(
+        name="get_weather",
+        description="Get weather",
+        parameters={"type": "object", "properties": {"city": {"type": "string"}}},
+    )
+    tool_def = ToolDefinition(type="function", function=func_schema)
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        response = await client.complete(sample_messages, tools=[tool_def])
+
+    # Verify tools were sent in the request payload
+    import json as _json
+
+    assert len(captured_request) == 1
+    payload = _json.loads(captured_request[0].content)
+    assert "tools" in payload
+    assert len(payload["tools"]) == 1
+    assert payload["tools"][0]["function"]["name"] == "get_weather"
+
+    # Verify response.tool_calls is populated correctly
+    assert len(response.tool_calls) == 1
+    tc = response.tool_calls[0]
+    assert tc.id == "call_abc123"
+    assert tc.function.name == "get_weather"
+    assert tc.function.arguments == '{"city": "Seoul"}'
+    assert response.finish_reason == "tool_calls"
+
+
+@respx.mock
+async def test_complete_tool_result_continuation(
+    _clean_env: None,
+) -> None:
+    """complete() accepts a tool-result turn (role='tool') and serializes it correctly."""
+    continuation_response = {
+        "id": "chatcmpl-continuation-test",
+        "object": "chat.completion",
+        "model": "dep89a2fde0e09",
+        "choices": [
+            {
+                "index": 0,
+                "message": {
+                    "role": "assistant",
+                    "content": "The weather in Seoul is sunny, 22°C.",
+                },
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 30, "completion_tokens": 15},
+    }
+
+    captured_request: list[httpx.Request] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_request.append(request)
+        return httpx.Response(200, json=continuation_response)
+
+    respx.post(CHAT_COMPLETIONS_URL).mock(side_effect=_capture)
+
+    # Build a message sequence that includes a tool-result turn
+    messages = [
+        ChatMessage(role="user", content="What is the weather in Seoul?"),
+        ChatMessage(
+            role="assistant",
+            content=None,
+            tool_calls=[
+                {
+                    "id": "call_xyz789",
+                    "type": "function",
+                    "function": {"name": "get_weather", "arguments": '{"city": "Seoul"}'},
+                }
+            ],
+        ),
+        ChatMessage(
+            role="tool",
+            content="sunny, 22°C",
+            tool_call_id="call_xyz789",
+        ),
+    ]
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        response = await client.complete(messages)
+
+    # Verify the request was made and the tool message was serialized
+    import json as _json
+
+    assert len(captured_request) == 1
+    payload = _json.loads(captured_request[0].content)
+    assert len(payload["messages"]) == 3
+
+    tool_msg = payload["messages"][2]
+    assert tool_msg["role"] == "tool"
+    assert tool_msg["tool_call_id"] == "call_xyz789"
+    assert tool_msg["content"] == "sunny, 22°C"
+
+    # Verify the continuation response was parsed correctly
+    assert response.content == "The weather in Seoul is sunny, 22°C."
+    assert response.finish_reason == "stop"
+
+
+@respx.mock
+async def test_complete_budget_exhaustion(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """complete() raises BudgetExceededError once the session token budget is exceeded."""
+    # Set all KOSMOS_ vars then configure a very tight budget (30 tokens)
+    for key in list(os.environ):
+        if key.startswith("KOSMOS_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-12345")
+    monkeypatch.setenv("KOSMOS_LLM_SESSION_BUDGET", "30")
+
+    # First response uses 20 tokens (within budget)
+    first_response = {
+        "id": "chatcmpl-budget-1",
+        "object": "chat.completion",
+        "model": "dep89a2fde0e09",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "First response."},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 15, "completion_tokens": 5},
+    }
+
+    # Second response uses 20 more tokens — pushes total to 40, exceeding budget of 30
+    second_response = {
+        "id": "chatcmpl-budget-2",
+        "object": "chat.completion",
+        "model": "dep89a2fde0e09",
+        "choices": [
+            {
+                "index": 0,
+                "message": {"role": "assistant", "content": "Second response."},
+                "finish_reason": "stop",
+            }
+        ],
+        "usage": {"prompt_tokens": 15, "completion_tokens": 5},
+    }
+
+    respx.post(CHAT_COMPLETIONS_URL).mock(
+        side_effect=[
+            httpx.Response(200, json=first_response),
+            httpx.Response(200, json=second_response),
+        ]
+    )
+
+    messages = [ChatMessage(role="user", content="Hello")]
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        # First call succeeds (20 tokens used, budget=30, still within limit)
+        result = await client.complete(messages)
+        assert result.content == "First response."
+
+        # Second call causes total=40 which exceeds budget=30 and raises at debit
+        with pytest.raises(BudgetExceededError):
+            await client.complete(messages)

--- a/tests/llm/test_config.py
+++ b/tests/llm/test_config.py
@@ -51,7 +51,7 @@ def test_default_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
     """base_url defaults to the FriendliAI v1 endpoint."""
     monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
     config = LLMClientConfig()
-    assert config.base_url == "https://api.friendli.ai/v1"
+    assert str(config.base_url) == "https://api.friendli.ai/v1"
 
 
 def test_default_model(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -92,7 +92,7 @@ def test_override_base_url_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
     monkeypatch.setenv("KOSMOS_FRIENDLI_BASE_URL", "https://custom.example.com/v2")
     config = LLMClientConfig()
-    assert config.base_url == "https://custom.example.com/v2"
+    assert str(config.base_url) == "https://custom.example.com/v2"
 
 
 def test_override_model_via_env(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/llm/test_config.py
+++ b/tests/llm/test_config.py
@@ -1,0 +1,131 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for LLMClientConfig loading from environment variables."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from pydantic import ValidationError
+
+from kosmos.llm.config import LLMClientConfig
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove all KOSMOS_* env vars to ensure a clean state for every test."""
+    for key in list(os.environ):
+        if key.startswith("KOSMOS_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Required field — missing token
+# ---------------------------------------------------------------------------
+
+
+def test_missing_token_raises_error() -> None:
+    """No KOSMOS_FRIENDLI_TOKEN in environment raises ValidationError."""
+    with pytest.raises(ValidationError):
+        LLMClientConfig()
+
+
+# ---------------------------------------------------------------------------
+# Token loading
+# ---------------------------------------------------------------------------
+
+
+def test_token_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """KOSMOS_FRIENDLI_TOKEN is surfaced as the secret value."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    config = LLMClientConfig()
+    assert config.token.get_secret_value() == "test-token-123"
+
+
+# ---------------------------------------------------------------------------
+# Default values
+# ---------------------------------------------------------------------------
+
+
+def test_default_base_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    """base_url defaults to the FriendliAI v1 endpoint."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    config = LLMClientConfig()
+    assert config.base_url == "https://api.friendli.ai/v1"
+
+
+def test_default_model(monkeypatch: pytest.MonkeyPatch) -> None:
+    """model defaults to the canonical K-EXAONE deployment identifier."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    config = LLMClientConfig()
+    assert config.model == "dep89a2fde0e09"
+
+
+def test_default_session_budget(monkeypatch: pytest.MonkeyPatch) -> None:
+    """session_budget defaults to 100 000 tokens."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    config = LLMClientConfig()
+    assert config.session_budget == 100000
+
+
+def test_default_timeout(monkeypatch: pytest.MonkeyPatch) -> None:
+    """timeout defaults to 60.0 seconds."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    config = LLMClientConfig()
+    assert config.timeout == 60.0
+
+
+def test_default_max_retries(monkeypatch: pytest.MonkeyPatch) -> None:
+    """max_retries defaults to 3."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    config = LLMClientConfig()
+    assert config.max_retries == 3
+
+
+# ---------------------------------------------------------------------------
+# Environment variable overrides
+# ---------------------------------------------------------------------------
+
+
+def test_override_base_url_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """KOSMOS_FRIENDLI_BASE_URL overrides the default base_url."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    monkeypatch.setenv("KOSMOS_FRIENDLI_BASE_URL", "https://custom.example.com/v2")
+    config = LLMClientConfig()
+    assert config.base_url == "https://custom.example.com/v2"
+
+
+def test_override_model_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """KOSMOS_FRIENDLI_MODEL overrides the default model identifier."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    monkeypatch.setenv("KOSMOS_FRIENDLI_MODEL", "dep-custom-model-abc")
+    config = LLMClientConfig()
+    assert config.model == "dep-custom-model-abc"
+
+
+def test_override_session_budget_via_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """KOSMOS_LLM_SESSION_BUDGET overrides the default session_budget."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    monkeypatch.setenv("KOSMOS_LLM_SESSION_BUDGET", "50000")
+    config = LLMClientConfig()
+    assert config.session_budget == 50000
+
+
+# ---------------------------------------------------------------------------
+# Validation errors — invalid field values
+# ---------------------------------------------------------------------------
+
+
+def test_invalid_session_budget_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    """session_budget of 0 is rejected with ValidationError."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    monkeypatch.setenv("KOSMOS_LLM_SESSION_BUDGET", "0")
+    with pytest.raises(ValidationError):
+        LLMClientConfig()
+
+
+def test_invalid_timeout_negative(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A negative timeout is rejected with ValidationError."""
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-123")
+    with pytest.raises(ValidationError):
+        LLMClientConfig(timeout=-1)

--- a/tests/llm/test_models.py
+++ b/tests/llm/test_models.py
@@ -17,6 +17,7 @@ from kosmos.llm.models import (
 # Helpers
 # ---------------------------------------------------------------------------
 
+
 def _make_tool_call(id: str = "call_abc") -> ToolCall:  # noqa: A002
     return ToolCall(id=id, function=FunctionCall(name="my_tool", arguments="{}"))
 

--- a/tests/llm/test_models.py
+++ b/tests/llm/test_models.py
@@ -1,0 +1,168 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for Pydantic model validation in kosmos.llm.models."""
+
+import pytest
+from pydantic import ValidationError
+
+from kosmos.llm.models import (
+    ChatCompletionResponse,
+    ChatMessage,
+    FunctionCall,
+    StreamEvent,
+    TokenUsage,
+    ToolCall,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tool_call(id: str = "call_abc") -> ToolCall:  # noqa: A002
+    return ToolCall(id=id, function=FunctionCall(name="my_tool", arguments="{}"))
+
+
+# ---------------------------------------------------------------------------
+# ChatMessage — validation failures
+# ---------------------------------------------------------------------------
+
+
+def test_system_message_requires_content() -> None:
+    """system role without content must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ChatMessage(role="system")
+
+
+def test_user_message_requires_content() -> None:
+    """user role without content must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ChatMessage(role="user")
+
+
+def test_tool_message_requires_tool_call_id() -> None:
+    """tool role without tool_call_id must raise ValidationError."""
+    with pytest.raises(ValidationError):
+        ChatMessage(role="tool", content="result")
+
+
+# ---------------------------------------------------------------------------
+# ChatMessage — valid construction
+# ---------------------------------------------------------------------------
+
+
+def test_assistant_message_allows_no_content() -> None:
+    """assistant role with content=None is valid (tool_calls path)."""
+    msg = ChatMessage(role="assistant", content=None)
+    assert msg.content is None
+
+
+def test_valid_system_message() -> None:
+    """system role with content constructs without error."""
+    msg = ChatMessage(role="system", content="You are a helpful assistant.")
+    assert msg.role == "system"
+    assert msg.content == "You are a helpful assistant."
+
+
+def test_valid_user_message() -> None:
+    """user role with content constructs without error."""
+    msg = ChatMessage(role="user", content="Hello!")
+    assert msg.role == "user"
+    assert msg.content == "Hello!"
+
+
+def test_valid_tool_message() -> None:
+    """tool role with tool_call_id and content constructs without error."""
+    msg = ChatMessage(role="tool", tool_call_id="call_xyz", content="42")
+    assert msg.tool_call_id == "call_xyz"
+    assert msg.content == "42"
+
+
+def test_valid_assistant_with_tool_calls() -> None:
+    """assistant with a non-empty tool_calls list constructs without error."""
+    tc = _make_tool_call()
+    msg = ChatMessage(role="assistant", tool_calls=[tc])
+    assert len(msg.tool_calls) == 1  # type: ignore[arg-type]
+    assert msg.tool_calls[0].id == "call_abc"  # type: ignore[index]
+
+
+# ---------------------------------------------------------------------------
+# TokenUsage
+# ---------------------------------------------------------------------------
+
+
+def test_total_tokens_computed() -> None:
+    """total_tokens equals input_tokens + output_tokens."""
+    usage = TokenUsage(input_tokens=10, output_tokens=25)
+    assert usage.total_tokens == 35
+
+
+def test_default_values() -> None:
+    """All TokenUsage fields default to 0."""
+    usage = TokenUsage()
+    assert usage.input_tokens == 0
+    assert usage.output_tokens == 0
+    assert usage.cache_read_tokens == 0
+    assert usage.cache_write_tokens == 0
+    assert usage.total_tokens == 0
+
+
+# ---------------------------------------------------------------------------
+# StreamEvent
+# ---------------------------------------------------------------------------
+
+
+def test_content_delta_event() -> None:
+    """StreamEvent of type content_delta carries the content field."""
+    event = StreamEvent(type="content_delta", content="Hello")
+    assert event.type == "content_delta"
+    assert event.content == "Hello"
+
+
+def test_usage_event() -> None:
+    """StreamEvent of type usage carries a TokenUsage payload."""
+    usage = TokenUsage(input_tokens=5, output_tokens=8)
+    event = StreamEvent(type="usage", usage=usage)
+    assert event.type == "usage"
+    assert event.usage is not None
+    assert event.usage.total_tokens == 13
+
+
+def test_done_event() -> None:
+    """StreamEvent of type done constructs with no extra fields set."""
+    event = StreamEvent(type="done")
+    assert event.type == "done"
+    assert event.content is None
+    assert event.usage is None
+
+
+# ---------------------------------------------------------------------------
+# ChatCompletionResponse
+# ---------------------------------------------------------------------------
+
+
+def test_valid_response() -> None:
+    """ChatCompletionResponse with all fields populated constructs correctly."""
+    usage = TokenUsage(input_tokens=10, output_tokens=20)
+    response = ChatCompletionResponse(
+        id="resp_001",
+        content="The answer is 42.",
+        usage=usage,
+        model="exaone-3.5",
+        finish_reason="stop",
+    )
+    assert response.id == "resp_001"
+    assert response.content == "The answer is 42."
+    assert response.usage.total_tokens == 30
+    assert response.model == "exaone-3.5"
+    assert response.finish_reason == "stop"
+
+
+def test_tool_calls_default_empty() -> None:
+    """tool_calls defaults to an empty list when not provided."""
+    usage = TokenUsage(input_tokens=1, output_tokens=1)
+    response = ChatCompletionResponse(
+        id="resp_002",
+        usage=usage,
+        model="exaone-3.5",
+        finish_reason="tool_calls",
+    )
+    assert response.tool_calls == []

--- a/tests/llm/test_retry.py
+++ b/tests/llm/test_retry.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for retry_with_backoff and RetryPolicy in kosmos.llm.retry."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from kosmos.llm.errors import AuthenticationError, LLMConnectionError, LLMResponseError
+from kosmos.llm.retry import RetryPolicy, retry_with_backoff
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+fast_policy = RetryPolicy(
+    max_retries=3,
+    base_delay=0.001,  # 1ms — fast for tests
+    multiplier=1.0,
+    max_delay=0.01,
+)
+
+
+def make_http_error(status_code: int) -> httpx.HTTPStatusError:
+    """Build an httpx.HTTPStatusError with the given status code."""
+    response = httpx.Response(
+        status_code, request=httpx.Request("POST", "https://test.com")
+    )
+    return httpx.HTTPStatusError(
+        f"HTTP {status_code}",
+        request=response.request,
+        response=response,
+    )
+
+
+class MockCallable:
+    """Async callable that fails a fixed number of times before succeeding."""
+
+    def __init__(
+        self,
+        fail_times: int,
+        error: Exception,
+        result: str = "success",
+    ) -> None:
+        self.call_count = 0
+        self.fail_times = fail_times
+        self.error = error
+        self.result = result
+
+    async def __call__(self) -> str:
+        self.call_count += 1
+        if self.call_count <= self.fail_times:
+            raise self.error
+        return self.result
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_success_no_retry() -> None:
+    """Function succeeds on first try — no retry should occur."""
+    mock = MockCallable(fail_times=0, error=make_http_error(200))
+    result = await retry_with_backoff(mock, fast_policy)
+    assert result == "success"
+    assert mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_429_retries_then_succeeds() -> None:
+    """Function fails with 429 twice, then succeeds on the third attempt."""
+    mock = MockCallable(fail_times=2, error=make_http_error(429))
+    result = await retry_with_backoff(mock, fast_policy)
+    assert result == "success"
+    assert mock.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_503_retries_then_succeeds() -> None:
+    """Function fails with 503 once, then succeeds on the second attempt."""
+    mock = MockCallable(fail_times=1, error=make_http_error(503))
+    result = await retry_with_backoff(mock, fast_policy)
+    assert result == "success"
+    assert mock.call_count == 2
+
+
+@pytest.mark.asyncio
+async def test_401_immediate_failure() -> None:
+    """Function fails with 401 — AuthenticationError raised immediately, no retry."""
+    mock = MockCallable(fail_times=99, error=make_http_error(401))
+    with pytest.raises(AuthenticationError) as exc_info:
+        await retry_with_backoff(mock, fast_policy)
+    assert exc_info.value.status_code == 401
+    assert mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_403_immediate_failure() -> None:
+    """Function fails with 403 — AuthenticationError raised immediately, no retry."""
+    mock = MockCallable(fail_times=99, error=make_http_error(403))
+    with pytest.raises(AuthenticationError) as exc_info:
+        await retry_with_backoff(mock, fast_policy)
+    assert exc_info.value.status_code == 403
+    assert mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_400_immediate_failure() -> None:
+    """Function fails with 400 — LLMResponseError raised immediately, no retry."""
+    mock = MockCallable(fail_times=99, error=make_http_error(400))
+    with pytest.raises(LLMResponseError) as exc_info:
+        await retry_with_backoff(mock, fast_policy)
+    assert exc_info.value.status_code == 400
+    assert mock.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retry_exhaustion() -> None:
+    """Function always fails with 429 — LLMConnectionError after max_retries exhausted."""
+    mock = MockCallable(fail_times=99, error=make_http_error(429))
+    with pytest.raises(LLMConnectionError):
+        await retry_with_backoff(mock, fast_policy)
+    # 1 initial attempt + 3 retries = 4 total calls
+    assert mock.call_count == fast_policy.max_retries + 1
+
+
+@pytest.mark.asyncio
+async def test_connection_error_retries() -> None:
+    """Function raises httpx.ConnectError, retries, then succeeds."""
+    connect_error = httpx.ConnectError(
+        "Connection refused",
+        request=httpx.Request("POST", "https://test.com"),
+    )
+    mock = MockCallable(fail_times=2, error=connect_error)
+    result = await retry_with_backoff(mock, fast_policy)
+    assert result == "success"
+    assert mock.call_count == 3

--- a/tests/llm/test_retry.py
+++ b/tests/llm/test_retry.py
@@ -23,9 +23,7 @@ fast_policy = RetryPolicy(
 
 def make_http_error(status_code: int) -> httpx.HTTPStatusError:
     """Build an httpx.HTTPStatusError with the given status code."""
-    response = httpx.Response(
-        status_code, request=httpx.Request("POST", "https://test.com")
-    )
+    response = httpx.Response(status_code, request=httpx.Request("POST", "https://test.com"))
     return httpx.HTTPStatusError(
         f"HTTP {status_code}",
         request=response.request,

--- a/tests/llm/test_streaming.py
+++ b/tests/llm/test_streaming.py
@@ -193,9 +193,7 @@ async def test_stream_auth_error(
     sample_messages: list[ChatMessage],
 ) -> None:
     """A 401 response raises AuthenticationError before any events are yielded."""
-    respx.post(_COMPLETIONS_URL).mock(
-        return_value=httpx.Response(401, text="Unauthorized")
-    )
+    respx.post(_COMPLETIONS_URL).mock(return_value=httpx.Response(401, text="Unauthorized"))
 
     with pytest.raises(AuthenticationError) as exc_info:
         async for _ in llm_client.stream(sample_messages):
@@ -210,9 +208,7 @@ async def test_stream_connection_error(
     sample_messages: list[ChatMessage],
 ) -> None:
     """A transport-level connection failure raises StreamInterruptedError."""
-    respx.post(_COMPLETIONS_URL).mock(
-        side_effect=httpx.ConnectError("Connection refused")
-    )
+    respx.post(_COMPLETIONS_URL).mock(side_effect=httpx.ConnectError("Connection refused"))
 
     with pytest.raises(StreamInterruptedError):
         async for _ in llm_client.stream(sample_messages):

--- a/tests/llm/test_streaming.py
+++ b/tests/llm/test_streaming.py
@@ -1,0 +1,219 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for LLMClient.stream() SSE parsing."""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+import pytest
+import respx
+
+from kosmos.llm.client import LLMClient
+from kosmos.llm.config import LLMClientConfig
+from kosmos.llm.errors import AuthenticationError, StreamInterruptedError
+from kosmos.llm.models import ChatMessage, StreamEvent
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_COMPLETIONS_URL = "https://api.friendli.ai/v1/chat/completions"
+
+
+def _build_sse_body(*chunks: dict, done: bool = True) -> bytes:
+    """Serialize a sequence of chunk dicts into an SSE byte body."""
+    lines: list[str] = [f"data: {json.dumps(c)}\n\n" for c in chunks]
+    if done:
+        lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode()
+
+
+def _make_sse_response(body: bytes, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=body,
+        headers={"content-type": "text/event-stream"},
+    )
+
+
+def _delta_chunk(content: str, finish_reason: str | None = None) -> dict:
+    return {
+        "id": "chatcmpl-test-123",
+        "object": "chat.completion.chunk",
+        "choices": [
+            {
+                "index": 0,
+                "delta": {"content": content},
+                "finish_reason": finish_reason,
+            }
+        ],
+    }
+
+
+def _stop_chunk(
+    prompt_tokens: int = 10,
+    completion_tokens: int = 5,
+    total_tokens: int = 15,
+) -> dict:
+    return {
+        "id": "chatcmpl-test-123",
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": total_tokens,
+        },
+    }
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip all KOSMOS_ env vars and inject a known test token."""
+    for key in list(os.environ):
+        if key.startswith("KOSMOS_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-12345")
+
+
+@pytest.fixture
+def llm_client() -> LLMClient:
+    """An LLMClient backed by the injected test token."""
+    config = LLMClientConfig()
+    return LLMClient(config=config)
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+async def test_stream_content_deltas(
+    llm_client: LLMClient,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """Content deltas are yielded as StreamEvent(type='content_delta')."""
+    body = _build_sse_body(
+        _delta_chunk("Hello"),
+        _delta_chunk(" world"),
+        _stop_chunk(),
+    )
+    respx.post(_COMPLETIONS_URL).mock(return_value=_make_sse_response(body))
+
+    events: list[StreamEvent] = []
+    async for event in llm_client.stream(sample_messages):
+        events.append(event)
+
+    content_events = [e for e in events if e.type == "content_delta"]
+    assert len(content_events) == 2
+    assert content_events[0].content == "Hello"
+    assert content_events[1].content == " world"
+
+
+@respx.mock
+async def test_stream_usage_event(
+    llm_client: LLMClient,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """The final usage chunk yields a StreamEvent(type='usage') with correct counts."""
+    body = _build_sse_body(
+        _delta_chunk("Hi"),
+        _stop_chunk(prompt_tokens=20, completion_tokens=8, total_tokens=28),
+    )
+    respx.post(_COMPLETIONS_URL).mock(return_value=_make_sse_response(body))
+
+    events: list[StreamEvent] = []
+    async for event in llm_client.stream(sample_messages):
+        events.append(event)
+
+    usage_events = [e for e in events if e.type == "usage"]
+    assert len(usage_events) == 1
+    usage = usage_events[0].usage
+    assert usage is not None
+    assert usage.input_tokens == 20
+    assert usage.output_tokens == 8
+    assert usage.total_tokens == 28
+
+
+@respx.mock
+async def test_stream_done_event(
+    llm_client: LLMClient,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """Stream ends with exactly one StreamEvent(type='done')."""
+    body = _build_sse_body(
+        _delta_chunk("Hello"),
+        _stop_chunk(),
+    )
+    respx.post(_COMPLETIONS_URL).mock(return_value=_make_sse_response(body))
+
+    events: list[StreamEvent] = []
+    async for event in llm_client.stream(sample_messages):
+        events.append(event)
+
+    done_events = [e for e in events if e.type == "done"]
+    assert len(done_events) == 1
+    assert events[-1].type == "done"
+
+
+@respx.mock
+async def test_stream_content_assembly(
+    llm_client: LLMClient,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """Concatenated content_delta payloads reconstruct the full response text."""
+    body = _build_sse_body(
+        _delta_chunk("Hello"),
+        _delta_chunk(","),
+        _delta_chunk(" world"),
+        _delta_chunk("!"),
+        _stop_chunk(),
+    )
+    respx.post(_COMPLETIONS_URL).mock(return_value=_make_sse_response(body))
+
+    assembled = ""
+    async for event in llm_client.stream(sample_messages):
+        if event.type == "content_delta" and event.content:
+            assembled += event.content
+
+    assert assembled == "Hello, world!"
+
+
+@respx.mock
+async def test_stream_auth_error(
+    llm_client: LLMClient,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """A 401 response raises AuthenticationError before any events are yielded."""
+    respx.post(_COMPLETIONS_URL).mock(
+        return_value=httpx.Response(401, text="Unauthorized")
+    )
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        async for _ in llm_client.stream(sample_messages):
+            pass  # pragma: no cover
+
+    assert exc_info.value.status_code == 401
+
+
+@respx.mock
+async def test_stream_connection_error(
+    llm_client: LLMClient,
+    sample_messages: list[ChatMessage],
+) -> None:
+    """A transport-level connection failure raises StreamInterruptedError."""
+    respx.post(_COMPLETIONS_URL).mock(
+        side_effect=httpx.ConnectError("Connection refused")
+    )
+
+    with pytest.raises(StreamInterruptedError):
+        async for _ in llm_client.stream(sample_messages):
+            pass  # pragma: no cover

--- a/tests/llm/test_usage.py
+++ b/tests/llm/test_usage.py
@@ -1,0 +1,98 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for UsageTracker in the KOSMOS LLM client module."""
+
+from __future__ import annotations
+
+import pytest
+
+from kosmos.llm.errors import BudgetExceededError
+from kosmos.llm.models import TokenUsage
+from kosmos.llm.usage import UsageTracker
+
+
+def _make_usage(input_tokens: int = 0, output_tokens: int = 0) -> TokenUsage:
+    return TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens)
+
+
+class TestInitialState:
+    def test_initial_state(self) -> None:
+        """New tracker has remaining == budget, is_exhausted == False, call_count == 0."""
+        tracker = UsageTracker(budget=1000)
+        assert tracker.remaining == 1000
+        assert tracker.is_exhausted is False
+        assert tracker.call_count == 0
+
+
+class TestCanAfford:
+    def test_can_afford_within_budget(self) -> None:
+        """can_afford returns True when the estimate fits within remaining budget."""
+        tracker = UsageTracker(budget=1000)
+        assert tracker.can_afford(100) is True
+
+    def test_can_afford_exceeds_budget(self) -> None:
+        """can_afford returns False when the estimate exceeds remaining budget."""
+        tracker = UsageTracker(budget=100)
+        assert tracker.can_afford(200) is False
+
+    def test_can_afford_exact_budget(self) -> None:
+        """can_afford returns True when the estimate equals remaining budget exactly."""
+        tracker = UsageTracker(budget=100)
+        assert tracker.can_afford(100) is True
+
+
+class TestDebit:
+    def test_debit_reduces_remaining(self) -> None:
+        """After a debit, remaining decreases by the total tokens in the usage object."""
+        tracker = UsageTracker(budget=1000)
+        tracker.debit(_make_usage(input_tokens=50, output_tokens=30))
+        assert tracker.remaining == 1000 - 80
+
+    def test_debit_increments_call_count(self) -> None:
+        """After 3 successive debits, call_count equals 3."""
+        tracker = UsageTracker(budget=10_000)
+        for _ in range(3):
+            tracker.debit(_make_usage(input_tokens=10, output_tokens=10))
+        assert tracker.call_count == 3
+
+    def test_exhaustion(self) -> None:
+        """Debiting exactly the budget amount leaves is_exhausted True."""
+        tracker = UsageTracker(budget=100)
+        # Debit exactly the full budget — should not raise
+        tracker.debit(_make_usage(input_tokens=60, output_tokens=40))
+        assert tracker.is_exhausted is True
+        assert tracker.remaining == 0
+
+    def test_remaining_never_negative(self) -> None:
+        """remaining returns 0 (not negative) even after an over-debit."""
+        tracker = UsageTracker(budget=100)
+        with pytest.raises(BudgetExceededError):
+            tracker.debit(_make_usage(input_tokens=80, output_tokens=80))
+        # State was updated before the exception; remaining is clamped to 0
+        assert tracker.remaining >= 0
+
+    def test_total_used(self) -> None:
+        """total_used equals the cumulative sum of all debited tokens."""
+        tracker = UsageTracker(budget=10_000)
+        tracker.debit(_make_usage(input_tokens=100, output_tokens=50))
+        tracker.debit(_make_usage(input_tokens=200, output_tokens=75))
+        assert tracker.total_used == 425
+
+
+class TestBudgetExceeded:
+    def test_debit_raises_on_exceed(self) -> None:
+        """debit raises BudgetExceededError when the new total surpasses the budget."""
+        tracker = UsageTracker(budget=100)
+        with pytest.raises(BudgetExceededError):
+            tracker.debit(_make_usage(input_tokens=60, output_tokens=60))
+
+
+class TestInvalidBudget:
+    def test_invalid_budget_zero(self) -> None:
+        """Constructing a tracker with budget=0 raises ValueError."""
+        with pytest.raises(ValueError):
+            UsageTracker(budget=0)
+
+    def test_invalid_budget_negative(self) -> None:
+        """Constructing a tracker with budget=-1 raises ValueError."""
+        with pytest.raises(ValueError):
+            UsageTracker(budget=-1)

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -106,7 +106,7 @@ def populated_registry(sample_tool_factory) -> ToolRegistry:
         provider="기상청",
         category=["날씨", "기상"],
         search_hint="날씨 예보 weather forecast 기상청",
-        core=True,
+        is_core=True,
     )
 
     # 2. Traffic accident statistics

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,0 +1,145 @@
+"""Shared pytest fixtures for the KOSMOS Tool System module.
+
+All tests use mock tools — no live API calls are made here.
+Imports from kosmos.tools resolve once Phase 3 implementation is complete.
+"""
+
+import pytest
+from pydantic import BaseModel
+
+from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Schema stubs used across tool tests
+# ---------------------------------------------------------------------------
+
+
+class MockInput(BaseModel):
+    """Minimal input schema for weather-style tool tests."""
+
+    city: str
+    date: str | None = None
+
+
+class MockOutput(BaseModel):
+    """Minimal output schema for weather-style tool tests."""
+
+    temperature: float
+    condition: str
+    humidity: int
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def sample_tool_factory():
+    """Return a factory that creates GovAPITool instances with sensible defaults.
+
+    Callers may override any field by passing keyword arguments.
+    Korean values (name_ko, provider, category, search_hint) are domain data
+    and are intentionally kept in Korean.
+    """
+
+    def _factory(
+        id: str = "kma_weather_forecast",  # noqa: A002
+        name_ko: str = "날씨예보",
+        provider: str = "기상청",
+        category: list[str] | None = None,
+        endpoint: str = "http://apis.data.go.kr/test",
+        auth_type: str = "api_key",
+        search_hint: str = "날씨 예보 weather forecast 기상청",
+        **overrides,
+    ) -> GovAPITool:
+        return GovAPITool(
+            id=id,
+            name_ko=name_ko,
+            provider=provider,
+            category=category or ["날씨", "기상"],
+            endpoint=endpoint,
+            auth_type=auth_type,
+            input_schema=MockInput,
+            output_schema=MockOutput,
+            search_hint=search_hint,
+            **overrides,
+        )
+
+    return _factory
+
+
+@pytest.fixture
+def sample_tool(sample_tool_factory) -> GovAPITool:
+    """A single pre-built GovAPITool instance using factory defaults."""
+    return sample_tool_factory()
+
+
+@pytest.fixture
+def mock_tool_adapter():
+    """A mock async adapter function that returns a fixed weather payload.
+
+    Returned dict mirrors MockOutput field names so callers can validate
+    output_schema parsing in integration tests.
+    """
+
+    async def _adapter(validated_input):
+        return {"temperature": 22.5, "condition": "맑음", "humidity": 45}
+
+    return _adapter
+
+
+@pytest.fixture
+def populated_registry(sample_tool_factory) -> ToolRegistry:
+    """A ToolRegistry pre-loaded with 4 diverse tools for search/filter tests.
+
+    Tools cover weather, traffic, health, and business domains so that
+    category-based and keyword-based search tests can exercise distinct results.
+    """
+    registry = ToolRegistry()
+
+    # 1. Weather forecast — core tool, marked as core=True
+    weather = sample_tool_factory(
+        id="kma_weather_forecast",
+        name_ko="날씨예보",
+        provider="기상청",
+        category=["날씨", "기상"],
+        search_hint="날씨 예보 weather forecast 기상청",
+        core=True,
+    )
+
+    # 2. Traffic accident statistics
+    traffic = sample_tool_factory(
+        id="koroad_accident_stats",
+        name_ko="교통사고통계",
+        provider="도로교통공단",
+        category=["교통", "사고"],
+        endpoint="http://apis.data.go.kr/koroad/accident",
+        search_hint="교통사고 통계 traffic accident road safety",
+    )
+
+    # 3. Hospital information lookup
+    hospital = sample_tool_factory(
+        id="hira_hospital_info",
+        name_ko="병원정보조회",
+        provider="건강보험심사평가원",
+        category=["의료", "병원"],
+        endpoint="http://apis.data.go.kr/hira/hospital",
+        search_hint="병원 의원 의료기관 hospital clinic HIRA",
+    )
+
+    # 4. Business registration lookup
+    business = sample_tool_factory(
+        id="nts_business_registration",
+        name_ko="사업자등록정보조회",
+        provider="국세청",
+        category=["사업자", "세금"],
+        endpoint="http://apis.data.go.kr/nts/business",
+        search_hint="사업자등록 법인 business registration NTS tax",
+    )
+
+    for tool in (weather, traffic, hospital, business):
+        registry.register(tool)
+
+    return registry

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -1,7 +1,6 @@
 """Shared pytest fixtures for the KOSMOS Tool System module.
 
 All tests use mock tools — no live API calls are made here.
-Imports from kosmos.tools resolve once Phase 3 implementation is complete.
 """
 
 import pytest

--- a/tests/tools/test_executor.py
+++ b/tests/tools/test_executor.py
@@ -1,0 +1,157 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for kosmos.tools.executor.ToolExecutor."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_executor(  # noqa: E501
+    sample_tool_factory,
+    mock_tool_adapter,
+    *,
+    tool_id: str = "kma_weather_forecast",
+):
+    """Build a ToolExecutor pre-loaded with one tool and its adapter."""
+    registry = ToolRegistry()
+    tool = sample_tool_factory(id=tool_id)
+    registry.register(tool)
+    executor = ToolExecutor(registry)
+    executor.register_adapter(tool_id, mock_tool_adapter)
+    return executor
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dispatch_success(sample_tool_factory, mock_tool_adapter):
+    """Valid arguments produce a ToolResult with success=True and correct data."""
+    executor = _make_executor(sample_tool_factory, mock_tool_adapter)
+    args = json.dumps({"city": "Seoul"})
+
+    result = await executor.dispatch("kma_weather_forecast", args)
+
+    assert result.success is True
+    assert result.tool_id == "kma_weather_forecast"
+    assert result.error is None
+    assert result.error_type is None
+    assert result.data is not None
+    assert result.data["temperature"] == 22.5
+    assert result.data["humidity"] == 45
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_tool(sample_tool_factory, mock_tool_adapter):
+    """Dispatching a tool_id not in the registry returns error_type='not_found'."""
+    executor = _make_executor(sample_tool_factory, mock_tool_adapter)
+    args = json.dumps({"city": "Busan"})
+
+    result = await executor.dispatch("nonexistent_tool", args)
+
+    assert result.success is False
+    assert result.tool_id == "nonexistent_tool"
+    assert result.error_type == "not_found"
+    assert result.error is not None
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_invalid_input_bad_json(sample_tool_factory, mock_tool_adapter):
+    """Malformed JSON returns error_type='validation'."""
+    executor = _make_executor(sample_tool_factory, mock_tool_adapter)
+
+    result = await executor.dispatch("kma_weather_forecast", "{not valid json}")
+
+    assert result.success is False
+    assert result.error_type == "validation"
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_invalid_input_schema_violation(sample_tool_factory, mock_tool_adapter):
+    """Valid JSON that fails schema validation returns error_type='validation'."""
+    executor = _make_executor(sample_tool_factory, mock_tool_adapter)
+    # Pydantic v2 coerces int->str, so test with a missing required field instead
+    args_missing = json.dumps({"date": "2026-04-12"})
+    result = await executor.dispatch("kma_weather_forecast", args_missing)
+
+    assert result.success is False
+    assert result.error_type == "validation"
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_rate_limit_exceeded(sample_tool_factory, mock_tool_adapter):
+    """After exhausting the rate limit, dispatch returns error_type='rate_limit'."""
+    registry = ToolRegistry()
+    # Set rate_limit_per_minute=1 so one call exhausts it
+    tool = sample_tool_factory(id="kma_weather_forecast", rate_limit_per_minute=1)
+    registry.register(tool)
+    executor = ToolExecutor(registry)
+    executor.register_adapter("kma_weather_forecast", mock_tool_adapter)
+
+    args = json.dumps({"city": "Seoul"})
+
+    # First call should succeed (consumes the only slot)
+    first = await executor.dispatch("kma_weather_forecast", args)
+    assert first.success is True
+
+    # Second call should be rate-limited
+    second = await executor.dispatch("kma_weather_forecast", args)
+    assert second.success is False
+    assert second.error_type == "rate_limit"
+    assert second.data is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_adapter_exception(sample_tool_factory):
+    """An adapter that raises RuntimeError returns error_type='execution'."""
+    registry = ToolRegistry()
+    tool = sample_tool_factory(id="kma_weather_forecast")
+    registry.register(tool)
+    executor = ToolExecutor(registry)
+
+    async def _failing_adapter(validated_input):
+        raise RuntimeError("upstream service unavailable")
+
+    executor.register_adapter("kma_weather_forecast", _failing_adapter)
+
+    result = await executor.dispatch("kma_weather_forecast", json.dumps({"city": "Incheon"}))
+
+    assert result.success is False
+    assert result.error_type == "execution"
+    assert "upstream service unavailable" in (result.error or "")
+    assert result.data is None
+
+
+@pytest.mark.asyncio
+async def test_dispatch_output_schema_mismatch(sample_tool_factory):
+    """An adapter returning wrong shape returns error_type='schema_mismatch'."""
+    registry = ToolRegistry()
+    tool = sample_tool_factory(id="kma_weather_forecast")
+    registry.register(tool)
+    executor = ToolExecutor(registry)
+
+    async def _wrong_shape_adapter(validated_input):
+        # Missing required fields: temperature, condition, humidity
+        return {"unexpected_field": "oops"}
+
+    executor.register_adapter("kma_weather_forecast", _wrong_shape_adapter)
+
+    result = await executor.dispatch("kma_weather_forecast", json.dumps({"city": "Daegu"}))
+
+    assert result.success is False
+    assert result.error_type == "schema_mismatch"
+    assert result.data is None

--- a/tests/tools/test_models.py
+++ b/tests/tools/test_models.py
@@ -1,0 +1,259 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for GovAPITool and ToolResult validation in kosmos.tools.models."""
+
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from kosmos.tools.models import GovAPITool, ToolResult
+
+# ---------------------------------------------------------------------------
+# Helper: minimal valid GovAPITool kwargs (without factory fixture)
+# ---------------------------------------------------------------------------
+
+
+class _MinimalInput(BaseModel):
+    q: str
+
+
+class _MinimalOutput(BaseModel):
+    result: str
+
+
+_MINIMAL_KWARGS = {
+    "id": "test_tool",
+    "name_ko": "테스트도구",
+    "provider": "테스트기관",
+    "category": ["test"],
+    "endpoint": "http://apis.data.go.kr/test",
+    "auth_type": "api_key",
+    "input_schema": _MinimalInput,
+    "output_schema": _MinimalOutput,
+    "search_hint": "test 테스트 sample",
+}
+
+
+def _make(**overrides) -> GovAPITool:
+    """Build a GovAPITool from _MINIMAL_KWARGS with optional field overrides."""
+    return GovAPITool(**{**_MINIMAL_KWARGS, **overrides})
+
+
+# ===========================================================================
+# GovAPITool — fail-closed defaults
+# ===========================================================================
+
+
+class TestFailClosedDefaults:
+    def test_fail_closed_defaults(self, sample_tool_factory):
+        """All boolean security fields must default to the restrictive value."""
+        tool = sample_tool_factory()
+
+        assert tool.requires_auth is True
+        assert tool.is_personal_data is True
+        assert tool.is_concurrency_safe is False
+        assert tool.cache_ttl_seconds == 0
+        assert tool.rate_limit_per_minute == 10
+        assert tool.is_core is False
+
+    def test_explicit_overrides(self, sample_tool_factory):
+        """Caller-supplied values must override every security default."""
+        tool = sample_tool_factory(
+            requires_auth=False,
+            is_personal_data=False,
+            is_concurrency_safe=True,
+            cache_ttl_seconds=300,
+            rate_limit_per_minute=60,
+            is_core=True,
+        )
+
+        assert tool.requires_auth is False
+        assert tool.is_personal_data is False
+        assert tool.is_concurrency_safe is True
+        assert tool.cache_ttl_seconds == 300
+        assert tool.rate_limit_per_minute == 60
+        assert tool.is_core is True
+
+
+# ===========================================================================
+# GovAPITool — id validation
+# ===========================================================================
+
+
+class TestIdValidation:
+    @pytest.mark.parametrize(
+        "valid_id",
+        [
+            "kma_weather",
+            "a",
+            "abc123",
+            "koroad_accident_search",
+        ],
+    )
+    def test_valid_id_patterns(self, valid_id):
+        """IDs that match ^[a-z][a-z0-9_]*$ must be accepted without error."""
+        tool = _make(id=valid_id)
+        assert tool.id == valid_id
+
+    def test_invalid_id_uppercase(self):
+        """IDs containing uppercase letters must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make(id="KMA_Weather")
+
+    def test_invalid_id_starts_with_number(self):
+        """IDs that start with a digit must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make(id="123abc")
+
+    def test_invalid_id_special_chars(self):
+        """IDs with hyphens or special chars must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make(id="kma-weather")
+
+    def test_invalid_id_empty(self):
+        """An empty string must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make(id="")
+
+
+# ===========================================================================
+# GovAPITool — category validation
+# ===========================================================================
+
+
+class TestCategoryValidation:
+    def test_empty_category_raises(self):
+        """An empty category list must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make(category=[])
+
+
+# ===========================================================================
+# GovAPITool — other field validations
+# ===========================================================================
+
+
+class TestOtherValidations:
+    def test_invalid_rate_limit_zero(self):
+        """rate_limit_per_minute=0 must raise ValidationError (must be > 0)."""
+        with pytest.raises(ValidationError):
+            _make(rate_limit_per_minute=0)
+
+    def test_invalid_cache_ttl_negative(self):
+        """cache_ttl_seconds=-1 must raise ValidationError (must be >= 0)."""
+        with pytest.raises(ValidationError):
+            _make(cache_ttl_seconds=-1)
+
+    def test_empty_search_hint_raises(self):
+        """An empty search_hint string must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make(search_hint="")
+
+    def test_whitespace_only_search_hint_raises(self):
+        """A whitespace-only search_hint must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            _make(search_hint="   ")
+
+
+# ===========================================================================
+# GovAPITool — to_openai_tool
+# ===========================================================================
+
+
+class TestToOpenAITool:
+    def test_to_openai_tool_format(self, sample_tool_factory):
+        """to_openai_tool() must return a well-formed OpenAI function definition."""
+        tool = sample_tool_factory()
+        result = tool.to_openai_tool()
+
+        assert result["type"] == "function"
+        func = result["function"]
+        assert func["name"] == tool.id
+        assert func["description"] == tool.name_ko
+        assert "properties" in func["parameters"]
+
+    def test_to_openai_tool_name_matches_id(self):
+        """to_openai_tool() 'name' must equal the tool's id field exactly."""
+        tool = _make(id="hira_hospital_info")
+        result = tool.to_openai_tool()
+
+        assert result["function"]["name"] == "hira_hospital_info"
+
+    def test_to_openai_tool_description_matches_name_ko(self):
+        """to_openai_tool() 'description' must equal name_ko verbatim."""
+        tool = _make(name_ko="병원정보조회")
+        result = tool.to_openai_tool()
+
+        assert result["function"]["description"] == "병원정보조회"
+
+    def test_to_openai_tool_parameters_is_json_schema(self):
+        """'parameters' must be the JSON Schema dict produced by input_schema."""
+        tool = _make()
+        result = tool.to_openai_tool()
+        parameters = result["function"]["parameters"]
+
+        # Must be a dict with at least the JSON Schema 'properties' key
+        assert isinstance(parameters, dict)
+        assert "properties" in parameters
+
+
+# ===========================================================================
+# ToolResult
+# ===========================================================================
+
+
+class TestToolResult:
+    def test_tool_result_success(self):
+        """A successful ToolResult must carry data and have no error fields set."""
+        result = ToolResult(
+            tool_id="kma_weather_forecast",
+            success=True,
+            data={"temperature": 22.5, "condition": "맑음", "humidity": 45},
+        )
+
+        assert result.tool_id == "kma_weather_forecast"
+        assert result.success is True
+        assert result.data == {"temperature": 22.5, "condition": "맑음", "humidity": 45}
+        assert result.error is None
+        assert result.error_type is None
+
+    def test_tool_result_failure(self):
+        """A failed ToolResult must carry error and error_type with no data."""
+        result = ToolResult(
+            tool_id="kma_weather_forecast",
+            success=False,
+            error="Upstream API returned 503",
+            error_type="execution",
+        )
+
+        assert result.tool_id == "kma_weather_forecast"
+        assert result.success is False
+        assert result.data is None
+        assert result.error == "Upstream API returned 503"
+        assert result.error_type == "execution"
+
+    def test_tool_result_all_error_types_accepted(self):
+        """All documented error_type literals must be accepted by ToolResult."""
+        valid_error_types = [
+            "validation",
+            "rate_limit",
+            "not_found",
+            "execution",
+            "schema_mismatch",
+        ]
+        for error_type in valid_error_types:
+            result = ToolResult(
+                tool_id="test_tool",
+                success=False,
+                error="some error",
+                error_type=error_type,
+            )
+            assert result.error_type == error_type
+
+    def test_tool_result_unknown_error_type_raises(self):
+        """An unrecognised error_type literal must raise ValidationError."""
+        with pytest.raises(ValidationError):
+            ToolResult(
+                tool_id="test_tool",
+                success=False,
+                error="some error",
+                error_type="unknown_type",
+            )

--- a/tests/tools/test_rate_limiter.py
+++ b/tests/tools/test_rate_limiter.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for the RateLimiter sliding-window implementation."""
+from __future__ import annotations
+
+import time
+
+from kosmos.tools.rate_limiter import RateLimiter
+
+
+def test_check_within_limit() -> None:
+    """A brand-new limiter with limit=5 should allow calls immediately."""
+    limiter = RateLimiter(limit=5)
+    assert limiter.check() is True
+
+
+def test_check_at_limit() -> None:
+    """After recording limit calls, check() must return False."""
+    limiter = RateLimiter(limit=5)
+    for _ in range(5):
+        limiter.record()
+    assert limiter.check() is False
+
+
+def test_remaining_count() -> None:
+    """After 3 calls with limit=5, remaining should be 2."""
+    limiter = RateLimiter(limit=5)
+    for _ in range(3):
+        limiter.record()
+    assert limiter.remaining == 2
+
+
+def test_remaining_at_limit() -> None:
+    """After recording exactly limit calls, remaining should be 0."""
+    limiter = RateLimiter(limit=5)
+    for _ in range(5):
+        limiter.record()
+    assert limiter.remaining == 0
+
+
+def test_record_and_check() -> None:
+    """check() should stay True until the limit is reached, then flip to False."""
+    limiter = RateLimiter(limit=3)
+    for _ in range(2):
+        assert limiter.check() is True
+        limiter.record()
+    assert limiter.check() is True
+    limiter.record()
+    assert limiter.check() is False
+
+
+def test_manual_reset() -> None:
+    """After filling the limit and calling reset(), check() returns True and remaining == limit."""
+    limiter = RateLimiter(limit=4)
+    for _ in range(4):
+        limiter.record()
+    assert limiter.check() is False
+    limiter.reset()
+    assert limiter.check() is True
+    assert limiter.remaining == 4
+
+
+def test_window_expiry() -> None:
+    """Calls recorded before the window expires should no longer count afterward."""
+    limiter = RateLimiter(limit=2, window_seconds=0.05)
+    limiter.record()
+    limiter.record()
+    assert not limiter.check()
+    time.sleep(0.1)  # Wait past the window
+    assert limiter.check()
+    assert limiter.remaining == 2  # All old calls expired
+
+
+def test_limit_property() -> None:
+    """The limit property must reflect the value passed to __init__."""
+    limiter = RateLimiter(limit=7)
+    assert limiter.limit == 7
+
+
+def test_window_seconds_property() -> None:
+    """The window_seconds property must reflect the value passed to __init__."""
+    limiter = RateLimiter(limit=1, window_seconds=30.0)
+    assert limiter.window_seconds == 30.0
+
+
+def test_independent_limiters() -> None:
+    """Two separate RateLimiter instances must not share state."""
+    limiter_a = RateLimiter(limit=3)
+    limiter_b = RateLimiter(limit=3)
+    for _ in range(3):
+        limiter_a.record()
+    assert limiter_a.check() is False
+    assert limiter_b.check() is True

--- a/tests/tools/test_rate_limiter.py
+++ b/tests/tools/test_rate_limiter.py
@@ -1,5 +1,6 @@
 # SPDX-License-Identifier: Apache-2.0
 """Unit tests for the RateLimiter sliding-window implementation."""
+
 from __future__ import annotations
 
 import time

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -192,7 +192,8 @@ def test_export_core_tools_openai_deterministic(sample_tool_factory):
     second = registry.export_core_tools_openai()
     assert first == second
     assert [item["function"]["name"] for item in first] == [  # type: ignore[index]
-        item["function"]["name"] for item in second  # type: ignore[index]
+        item["function"]["name"]
+        for item in second  # type: ignore[index]
     ]
 
 

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -1,0 +1,242 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for ToolRegistry registration and lookup."""
+
+from __future__ import annotations
+
+import pytest
+
+from kosmos.tools.errors import DuplicateToolError, ToolNotFoundError
+from kosmos.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def test_register_success(sample_tool_factory):
+    """Registering a tool should make it retrievable from the registry."""
+    registry = ToolRegistry()
+    tool = sample_tool_factory(id="tool_a")
+    registry.register(tool)
+    assert "tool_a" in registry
+
+
+def test_register_multiple_tools(sample_tool_factory):
+    """Registering three distinct tools should result in a registry of length 3."""
+    registry = ToolRegistry()
+    for tool_id in ("tool_x", "tool_y", "tool_z"):
+        registry.register(sample_tool_factory(id=tool_id))
+    assert len(registry) == 3
+
+
+def test_duplicate_registration_raises(sample_tool_factory):
+    """Registering the same tool id twice must raise DuplicateToolError."""
+    registry = ToolRegistry()
+    tool = sample_tool_factory(id="dup_tool")
+    registry.register(tool)
+    with pytest.raises(DuplicateToolError):
+        registry.register(sample_tool_factory(id="dup_tool"))
+
+
+def test_duplicate_error_contains_tool_id(sample_tool_factory):
+    """DuplicateToolError must carry the offending tool_id as an attribute."""
+    registry = ToolRegistry()
+    tool_id = "dup_id_check"
+    registry.register(sample_tool_factory(id=tool_id))
+    with pytest.raises(DuplicateToolError) as exc_info:
+        registry.register(sample_tool_factory(id=tool_id))
+    assert exc_info.value.tool_id == tool_id
+
+
+# ---------------------------------------------------------------------------
+# Lookup
+# ---------------------------------------------------------------------------
+
+
+def test_lookup_success(sample_tool_factory):
+    """Looking up a registered tool by id should return the exact same object."""
+    registry = ToolRegistry()
+    tool = sample_tool_factory(id="lookup_target")
+    registry.register(tool)
+    result = registry.lookup("lookup_target")
+    assert result is tool
+
+
+def test_lookup_not_found(sample_tool_factory):
+    """Looking up an id that was never registered must raise ToolNotFoundError."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="existing_tool"))
+    with pytest.raises(ToolNotFoundError):
+        registry.lookup("nonexistent_tool")
+
+
+def test_not_found_error_contains_tool_id(sample_tool_factory):
+    """ToolNotFoundError must carry the missing tool_id as an attribute."""
+    registry = ToolRegistry()
+    missing_id = "ghost_tool"
+    with pytest.raises(ToolNotFoundError) as exc_info:
+        registry.lookup(missing_id)
+    assert exc_info.value.tool_id == missing_id
+
+
+# ---------------------------------------------------------------------------
+# Collection methods
+# ---------------------------------------------------------------------------
+
+
+def test_all_tools(sample_tool_factory):
+    """all_tools() must return every registered tool."""
+    registry = ToolRegistry()
+    ids = {"alpha", "beta", "gamma"}
+    for tool_id in ids:
+        registry.register(sample_tool_factory(id=tool_id))
+    returned_ids = {t.id for t in registry.all_tools()}
+    assert returned_ids == ids
+
+
+def test_all_tools_empty():
+    """all_tools() on a fresh registry must return an empty list."""
+    registry = ToolRegistry()
+    assert registry.all_tools() == []
+
+
+# ---------------------------------------------------------------------------
+# Dunder methods
+# ---------------------------------------------------------------------------
+
+
+def test_len_empty():
+    """A freshly created registry must report length 0."""
+    registry = ToolRegistry()
+    assert len(registry) == 0
+
+
+def test_len_with_tools(sample_tool_factory):
+    """A registry with two registered tools must report length 2."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="t1"))
+    registry.register(sample_tool_factory(id="t2"))
+    assert len(registry) == 2
+
+
+def test_contains_registered(sample_tool_factory):
+    """The `in` operator must return True for a registered tool id."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="present_tool"))
+    assert "present_tool" in registry
+
+
+def test_contains_not_registered():
+    """The `in` operator must return False for an unknown tool id."""
+    registry = ToolRegistry()
+    assert "unknown_id" not in registry
+
+
+# ---------------------------------------------------------------------------
+# Prompt cache partitioning — core_tools / situational_tools
+# ---------------------------------------------------------------------------
+
+
+def test_core_tools_returns_only_core(sample_tool_factory):
+    """core_tools() must return exactly the tools registered with is_core=True."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="core_a", is_core=True))
+    registry.register(sample_tool_factory(id="core_b", is_core=True))
+    registry.register(sample_tool_factory(id="sit_c", is_core=False))
+    core = registry.core_tools()
+    assert len(core) == 2
+    assert {t.id for t in core} == {"core_a", "core_b"}
+
+
+def test_situational_tools_returns_only_non_core(sample_tool_factory):
+    """situational_tools() must return exactly the tools registered with is_core=False."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="core_a", is_core=True))
+    registry.register(sample_tool_factory(id="sit_b", is_core=False))
+    registry.register(sample_tool_factory(id="sit_c", is_core=False))
+    situational = registry.situational_tools()
+    assert len(situational) == 2
+    assert {t.id for t in situational} == {"sit_b", "sit_c"}
+
+
+def test_core_and_situational_disjoint(sample_tool_factory):
+    """core_tools() and situational_tools() must be disjoint and together cover all tools."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="core_a", is_core=True))
+    registry.register(sample_tool_factory(id="core_b", is_core=True))
+    registry.register(sample_tool_factory(id="sit_c", is_core=False))
+    registry.register(sample_tool_factory(id="sit_d", is_core=False))
+    core_ids = {t.id for t in registry.core_tools()}
+    sit_ids = {t.id for t in registry.situational_tools()}
+    assert core_ids & sit_ids == set()
+    assert len(core_ids) + len(sit_ids) == len(registry)
+
+
+def test_core_tools_sorted_by_id(sample_tool_factory):
+    """core_tools() must return tools sorted alphabetically by id."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="z_tool", is_core=True))
+    registry.register(sample_tool_factory(id="a_tool", is_core=True))
+    registry.register(sample_tool_factory(id="m_tool", is_core=True))
+    returned_ids = [t.id for t in registry.core_tools()]
+    assert returned_ids == ["a_tool", "m_tool", "z_tool"]
+
+
+def test_export_core_tools_openai_deterministic(sample_tool_factory):
+    """export_core_tools_openai() must return identical results on successive calls."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="c_tool", is_core=True))
+    registry.register(sample_tool_factory(id="a_tool", is_core=True))
+    registry.register(sample_tool_factory(id="b_tool", is_core=True))
+    first = registry.export_core_tools_openai()
+    second = registry.export_core_tools_openai()
+    assert first == second
+    assert [item["function"]["name"] for item in first] == [  # type: ignore[index]
+        item["function"]["name"] for item in second  # type: ignore[index]
+    ]
+
+
+def test_export_core_tools_openai_format(sample_tool_factory):
+    """export_core_tools_openai() must produce valid OpenAI function-calling definitions."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="fmt_tool", is_core=True))
+    result = registry.export_core_tools_openai()
+    assert len(result) == 1
+    item = result[0]
+    assert item["type"] == "function"
+    func = item["function"]
+    assert "name" in func
+    assert "parameters" in func
+
+
+def test_empty_core_tools(sample_tool_factory):
+    """core_tools() and export_core_tools_openai() return empty lists when no core tools exist."""
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="sit_a", is_core=False))
+    registry.register(sample_tool_factory(id="sit_b", is_core=False))
+    assert registry.core_tools() == []
+    assert registry.export_core_tools_openai() == []
+
+
+# ---------------------------------------------------------------------------
+# Rate limiter access
+# ---------------------------------------------------------------------------
+
+
+def test_get_rate_limiter_registered(sample_tool_factory):
+    """get_rate_limiter() must return a RateLimiter with the correct limit for a registered tool."""
+    from kosmos.tools.rate_limiter import RateLimiter
+
+    registry = ToolRegistry()
+    tool = sample_tool_factory(id="rl_tool", rate_limit_per_minute=30)
+    registry.register(tool)
+    limiter = registry.get_rate_limiter("rl_tool")
+    assert isinstance(limiter, RateLimiter)
+    assert limiter.limit == 30
+
+
+def test_get_rate_limiter_not_found():
+    """get_rate_limiter() must raise ToolNotFoundError for an unregistered tool id."""
+    registry = ToolRegistry()
+    with pytest.raises(ToolNotFoundError):
+        registry.get_rate_limiter("nonexistent")

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -57,12 +57,8 @@ def test_mixed_query(populated_registry):
     # Mixed query: weather tool score must be >= single-token score
     # (both tokens match the weather hint, so score = 1.0 vs 1.0 for single token —
     # or mixed provides equal/higher score than any partially-matching rival).
-    single_score = next(
-        r.score for r in single_results if r.tool.id == "kma_weather_forecast"
-    )
-    mixed_score = next(
-        r.score for r in mixed_results if r.tool.id == "kma_weather_forecast"
-    )
+    single_score = next(r.score for r in single_results if r.tool.id == "kma_weather_forecast")
+    mixed_score = next(r.score for r in mixed_results if r.tool.id == "kma_weather_forecast")
     assert mixed_score >= single_score
 
 

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -26,7 +26,7 @@ def _tool_ids(results) -> list[str]:
 
 def test_korean_keyword_match(populated_registry):
     """Searching '날씨' should return the weather tool among results."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     results = search_tools(tools, "날씨")
 
     assert results, "Expected at least one result for '날씨'"
@@ -35,7 +35,7 @@ def test_korean_keyword_match(populated_registry):
 
 def test_english_keyword_match(populated_registry):
     """Searching 'weather' (English) should return the weather tool."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     results = search_tools(tools, "weather")
 
     assert results, "Expected at least one result for 'weather'"
@@ -45,7 +45,7 @@ def test_english_keyword_match(populated_registry):
 def test_mixed_query(populated_registry):
     """Searching '날씨 weather' (two tokens) should score the weather tool higher
     than a single-token query that also matches one other tool."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
 
     single_results = search_tools(tools, "날씨")
     mixed_results = search_tools(tools, "날씨 weather")
@@ -69,7 +69,7 @@ def test_mixed_query(populated_registry):
 
 def test_empty_query_returns_empty(populated_registry):
     """An empty string query must return an empty list."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     results = search_tools(tools, "")
 
     assert results == []
@@ -77,7 +77,7 @@ def test_empty_query_returns_empty(populated_registry):
 
 def test_whitespace_query_returns_empty(populated_registry):
     """A whitespace-only query must return an empty list."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     results = search_tools(tools, "   ")
 
     assert results == []
@@ -85,7 +85,7 @@ def test_whitespace_query_returns_empty(populated_registry):
 
 def test_no_match_returns_empty(populated_registry):
     """A query with no overlap against any hint must return an empty list."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     results = search_tools(tools, "블록체인 blockchain")
 
     assert results == []
@@ -98,7 +98,7 @@ def test_no_match_returns_empty(populated_registry):
 
 def test_max_results_limit(populated_registry):
     """max_results=1 must return at most 1 result even if multiple tools match."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     # Use a broad query matching multiple tools to verify the cap.
     results = search_tools(tools, "hospital traffic weather business", max_results=1)
 
@@ -113,7 +113,7 @@ def test_max_results_limit(populated_registry):
 def test_score_ranking(populated_registry):
     """A query matching two tokens of the weather hint but only one token of
     another hint should rank the weather tool first."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
 
     # "날씨 weather" both appear only in the weather tool's hint.
     # "hospital" appears only in the hospital tool's hint.
@@ -134,7 +134,7 @@ def test_score_ranking(populated_registry):
 
 def test_substring_matching(populated_registry):
     """Query token '교통' should match hint token '교통사고' via substring matching."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     results = search_tools(tools, "교통")
 
     assert results, "Expected at least one result for '교통'"
@@ -151,7 +151,7 @@ def test_substring_matching(populated_registry):
 
 def test_case_insensitive(populated_registry):
     """Uppercase query 'WEATHER' should still match lowercase 'weather' in hint."""
-    tools = list(populated_registry._tools.values())
+    tools = populated_registry.all_tools()
     results = search_tools(tools, "WEATHER")
 
     assert results, "Expected at least one result for 'WEATHER'"

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -99,8 +99,7 @@ def test_no_match_returns_empty(populated_registry):
 def test_max_results_limit(populated_registry):
     """max_results=1 must return at most 1 result even if multiple tools match."""
     tools = list(populated_registry._tools.values())
-    # "traffic" does not appear in any hint but "accident" appears in koroad hint.
-    # Use a broad term present in multiple hints to guarantee multiple matches.
+    # Use a broad query matching multiple tools to verify the cap.
     results = search_tools(tools, "hospital traffic weather business", max_results=1)
 
     assert len(results) <= 1

--- a/tests/tools/test_search.py
+++ b/tests/tools/test_search.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for bilingual (Korean + English) search in the KOSMOS Tool System.
+
+All tests use mock tools from conftest fixtures — no live API calls are made.
+"""
+
+from __future__ import annotations
+
+from kosmos.tools.models import GovAPITool, SearchToolsInput, SearchToolsOutput
+from kosmos.tools.search import create_search_meta_tool, search_tools
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _tool_ids(results) -> list[str]:
+    """Extract tool IDs from a list of ToolSearchResult objects."""
+    return [r.tool.id for r in results]
+
+
+# ---------------------------------------------------------------------------
+# Bilingual keyword matching
+# ---------------------------------------------------------------------------
+
+
+def test_korean_keyword_match(populated_registry):
+    """Searching '날씨' should return the weather tool among results."""
+    tools = list(populated_registry._tools.values())
+    results = search_tools(tools, "날씨")
+
+    assert results, "Expected at least one result for '날씨'"
+    assert "kma_weather_forecast" in _tool_ids(results)
+
+
+def test_english_keyword_match(populated_registry):
+    """Searching 'weather' (English) should return the weather tool."""
+    tools = list(populated_registry._tools.values())
+    results = search_tools(tools, "weather")
+
+    assert results, "Expected at least one result for 'weather'"
+    assert "kma_weather_forecast" in _tool_ids(results)
+
+
+def test_mixed_query(populated_registry):
+    """Searching '날씨 weather' (two tokens) should score the weather tool higher
+    than a single-token query that also matches one other tool."""
+    tools = list(populated_registry._tools.values())
+
+    single_results = search_tools(tools, "날씨")
+    mixed_results = search_tools(tools, "날씨 weather")
+
+    # Both queries must find the weather tool.
+    assert "kma_weather_forecast" in _tool_ids(single_results)
+    assert "kma_weather_forecast" in _tool_ids(mixed_results)
+
+    # Mixed query: weather tool score must be >= single-token score
+    # (both tokens match the weather hint, so score = 1.0 vs 1.0 for single token —
+    # or mixed provides equal/higher score than any partially-matching rival).
+    single_score = next(
+        r.score for r in single_results if r.tool.id == "kma_weather_forecast"
+    )
+    mixed_score = next(
+        r.score for r in mixed_results if r.tool.id == "kma_weather_forecast"
+    )
+    assert mixed_score >= single_score
+
+
+# ---------------------------------------------------------------------------
+# Empty / whitespace / no-match guards
+# ---------------------------------------------------------------------------
+
+
+def test_empty_query_returns_empty(populated_registry):
+    """An empty string query must return an empty list."""
+    tools = list(populated_registry._tools.values())
+    results = search_tools(tools, "")
+
+    assert results == []
+
+
+def test_whitespace_query_returns_empty(populated_registry):
+    """A whitespace-only query must return an empty list."""
+    tools = list(populated_registry._tools.values())
+    results = search_tools(tools, "   ")
+
+    assert results == []
+
+
+def test_no_match_returns_empty(populated_registry):
+    """A query with no overlap against any hint must return an empty list."""
+    tools = list(populated_registry._tools.values())
+    results = search_tools(tools, "블록체인 blockchain")
+
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# max_results cap
+# ---------------------------------------------------------------------------
+
+
+def test_max_results_limit(populated_registry):
+    """max_results=1 must return at most 1 result even if multiple tools match."""
+    tools = list(populated_registry._tools.values())
+    # "traffic" does not appear in any hint but "accident" appears in koroad hint.
+    # Use a broad term present in multiple hints to guarantee multiple matches.
+    results = search_tools(tools, "hospital traffic weather business", max_results=1)
+
+    assert len(results) <= 1
+
+
+# ---------------------------------------------------------------------------
+# Score-based ranking
+# ---------------------------------------------------------------------------
+
+
+def test_score_ranking(populated_registry):
+    """A query matching two tokens of the weather hint but only one token of
+    another hint should rank the weather tool first."""
+    tools = list(populated_registry._tools.values())
+
+    # "날씨 weather" both appear only in the weather tool's hint.
+    # "hospital" appears only in the hospital tool's hint.
+    # Weather tool should have score 2/3, hospital 1/3 → weather ranks first.
+    results = search_tools(tools, "날씨 weather hospital")
+
+    assert results, "Expected results"
+    assert results[0].tool.id == "kma_weather_forecast", (
+        f"Expected weather tool first, got {results[0].tool.id}"
+    )
+    assert results[0].score >= results[1].score
+
+
+# ---------------------------------------------------------------------------
+# Substring matching
+# ---------------------------------------------------------------------------
+
+
+def test_substring_matching(populated_registry):
+    """Query token '교통' should match hint token '교통사고' via substring matching."""
+    tools = list(populated_registry._tools.values())
+    results = search_tools(tools, "교통")
+
+    assert results, "Expected at least one result for '교통'"
+    assert "koroad_accident_stats" in _tool_ids(results)
+
+    matched_result = next(r for r in results if r.tool.id == "koroad_accident_stats")
+    assert "교통" in matched_result.matched_tokens
+
+
+# ---------------------------------------------------------------------------
+# Case-insensitive matching
+# ---------------------------------------------------------------------------
+
+
+def test_case_insensitive(populated_registry):
+    """Uppercase query 'WEATHER' should still match lowercase 'weather' in hint."""
+    tools = list(populated_registry._tools.values())
+    results = search_tools(tools, "WEATHER")
+
+    assert results, "Expected at least one result for 'WEATHER'"
+    assert "kma_weather_forecast" in _tool_ids(results)
+
+
+# ---------------------------------------------------------------------------
+# create_search_meta_tool factory
+# ---------------------------------------------------------------------------
+
+
+def test_create_search_meta_tool():
+    """The meta-tool returned by create_search_meta_tool must meet contract requirements."""
+    meta_tool = create_search_meta_tool()
+
+    assert isinstance(meta_tool, GovAPITool)
+    assert meta_tool.id == "search_tools"
+    assert meta_tool.is_core is True
+    assert meta_tool.input_schema is SearchToolsInput
+    assert meta_tool.output_schema is SearchToolsOutput
+    # Internal tool must not require auth and must be concurrency-safe.
+    assert meta_tool.requires_auth is False
+    assert meta_tool.is_concurrency_safe is True
+    assert meta_tool.is_personal_data is False

--- a/uv.lock
+++ b/uv.lock
@@ -391,6 +391,7 @@ source = { editable = "." }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
+    { name = "pydantic-settings" },
     { name = "rich" },
     { name = "typer" },
 ]
@@ -420,6 +421,7 @@ requires-dist = [
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
     { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
     { name = "pytest-cov", marker = "extra == 'dev'", specifier = ">=5.0" },
@@ -869,6 +871,20 @@ wheels = [
 ]
 
 [[package]]
+name = "pydantic-settings"
+version = "2.13.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "python-dotenv" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/52/6d/fffca34caecc4a3f97bda81b2098da5e8ab7efc9a66e819074a11955d87e/pydantic_settings-2.13.1.tar.gz", hash = "sha256:b4c11847b15237fb0171e1462bf540e294affb9b86db4d9aa5c01730bdbe4025", size = 223826, upload-time = "2026-02-19T13:45:08.055Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/00/4b/ccc026168948fec4f7555b9164c724cf4125eac006e176541483d2c959be/pydantic_settings-2.13.1-py3-none-any.whl", hash = "sha256:d56fd801823dbeae7f0975e1f8c8e25c258eb75d278ea7abb5d9cebb01b56237", size = 58929, upload-time = "2026-02-19T13:45:06.034Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -953,6 +969,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/de/ef/3bae0e537cfe91e8431efcba4434463d2c5a65f5a89edd47c6cf2f03c55f/python_discovery-1.2.2.tar.gz", hash = "sha256:876e9c57139eb757cb5878cbdd9ae5379e5d96266c99ef731119e04fffe533bb", size = 58872, upload-time = "2026-04-07T17:28:49.249Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d8/db/795879cc3ddfe338599bddea6388cc5100b088db0a4caf6e6c1af1c27e04/python_discovery-1.2.2-py3-none-any.whl", hash = "sha256:e1ae95d9af875e78f15e19aed0c6137ab1bb49c200f21f5061786490c9585c7a", size = 31894, upload-time = "2026-04-07T17:28:48.09Z" },
+]
+
+[[package]]
+name = "python-dotenv"
+version = "1.2.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
 ]
 
 [[package]]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -1,0 +1,8 @@
+# Vulture whitelist — false positives from framework patterns.
+# See: https://github.com/jendrikseipp/vulture#whitelisting
+
+# Pydantic @field_validator / @model_validator require cls as first arg
+cls  # noqa: F821
+
+# __aexit__ protocol requires *args
+args  # noqa: F821


### PR DESCRIPTION
## Summary

Implements **Epic #4 (LLM Client Integration)** and **Epic #6 (Tool System & Registry)** — the foundational Layer 1 and Layer 2 modules for the KOSMOS conversational agent platform.

### LLM Client (`src/kosmos/llm/`)
- **LLMClient**: Async `complete()` and `stream()` via FriendliAI OpenAI-compatible endpoint
- **SSE streaming**: `content_delta`, `tool_call_delta`, `usage` event parsing
- **Pydantic v2 models**: `ChatMessage` (role validation), `TokenUsage`, `ToolDefinition`, `FunctionSchema`
- **Config**: `LLMClientConfig` via pydantic-settings (`KOSMOS_FRIENDLI_*` env vars)
- **Budget enforcement**: `UsageTracker` with per-session token budget
- **Retry**: Exponential backoff with full jitter for 429/503; immediate fail on 401/400
- **Error hierarchy**: `AuthenticationError`, `BudgetExceededError`, `LLMConnectionError`, etc.

### Tool System (`src/kosmos/tools/`)
- **GovAPITool**: Pydantic v2 model with fail-closed defaults (Constitution § II)
- **ToolRegistry**: Register, lookup, search, core/situational partition
- **Bilingual search**: Korean + English token-overlap scoring with substring matching
- **RateLimiter**: Sliding-window per-tool rate limiting (`collections.deque`)
- **ToolExecutor**: Dispatch pipeline (validate → rate-check → execute → validate output)
- **Deterministic export**: `export_core_tools_openai()` sorted by id for prompt cache stability

### Stats
- 49 files changed, 6,052 insertions
- **139 tests**, all passing
- Zero live API calls in test suite

Closes #4, Closes #6

## Test plan
- [x] `uv run ruff check src/ tests/` — lint clean
- [x] `uv run pytest tests/ -q` — 139 tests pass
- [x] Public exports validated via import check
- [ ] CI pipeline checks (pytest, ruff, mypy)