### PR TITLE
docs: add code review steps to leader prompt

### DIFF
--- a/prompts/phase1-roadmap-leader.md
+++ b/prompts/phase1-roadmap-leader.md
@@ -9,10 +9,10 @@
 
 You are the Lead agent for KOSMOS Phase 1. The project infrastructure is complete:
 - GitHub issue tree: 3 Initiatives + 22 Epics (linked via Sub-Issues API)
-- CI/CD pipeline: ruff, mypy, pytest, CodeQL, Claude Code Action PR review
+- CI/CD pipeline: ruff, mypy, pytest, CodeQL, GitHub Copilot Code Review
 - API keys registered: `KOSMOS_DATA_GO_KR_KEY`, `KOSMOS_KOROAD_API_KEY`, `KOSMOS_FRIENDLI_TOKEN`, `ANTHROPIC_API_KEY`
 - Technical docs saved under `research/data/` for 6 providers (KOROAD, KMA, NMC, HIRA, SSIS, Gov24)
-- Branch protection on `main`: PR required, CI must pass, 1 review required
+- Branch protection on `main`: PR required, CI must pass, no human review required (solo project)
 
 **No source code exists yet.** You are starting from zero.
 
@@ -96,13 +96,63 @@ gh api repos/umyunsang/KOSMOS/issues/EPIC_NUM/sub_issues --method POST -f sub_is
 - If 3+ independent tasks: spawn Teammates (Sonnet) in isolated worktrees
 - If 1-2 tasks: Lead handles solo
 - Each Teammate works on `feat/<epic-slug>/<task-slug>` worktree
-- Lead merges worktrees, resolves conflicts
+
+#### Step 7a: Internal code review (per task)
+After each Teammate completes a task, Lead performs code review before merging:
+
+1. **Read the diff**: review all changed files in the Teammate's worktree
+2. **Check against constitution**: Pydantic v2, fail-closed defaults, no `Any`, no hardcoded keys, English source text
+3. **Check against spec**: does the implementation match spec.md and plan.md requirements?
+4. **Check code quality**:
+   - Type hints on all public functions
+   - Error handling follows Layer 6 patterns
+   - Tests cover happy-path and error-path
+   - No `print()` outside CLI layer (use `logging`)
+   - Import ordering: stdlib → third-party → local
+5. **Verdict**:
+   - **APPROVE**: merge the worktree into `feat/<epic-slug>`
+   - **REQUEST CHANGES**: list specific issues → Teammate fixes → re-review
+   - Max 2 review rounds per task. If still failing, Lead fixes directly.
+
+#### Step 7b: Integration review
+After all tasks are merged into `feat/<epic-slug>`:
+1. Run `uv run pytest` on the full branch
+2. Verify cross-module imports and interfaces are consistent
+3. Check for duplicate code across tasks
+4. Resolve any merge conflicts
 
 ### Step 8: PR and CI
 - Create PR with `Closes #N` for all completed Task issues
 - Monitor CI: `gh pr checks <PR_NUMBER> --watch --interval 10`
 - If checks fail: investigate and fix
-- Report: PR link, check summary, pass/fail status
+
+### Step 9: Copilot Code Review response
+After CI passes, GitHub Copilot will post review comments on the PR.
+
+1. **Wait for Copilot review** (usually 1-2 minutes after PR creation):
+   ```bash
+   # Check for Copilot review comments
+   gh api repos/umyunsang/KOSMOS/pulls/<PR_NUMBER>/reviews \
+     --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | {state, body}'
+   ```
+
+2. **Read all Copilot comments**:
+   ```bash
+   gh api repos/umyunsang/KOSMOS/pulls/<PR_NUMBER>/comments \
+     --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | {path, line, body}'
+   ```
+
+3. **Triage each comment**:
+   - **Valid issue** (bug, security, correctness): fix immediately
+   - **Style suggestion** (naming, formatting): fix if consistent with project conventions
+   - **False positive** (disagree with suggestion): skip, but document reason
+
+4. **Push fixes** if any changes were made
+5. **Verify CI passes** again after fixes
+
+### Step 10: Final report
+- Report to user: PR link, CI status, Copilot review summary (issues found/fixed/skipped)
+- **STOP and wait for user to merge or approve**
 
 ## Agent Teams rules
 


### PR DESCRIPTION
## Summary
- Add Step 7a: internal code review (Lead reviews each Teammate's code per task)
- Add Step 7b: integration review after all tasks merged
- Add Step 9: GitHub Copilot Code Review response (read, triage, fix)
- Add Step 10: final report with review summary
- Replace Claude Code Action reference with Copilot Code Review

## Review flow (updated)
```
Task impl (Sonnet) → Lead code review (Opus) → merge to feat branch
                                                      ↓
                                              PR → CI → Copilot review
                                                      ↓
                                              Lead fixes Copilot issues
                                                      ↓
                                              User merge approval
```