### PR TITLE
docs: add wave leader template and Wave 3-4 prompts

### DIFF
--- a/prompts/TEMPLATE-wave-leader.md
+++ b/prompts/TEMPLATE-wave-leader.md
@@ -1,0 +1,225 @@
+# Wave Leader Prompt Template
+
+> Use this template to generate a wave-specific leader prompt for any Phase/Wave.
+> Fill in the `{{PLACEHOLDER}}` values and delete this instruction block.
+>
+> **How to use**: Copy this file, replace all `{{...}}` placeholders, and save as `wave<N>-leader.md`.
+> Or give this template to Claude with the context and ask it to generate the prompt.
+
+---
+
+# {{WAVE_NAME}} Execution — Leader Prompt
+
+> This prompt is for a Lead agent (Opus) to execute {{WAVE_NAME}} of the Phase {{PHASE_NUMBER}} roadmap.
+> Read `AGENTS.md`, `docs/vision.md`, and `.specify/memory/constitution.md` first.
+
+---
+
+## Context
+
+You are the Lead agent for KOSMOS Phase {{PHASE_NUMBER}} {{WAVE_NAME}}. Prior waves are complete:
+{{COMPLETED_WAVES}}
+<!-- Example:
+- Wave 1: Epic #4 (LLM Client), Epic #6 (Tool System) — DONE
+- Wave 2: Epic #5 (Query Engine), Epic #7 (API Adapters) — DONE
+-->
+
+The codebase now has:
+{{EXISTING_CODEBASE}}
+<!-- Example:
+- `src/kosmos/llm/` — LLM Client
+- `src/kosmos/tools/` — Tool System + Adapters
+- `src/kosmos/engine/` — Query Engine
+-->
+
+Infrastructure:
+- CI/CD: ruff, mypy --strict, pytest (3.12/3.13), CodeQL, security checks
+- GitHub Copilot Code Review enabled
+- Branch protection: PR required, CI must pass
+- Auto-merge: dependabot only. Feature PRs require user approval.
+
+## {{WAVE_NAME}} goal
+
+{{WAVE_EPIC_COUNT}} Epics in this wave:
+
+```
+{{WAVE_DEPENDENCY_TREE}}
+```
+<!-- Example:
+Wave 3 ─── All parallel-safe
+  ├── Epic #8   Permission Pipeline v1 (Layer 3)
+  ├── Epic #9   Context Assembly v1 (Layer 5)
+  ├── Epic #10  Error Recovery v1 (Layer 6)
+  └── Epic #11  CLI Interface (typer + rich)
+-->
+
+{{PARALLEL_NOTE}}
+<!-- "All Epics are independent — run spec cycles in parallel." OR
+     "Epic #X depends on #Y. Run #Y first, then #X." -->
+
+## Epic-specific notes
+
+{{EPIC_DETAILS}}
+<!-- For each Epic, write:
+
+#### Epic #N — Name (Layer)
+- Reference: `docs/vision.md § Layer N`
+- Reference sources: (from constitution reference mapping table)
+- Scope for this phase:
+  - Requirement 1
+  - Requirement 2
+  - What is deferred to next phase
+-->
+
+## Workflow per Epic
+
+Follow `AGENTS.md § Spec-driven workflow`. 10-step process:
+
+### Steps 1-6: Spec cycle
+
+#### Step 1: Verify Epic issue exists
+```bash
+gh issue view <EPIC_NUMBER> --repo umyunsang/KOSMOS
+```
+
+#### Step 2: `/speckit-specify` → spec.md
+- Read `docs/vision.md` for the relevant layer design
+{{SPECIFY_EXTRA_INSTRUCTIONS}}
+<!-- For tool adapter Epics: "follow docs/tool-adapters.md § Spec cycle protocol" -->
+- Output: `specs/NNN-slug/spec.md`
+- **STOP and wait for user approval**
+
+#### Step 3: `/speckit-plan` → plan.md
+- Read `docs/vision.md § Reference materials` — map each design decision to a reference source
+- Read `.specify/memory/constitution.md` for compliance rules
+- Actively reference reconstructed sources:
+  - `ChinaSiro/claude-code-sourcemap` — tool loop, permission model, context assembly
+  - `openedclaude/claude-reviews-claude` — architecture review, design rationale
+  - `ultraworkers/claw-code` — runtime behavior, hook system, tool execution
+{{PLAN_EXTRA_INSTRUCTIONS}}
+- Output: `specs/NNN-slug/plan.md`
+- **STOP and wait for user approval**
+
+#### Step 4: `/speckit-tasks` → tasks.md
+- Decompose into implementable tasks
+- Mark `parallel-safe` tasks that can be assigned to different Teammates
+- Output: `specs/NNN-slug/tasks.md`
+- **STOP and wait for user approval**
+
+#### Step 5: `/speckit-analyze` → constitution compliance check
+
+#### Step 6: `/speckit-taskstoissues` → create Task issues
+- Create GitHub issues from tasks.md
+- Link each as sub-issue of the Epic:
+```bash
+TASK_ID=$(gh api graphql -f query='query{repository(owner:"umyunsang",name:"KOSMOS"){issue(number:TASK_NUM){id}}}' --jq '.data.repository.issue.id')
+gh api repos/umyunsang/KOSMOS/issues/EPIC_NUM/sub_issues --method POST -f sub_issue_id="$TASK_ID"
+```
+- **STOP and wait for user approval**
+
+### Steps 7-10: Implementation + Review
+
+#### Step 7: `/speckit-implement` → Agent Teams execution
+- Create feature branch: `feat/<epic-slug>`
+- If 3+ independent tasks: spawn Teammates (Sonnet) in isolated worktrees
+- If 1-2 tasks: Lead handles solo
+
+##### Step 7a: Internal code review (per task)
+After each Teammate completes a task:
+1. Read the diff
+2. Check against constitution: Pydantic v2, fail-closed defaults, no `Any`, no hardcoded keys, English source text
+3. Check against spec: implementation matches spec.md and plan.md
+4. Check code quality: type hints, error handling, tests (happy + error path), no `print()`, import ordering
+5. Verdict: APPROVE → merge, or REQUEST CHANGES → fix → re-review (max 2 rounds)
+
+##### Step 7b: Integration review
+After all tasks merged into `feat/<epic-slug>`:
+```bash
+uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src && uv run pytest
+```
+
+#### Step 8: PR and CI
+- Merge latest main: `git fetch origin main && git merge origin/main`
+- Branch name MUST match: `feat/<kebab-case-slug>`
+- PR body: `Closes #N` for all Task issues
+- Monitor CI: `gh pr checks <PR_NUMBER> --watch --interval 10`
+- If checks fail: investigate and fix
+
+#### Step 9: Copilot Code Review response
+1. Wait for Copilot review (~1-2 min after PR creation)
+2. Read comments:
+   ```bash
+   gh api repos/umyunsang/KOSMOS/pulls/<PR_NUMBER>/comments \
+     --jq '.[] | select(.user.login == "copilot-pull-request-reviewer[bot]") | {path, line, body}'
+   ```
+3. Triage: fix valid issues, skip false positives
+4. Push fixes, verify CI
+
+#### Step 10: Final report
+- PR link, CI status, Copilot review summary, internal review summary
+- List of Task issues that close on merge
+- **STOP and wait for user to merge**
+
+## Agent Teams rules
+
+| Role | Agent Type | Model | When to use |
+|------|-----------|-------|-------------|
+| Lead | — | Opus | Planning, spec authoring, code review, synthesis |
+| Backend | Backend Architect | Sonnet | Python implementation |
+| Tests | API Tester | Sonnet | Test suites, fixtures |
+| Security | Security Engineer | Sonnet | Permission pipeline |
+| Docs | Technical Writer | Sonnet | API docs |
+
+## Hard constraints
+
+- All source text in English. Korean only in domain data.
+- Pydantic v2 for all tool I/O. Never `Any`.
+- `KOSMOS_` prefix for all env vars. Never commit secrets.
+- `@pytest.mark.live` on real API tests — never run in CI.
+- Conventional Commits. Branch: `feat/<slug>`.
+- `uv run pytest` must pass before every PR.
+- Never advance to the next spec step without user approval.
+{{EXTRA_CONSTRAINTS}}
+
+## Starting the work
+
+Begin now:
+1. `git checkout main && git pull origin main`
+2. Read existing source code to understand current codebase state
+3. Verify all Epic issues exist on GitHub
+{{START_INSTRUCTIONS}}
+<!-- Example:
+4. Begin `/speckit-specify` for all Epics in parallel
+5. Present all specs to the user for approval
+-->
+
+---
+
+## Template reference — Placeholder descriptions
+
+| Placeholder | Description | Example |
+|---|---|---|
+| `{{WAVE_NAME}}` | Wave identifier | `Wave 3`, `Phase 2 Wave 1` |
+| `{{PHASE_NUMBER}}` | Phase number | `1`, `2`, `3` |
+| `{{COMPLETED_WAVES}}` | Bullet list of completed waves + Epics | See above |
+| `{{EXISTING_CODEBASE}}` | Bullet list of `src/kosmos/` modules | See above |
+| `{{WAVE_EPIC_COUNT}}` | Number of Epics | `4 Epics, ALL parallel-safe` |
+| `{{WAVE_DEPENDENCY_TREE}}` | ASCII tree of Epics + dependencies | See above |
+| `{{PARALLEL_NOTE}}` | Parallel execution guidance | See above |
+| `{{EPIC_DETAILS}}` | Per-Epic reference, scope, and notes | See above |
+| `{{SPECIFY_EXTRA_INSTRUCTIONS}}` | Extra instructions for `/speckit-specify` | Tool adapter protocol |
+| `{{PLAN_EXTRA_INSTRUCTIONS}}` | Extra instructions for `/speckit-plan` | Schema design notes |
+| `{{EXTRA_CONSTRAINTS}}` | Phase-specific constraints | `- Phase 1 CLI: typer + rich only` |
+| `{{START_INSTRUCTIONS}}` | Starting steps specific to this wave | See above |
+
+## Constitution reference mapping (copy relevant rows)
+
+| Layer | Primary reference | Secondary reference |
+|---|---|---|
+| Query Engine | Claude Agent SDK (async generator loop) | Claude Code reconstructed (tool loop internals) |
+| Tool System | Pydantic AI (schema-driven registry) | Claude Agent SDK (tool definitions) |
+| Permission Pipeline | OpenAI Agents SDK (guardrail pipeline) | Claude Code reconstructed (permission model) |
+| Agent Swarms | AutoGen (AgentRuntime mailbox IPC) | Anthropic Cookbook (orchestrator-workers) |
+| Context Assembly | Claude Code reconstructed (context assembly) | Anthropic docs (prompt caching) |
+| Error Recovery | OpenAI Agents SDK (retry matrix) | Claude Agent SDK (error handling) |
+| TUI | Ink + Gemini CLI (React terminal UI) | Claude Code reconstructed (TUI components) |

--- a/prompts/wave3-leader.md
+++ b/prompts/wave3-leader.md
@@ -1,0 +1,156 @@
+# Wave 3 Execution — Leader Prompt
+
+> This prompt is for a Lead agent (Opus) to execute Wave 3 of the Phase 1 roadmap.
+> Read `AGENTS.md`, `docs/vision.md`, and `.specify/memory/constitution.md` first.
+
+---
+
+## Context
+
+You are the Lead agent for KOSMOS Phase 1 Wave 3. Prior waves are complete and merged:
+- Wave 1: Epic #4 (LLM Client), Epic #6 (Tool System) — DONE
+- Wave 2: Epic #5 (Query Engine Core), Epic #7 (API Adapters: KOROAD, KMA) — DONE
+
+The codebase now has:
+- `src/kosmos/llm/` — FriendliAI K-EXAONE client, models, retry, usage tracking
+- `src/kosmos/tools/` — GovAPITool, ToolRegistry, bilingual search, adapters (KOROAD, KMA)
+- `src/kosmos/engine/` — Query engine async generator loop, QueryState, StopReason, preprocessing
+- Full test coverage for all above layers
+
+Infrastructure:
+- CI/CD: ruff, mypy --strict, pytest (3.12/3.13), CodeQL, security checks
+- GitHub Copilot Code Review enabled
+- Branch protection: PR required, CI must pass
+- Auto-merge: dependabot only. Feature PRs require user approval.
+
+## Wave 3 goal
+
+Four Epics, ALL independent of each other — run all 4 spec cycles in parallel:
+
+```
+Wave 3 ─── All parallel-safe (each depends on Wave 2 outputs, not on each other)
+  ├── Epic #8   Permission Pipeline v1 (Layer 3)    ← needs Query Engine + Tool System
+  ├── Epic #9   Context Assembly v1 (Layer 5)       ← needs Query Engine
+  ├── Epic #10  Error Recovery v1 (Layer 6)          ← needs Query Engine
+  └── Epic #11  CLI Interface (typer + rich)         ← needs Query Engine
+```
+
+## Parallel execution strategy
+
+Since all 4 Epics are independent:
+1. Run `/speckit-specify` for all 4 Epics in parallel → present all 4 specs for approval
+2. After approval, run `/speckit-plan` for all 4 in parallel → present all 4 plans
+3. After approval, run `/speckit-tasks` for all 4 → present all 4 task lists
+4. After approval, run `/speckit-analyze` + `/speckit-taskstoissues` for all 4
+5. Implementation: spawn Agent Teams across all 4 Epics simultaneously
+
+## Workflow per Epic
+
+Follow `AGENTS.md § Spec-driven workflow`. Same 10-step process as Wave 2.
+
+### Steps 1-6: Spec cycle (run for all 4 Epics in parallel)
+
+For each Epic, follow Steps 1-6 from `prompts/wave2-leader.md`. Key differences per Epic:
+
+#### Epic #8 — Permission Pipeline v1 (Layer 3)
+- Reference: `docs/vision.md § Layer 3 — Permission Pipeline`
+- Reference sources: OpenAI Agents SDK guardrail pipeline, Claude Code reconstructed permission model
+- Scope for v1:
+  - 7-step gauntlet skeleton (all steps defined, steps 2-5 as pass-through stubs)
+  - Step 1: Configuration rules (per-API access tier: public, authenticated, restricted)
+  - Step 6: Sandboxed execution (isolated context, no ambient credentials)
+  - Step 7: Audit log (timestamp, citizen id, API, parameters, outcome)
+  - Bypass-immune checks (NON-NEGOTIABLE): cannot query another citizen's records, medical records without consent, writes without identity verification
+- Constitution: fail-closed defaults are CRITICAL here. Read `.specify/memory/constitution.md § II` carefully.
+
+#### Epic #9 — Context Assembly v1 (Layer 5)
+- Reference: `docs/vision.md § Layer 5 — Context Assembly`
+- Reference sources: Claude Code reconstructed context assembly, Anthropic docs prompt caching
+- Scope for v1:
+  - System prompt assembly (platform-wide policies)
+  - Session context (conversation state)
+  - Per-turn attachments (auth level, in-flight state, API health)
+  - Reminder cadence for long sessions
+  - Memory tiers 1-4 (system, region, citizen, session). Tier 5 (auto) deferred to Phase 2.
+
+#### Epic #10 — Error Recovery v1 (Layer 6)
+- Reference: `docs/vision.md § Layer 6 — Error Recovery`
+- Reference sources: OpenAI Agents SDK retry matrix, Claude Agent SDK error handling
+- Scope for v1:
+  - Error classification: 429, 503, 401, timeout, data inconsistency, hard failure
+  - Recovery strategies per class (backoff, alternative API, token refresh, retry, cross-verify, graceful message)
+  - Foreground vs background distinction
+  - `withRetry`-style composable retry policies
+  - Integration with Query Engine loop and Tool System
+
+#### Epic #11 — CLI Interface (typer + rich)
+- Reference: NOT Ink/TypeScript. Phase 1 CLI uses Python `typer` + `rich` only.
+- Scope for v1:
+  - `typer` CLI with `rich` console output
+  - Interactive conversation loop (REPL-style)
+  - Streaming LLM response display
+  - Tool execution progress indicators
+  - Error display with user-friendly messages
+  - Session management (start, resume, quit)
+  - `KOSMOS_` env var configuration
+
+### Steps 7-10: Implementation + Review (run for all 4 Epics)
+
+Same process as Wave 2. For each Epic:
+
+#### Step 7: Implementation with internal code review
+- Create feature branch: `feat/<epic-slug>` (e.g., `feat/permission-pipeline-v1`)
+- Spawn Teammates (Sonnet) for parallel task execution
+- **Step 7a**: Lead reviews each Teammate's code per task
+  - Check constitution compliance, spec alignment, code quality
+  - APPROVE or REQUEST CHANGES (max 2 rounds)
+- **Step 7b**: Integration review after all tasks merged
+  - `uv run ruff check src tests && uv run ruff format --check src tests && uv run mypy src && uv run pytest`
+  - Cross-module interface consistency check
+
+#### Step 8: PR and CI
+- Merge latest main: `git fetch origin main && git merge origin/main`
+- Branch name: `feat/<kebab-case-slug>`
+- PR body: `Closes #N` for all Task issues
+- Monitor CI until pass
+
+#### Step 9: Copilot Code Review response
+- Read Copilot comments via `gh api`
+- Triage: fix valid issues, skip false positives
+- Push fixes, verify CI
+
+#### Step 10: Final report
+- PR link, CI status, Copilot summary, internal review summary
+- **STOP and wait for user to merge**
+
+## Agent Teams rules
+
+| Role | Agent Type | Model | When to use |
+|------|-----------|-------|-------------|
+| Lead | — | Opus | Planning, spec authoring, code review, synthesis |
+| Backend | Backend Architect | Sonnet | Python implementation |
+| Tests | API Tester | Sonnet | Test suites, fixtures |
+| Security | Security Engineer | Sonnet | Permission pipeline (#8) |
+| Docs | Technical Writer | Sonnet | API docs |
+
+## Hard constraints
+
+- All source text in English. Korean only in domain data.
+- Pydantic v2 for all tool I/O. Never `Any`.
+- `KOSMOS_` prefix for all env vars. Never commit secrets.
+- `@pytest.mark.live` on real API tests — never run in CI.
+- Conventional Commits. Branch: `feat/<slug>`.
+- `uv run pytest` must pass before every PR.
+- Never advance to the next spec step without user approval.
+- Phase 1 CLI uses `typer` + `rich` (Python). Do NOT introduce TypeScript or Ink.
+
+## Starting the work
+
+Begin now:
+1. `git checkout main && git pull origin main`
+2. Read the Wave 2 outputs: `src/kosmos/engine/`, `src/kosmos/tools/adapters/`
+3. Verify Epics #8, #9, #10, #11 exist on GitHub
+4. Begin `/speckit-specify` for ALL 4 Epics in parallel
+5. Present all 4 specs to the user for approval
+
+When all 4 PRs are merged, report readiness for Wave 4 (Scenario 1 E2E).

--- a/prompts/wave4-leader.md
+++ b/prompts/wave4-leader.md
@@ -1,0 +1,151 @@
+# Wave 4 Execution — Leader Prompt
+
+> This prompt is for a Lead agent (Opus) to execute Wave 4 (final wave) of the Phase 1 roadmap.
+> Read `AGENTS.md`, `docs/vision.md`, and `.specify/memory/constitution.md` first.
+
+---
+
+## Context
+
+You are the Lead agent for KOSMOS Phase 1 Wave 4 — the final integration wave. All prior waves are complete:
+- Wave 1: Epic #4 (LLM Client), Epic #6 (Tool System) — DONE
+- Wave 2: Epic #5 (Query Engine), Epic #7 (API Adapters) — DONE
+- Wave 3: Epic #8 (Permission Pipeline), Epic #9 (Context Assembly), Epic #10 (Error Recovery), Epic #11 (CLI) — DONE
+
+The codebase now has all 6 architectural layers implemented at v1 level:
+- `src/kosmos/llm/` — LLM Client (Layer 1 dependency)
+- `src/kosmos/engine/` — Query Engine (Layer 1)
+- `src/kosmos/tools/` — Tool System + Adapters (Layer 2)
+- `src/kosmos/permission/` — Permission Pipeline v1 (Layer 3)
+- `src/kosmos/context/` — Context Assembly v1 (Layer 5)
+- `src/kosmos/recovery/` — Error Recovery v1 (Layer 6)
+- `src/kosmos/cli/` — CLI Interface (typer + rich)
+
+## Wave 4 goal
+
+One Epic — the acceptance test for the entire Phase 1:
+
+```
+Wave 4
+  └── Epic #12  Scenario 1 E2E — Route Safety
+```
+
+### Target interaction
+```
+Citizen:  "내일 부산에서 서울 가는데, 안전한 경로 추천해줘"
+KOSMOS:   fuses KOROAD accident data + KMA weather alerts + road-risk index
+          → "경부고속도로 대전-천안 구간 위험 등급, 안개 주의보.
+             중부내륙 우회를 추천합니다."
+```
+
+This is NOT a new feature — it is an **integration test** that proves all layers work together end-to-end.
+
+## Workflow
+
+### Step 1: Verify Epic #12 exists
+```bash
+gh issue view 12 --repo umyunsang/KOSMOS
+```
+
+### Step 2: `/speckit-specify` → spec.md
+- This spec describes the E2E scenario, not a new architectural component
+- Define:
+  - Input: natural-language route safety question (Korean)
+  - Expected flow: Query Engine → tool discovery → KOROAD adapter → KMA adapter → road risk calculation → synthesis → response
+  - Expected output: actionable route recommendation with cited data sources
+  - Edge cases: API down, no data for region, ambiguous location, rate limit hit
+  - Success criteria: citizen gets a useful answer within 30 seconds
+- **STOP and wait for user approval**
+
+### Step 3: `/speckit-plan` → plan.md
+- Map the data flow through all 6 layers:
+  1. CLI receives input → passes to Query Engine
+  2. Query Engine calls LLM for intent analysis
+  3. LLM requests tools via tool_use → Tool System resolves adapters
+  4. Permission Pipeline gates each API call
+  5. Context Assembly provides session context to LLM
+  6. Error Recovery handles any API failures
+  7. LLM synthesizes results → CLI displays response
+- Identify integration points that need glue code
+- Define test fixtures: recorded KOROAD + KMA responses for the scenario
+- **STOP and wait for user approval**
+
+### Step 4: `/speckit-tasks` → tasks.md
+- Expected tasks:
+  - Integration glue: wire CLI → Engine → Tools → Permission → Context
+  - Scenario test fixtures: recorded API responses for Busan→Seoul route
+  - E2E test: `test_scenario1_route_safety.py` with `@pytest.mark.live` variant
+  - CLI smoke test: interactive session can complete the scenario
+  - Documentation: update README with usage example
+- **STOP and wait for user approval**
+
+### Step 5: `/speckit-analyze` → constitution compliance check
+
+### Step 6: `/speckit-taskstoissues` → create Task issues, link to Epic #12
+- **STOP and wait for user approval**
+
+### Step 7: Implementation
+- Create feature branch: `feat/scenario1-e2e`
+- This wave is integration-focused — Lead may handle solo (few tasks, high coupling)
+- Key implementation:
+  - Wire all layers together in the correct dependency order
+  - Create recorded fixtures from actual API responses (use `@pytest.mark.live` for recording)
+  - Write E2E test that runs entirely on fixtures (no live APIs in CI)
+  - Verify the CLI can complete the full scenario interactively
+
+#### Step 7a: Internal code review
+- Focus on integration correctness: are all layer interfaces used correctly?
+- Check error propagation: does a KOROAD 503 trigger Error Recovery → fallback?
+- Check permission flow: does the pipeline correctly gate each API call?
+
+#### Step 7b: Integration verification
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy src
+uv run pytest
+uv run pytest tests/e2e/ -v  # E2E tests specifically
+```
+
+### Step 8: PR and CI
+- Branch: `feat/scenario1-e2e`
+- PR body: `Closes #12` + all Task issue numbers
+- Monitor CI until all checks pass
+
+### Step 9: Copilot Code Review response
+- Read and triage Copilot comments
+- Fix valid issues, push, verify CI
+
+### Step 10: Final report — Phase 1 completion
+Report to user:
+- PR link and CI status
+- Copilot review summary
+- **Scenario 1 test result**: PASS or FAIL with details
+- **Phase 1 completion status**:
+  - [ ] All 9 Epics (#4-#12) merged
+  - [ ] All Task issues closed
+  - [ ] Scenario 1 E2E test passes on fixtures
+  - [ ] CLI can complete the route safety scenario interactively
+  - [ ] `uv run pytest` passes with full coverage
+- **Readiness for Phase 2**: what's next (Agent Swarms, more adapters, Ministry specialists)
+- **STOP and wait for user to merge**
+
+## Hard constraints
+
+- All source text in English. Korean only in domain data.
+- Pydantic v2 for all tool I/O. Never `Any`.
+- `KOSMOS_` prefix for all env vars. Never commit secrets.
+- `@pytest.mark.live` on real API tests — never run in CI.
+- Conventional Commits. Branch: `feat/<slug>`.
+- `uv run pytest` must pass before every PR.
+- Never advance to the next spec step without user approval.
+- E2E tests in CI MUST use recorded fixtures, never live APIs.
+
+## Starting the work
+
+Begin now:
+1. `git checkout main && git pull origin main`
+2. Read ALL source code under `src/kosmos/` to understand the full codebase
+3. Verify Epic #12 exists on GitHub
+4. Begin `/speckit-specify` for Epic #12
+5. Present the spec to the user for approval


### PR DESCRIPTION
## Summary
- `TEMPLATE-wave-leader.md`: reusable template with `{{PLACEHOLDER}}` fields — any session can generate future wave prompts
- `wave3-leader.md`: 4 parallel Epics (#8 Permission, #9 Context, #10 Error Recovery, #11 CLI)
- `wave4-leader.md`: Scenario 1 E2E integration test (#12) — Phase 1 completion gate

## Prompt inventory after merge
```
prompts/
├── cicd-setup-leader.md          # CI/CD (done)
├── phase1-roadmap-leader.md      # Overall Phase 1 (Wave 1 reference)
├── wave2-leader.md               # Epic #5, #7
├── wave3-leader.md               # Epic #8, #9, #10, #11 (parallel)
├── wave4-leader.md               # Epic #12 (E2E)
└── TEMPLATE-wave-leader.md       # Reusable for Phase 2+
```