### PR TITLE
feat(recovery): implement Layer 6 Error Recovery v1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,18 @@ Conventional Commits. Branches: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, 
 
 Cloudflare Worker (`infra/copilot-gate-app/`) → Check Run gate. **CRITICAL >= 1 → fail**, **IMPORTANT >= 3 → fail**, else pass. Deploy: `cd infra/copilot-gate-app && npx wrangler deploy`.
 
-GraphQL `requestReviewsByLogin` has **~1/3 failure rate**. After every push: if gate stays `in_progress` for 2+ min, manually re-request Copilot review. If that also fails, add label `copilot-review-bypass`. Full procedure: `docs/copilot-gate.md`.
+**After every push (including fix commits from Copilot review feedback):**
+1. Read Copilot review comments (`gh api 'repos/OWNER/REPO/pulls/N/comments'`), fix issues, commit and push.
+2. **Always** re-request Copilot review via GraphQL after push — it does NOT auto-trigger:
+   ```bash
+   PR_NODE_ID=$(gh api repos/umyunsang/KOSMOS/pulls/<N> --jq '.node_id')
+   gh api graphql -f query='mutation($input: RequestReviewsByLoginInput!) { requestReviewsByLogin(input: $input) { pullRequest { id } } }' \
+     -F "input[pullRequestId]=$PR_NODE_ID" -F 'input[botLogins][]=copilot-pull-request-reviewer[bot]' -F 'input[union]:=true'
+   ```
+3. If gate stays `pending`/`in_progress` for 2+ min after re-request, add label `copilot-review-bypass`.
+4. `requestReviewsByLogin` has **~1/3 failure rate** — retry once before resorting to bypass label.
+
+Full procedure: `docs/copilot-gate.md`.
 
 ## New tool adapter
 

--- a/src/kosmos/engine/query.py
+++ b/src/kosmos/engine/query.py
@@ -269,12 +269,20 @@ async def query(ctx: QueryContext) -> AsyncIterator[QueryEvent]:  # noqa: C901
         except StreamInterruptedError as exc:
             stream_interrupted_count += 1
             if stream_interrupted_count == 1:
-                # First interruption: retry the stream once
+                # First interruption: retry the stream once.
+                # If partial content was already yielded to the consumer,
+                # emit a visible restart signal so the output clearly
+                # separates stale fragments from the fresh retry.
                 logger.warning(
                     "LLM stream interrupted (attempt %d), retrying: %s",
                     stream_interrupted_count,
                     exc,
                 )
+                if content_parts:
+                    yield QueryEvent(
+                        type="text_delta",
+                        content="\n[stream interrupted — retrying]\n",
+                    )
                 continue
             # Second interruption: unrecoverable
             logger.error(

--- a/src/kosmos/engine/query.py
+++ b/src/kosmos/engine/query.py
@@ -299,6 +299,11 @@ async def query(ctx: QueryContext) -> AsyncIterator[QueryEvent]:  # noqa: C901
             )
             return
 
+        # Reset per-iteration retry counter so each new iteration gets its own
+        # single-retry budget.  A successful stream clears any previous
+        # interruption count; the counter only matters within a single attempt.
+        stream_interrupted_count = 0
+
         # --- Assemble assistant message and append to history ---
         assembled_calls = _assemble_tool_calls(pending_calls) if pending_calls else []
         assistant_content = "".join(content_parts) or None

--- a/src/kosmos/engine/query.py
+++ b/src/kosmos/engine/query.py
@@ -20,7 +20,7 @@ from kosmos.engine.events import QueryEvent, StopReason
 from kosmos.engine.models import QueryContext
 from kosmos.engine.preprocessing import PreprocessingPipeline
 from kosmos.engine.tokens import estimate_tokens
-from kosmos.llm.errors import BudgetExceededError
+from kosmos.llm.errors import BudgetExceededError, StreamInterruptedError
 from kosmos.llm.models import ChatMessage, FunctionCall, ToolCall, ToolDefinition
 from kosmos.tools.errors import ToolNotFoundError
 from kosmos.tools.executor import ToolExecutor
@@ -200,6 +200,7 @@ async def query(ctx: QueryContext) -> AsyncIterator[QueryEvent]:  # noqa: C901
         QueryEvent stream as described above.
     """
     iteration = 0
+    stream_interrupted_count = 0
     pipeline = PreprocessingPipeline()
 
     while iteration < ctx.config.max_iterations:
@@ -263,6 +264,28 @@ async def query(ctx: QueryContext) -> AsyncIterator[QueryEvent]:  # noqa: C901
                 type="stop",
                 stop_reason=StopReason.api_budget_exceeded,
                 stop_message="Token budget exceeded during stream",
+            )
+            return
+        except StreamInterruptedError as exc:
+            stream_interrupted_count += 1
+            if stream_interrupted_count == 1:
+                # First interruption: retry the stream once
+                logger.warning(
+                    "LLM stream interrupted (attempt %d), retrying: %s",
+                    stream_interrupted_count,
+                    exc,
+                )
+                continue
+            # Second interruption: unrecoverable
+            logger.error(
+                "LLM stream interrupted again (attempt %d), giving up: %s",
+                stream_interrupted_count,
+                exc,
+            )
+            yield QueryEvent(
+                type="stop",
+                stop_reason=StopReason.error_unrecoverable,
+                stop_message=f"LLM stream interrupted: {exc}",
             )
             return
         except asyncio.CancelledError:

--- a/src/kosmos/recovery/__init__.py
+++ b/src/kosmos/recovery/__init__.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KOSMOS Layer 6 — Error Recovery package.
+
+Public API for the error-recovery sub-system that wraps data.go.kr tool
+adapter calls with retry, circuit-breaker, and cache-fallback logic.
+"""
+
+from kosmos.recovery.cache import CacheEntry, ResponseCache
+from kosmos.recovery.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerRegistry,
+    CircuitState,
+)
+from kosmos.recovery.classifier import (
+    ClassifiedError,
+    DataGoKrErrorClassifier,
+    DataGoKrErrorCode,
+    ErrorClass,
+)
+from kosmos.recovery.executor import ErrorContext, RecoveryExecutor, RecoveryResult
+from kosmos.recovery.messages import build_degradation_message
+from kosmos.recovery.retry import ToolRetryPolicy, retry_tool_call
+
+__all__ = [
+    # cache
+    "CacheEntry",
+    "ResponseCache",
+    # circuit_breaker
+    "CircuitBreaker",
+    "CircuitBreakerConfig",
+    "CircuitBreakerRegistry",
+    "CircuitState",
+    # classifier
+    "ClassifiedError",
+    "DataGoKrErrorClassifier",
+    "DataGoKrErrorCode",
+    "ErrorClass",
+    # executor
+    "ErrorContext",
+    "RecoveryExecutor",
+    "RecoveryResult",
+    # messages
+    "build_degradation_message",
+    # retry
+    "ToolRetryPolicy",
+    "retry_tool_call",
+]

--- a/src/kosmos/recovery/cache.py
+++ b/src/kosmos/recovery/cache.py
@@ -78,9 +78,9 @@ class ResponseCache:
     def get(self, tool_id: str, arguments_hash: str) -> dict[str, object] | None:
         """Retrieve a cached response if it exists and has not expired.
 
-        Expired entries are removed from the store so the LRU capacity remains
-        accurate.  Use get_stale() when you want to read an expired entry
-        without deleting it (e.g. for a stale-cache fallback).
+        Expired entries are **not** deleted so that ``get_stale()`` can still
+        return them as a fallback after a failed live API call.  LRU eviction
+        in ``put()`` naturally reclaims capacity over time.
 
         Args:
             tool_id: Tool identifier.
@@ -101,7 +101,6 @@ class ResponseCache:
         age = time.monotonic() - entry.cached_at
         if age > entry.ttl_seconds:
             logger.debug("Cache entry expired for tool=%s (age=%.1fs)", tool_id, age)
-            del self._store[key]
             return None
 
         # Move to end (most-recently used)

--- a/src/kosmos/recovery/cache.py
+++ b/src/kosmos/recovery/cache.py
@@ -35,7 +35,11 @@ class CacheEntry(BaseModel):
     """The cached response data."""
 
     cached_at: float
-    """Unix timestamp (from ``time.monotonic`` epoch offset) when the entry was stored."""
+    """Monotonic clock value (time.monotonic()) at which the entry was stored.
+
+    This is *not* a wall-clock Unix timestamp; comparisons must use
+    time.monotonic() as the reference.
+    """
 
     ttl_seconds: int
     """Cache lifetime in seconds; 0 means this entry should never be used."""
@@ -44,15 +48,14 @@ class CacheEntry(BaseModel):
 class ResponseCache:
     """Bounded LRU in-memory cache for tool responses.
 
-    Uses ``collections.OrderedDict`` to implement LRU eviction:
-    - On every ``get`` hit the entry is moved to the end (most-recent).
-    - On ``put`` when the cache is full the front entry (least-recent) is evicted.
+    Uses collections.OrderedDict to implement LRU eviction:
+    - On every get hit the entry is moved to the end (most-recent).
+    - On put when the cache is full the front entry (least-recent) is evicted.
     """
 
     def __init__(self, max_entries: int = _DEFAULT_MAX_ENTRIES) -> None:
         self._max = max_entries
         self._store: OrderedDict[str, CacheEntry] = OrderedDict()
-        self._base_time = time.time() - time.monotonic()  # wall-clock offset
 
     # ------------------------------------------------------------------
     # Public API
@@ -75,12 +78,16 @@ class ResponseCache:
     def get(self, tool_id: str, arguments_hash: str) -> dict[str, object] | None:
         """Retrieve a cached response if it exists and has not expired.
 
+        Expired entries are removed from the store so the LRU capacity remains
+        accurate.  Use get_stale() when you want to read an expired entry
+        without deleting it (e.g. for a stale-cache fallback).
+
         Args:
             tool_id: Tool identifier.
-            arguments_hash: SHA-256 hash of the arguments (from ``compute_hash``).
+            arguments_hash: SHA-256 hash of the arguments (from compute_hash).
 
         Returns:
-            The cached data dict, or ``None`` if missing or expired.
+            The cached data dict, or None if missing or expired.
         """
         key = self._make_key(tool_id, arguments_hash)
         entry = self._store.get(key)
@@ -102,6 +109,36 @@ class ResponseCache:
         logger.debug("Cache hit for tool=%s (age=%.1fs)", tool_id, age)
         return dict(entry.data)
 
+    def get_stale(self, tool_id: str, arguments_hash: str) -> dict[str, object] | None:
+        """Retrieve a cached response regardless of expiry, without deleting it.
+
+        This method is intended for the stale-cache fallback path: when a live
+        API call has failed, an expired entry is still better than no data.
+        Unlike get(), this method does **not** delete the entry if it has
+        expired, so the stale data remains available for subsequent fallback
+        calls within the same session.
+
+        Args:
+            tool_id: Tool identifier.
+            arguments_hash: SHA-256 hash of the arguments (from compute_hash).
+
+        Returns:
+            The cached data dict (fresh or stale), or None if no entry
+            exists or the TTL is 0.
+        """
+        key = self._make_key(tool_id, arguments_hash)
+        entry = self._store.get(key)
+        if entry is None or entry.ttl_seconds == 0:
+            return None
+        age = time.monotonic() - entry.cached_at
+        logger.debug(
+            "Stale cache read for tool=%s (age=%.1fs, ttl=%ds)",
+            tool_id,
+            age,
+            entry.ttl_seconds,
+        )
+        return dict(entry.data)
+
     def put(
         self,
         tool_id: str,
@@ -111,7 +148,7 @@ class ResponseCache:
     ) -> None:
         """Store a response in the cache.
 
-        Entries with ``ttl_seconds=0`` are silently discarded (fail-closed).
+        Entries with ttl_seconds=0 are silently discarded (fail-closed).
 
         Args:
             tool_id: Tool identifier.

--- a/src/kosmos/recovery/cache.py
+++ b/src/kosmos/recovery/cache.py
@@ -1,0 +1,147 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Response cache for tool adapter results.
+
+Provides a bounded LRU in-memory cache keyed on (tool_id, sha256(arguments)).
+A TTL of 0 means "no caching" (fail-closed default per Constitution § II).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import time
+from collections import OrderedDict
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_MAX_ENTRIES: int = 256
+
+
+class CacheEntry(BaseModel):
+    """A single cached response entry."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_id: str
+    """Identifier of the tool whose response is cached."""
+
+    arguments_hash: str
+    """SHA-256 hex digest of the serialized input arguments."""
+
+    data: dict[str, object]
+    """The cached response data."""
+
+    cached_at: float
+    """Unix timestamp (from ``time.monotonic`` epoch offset) when the entry was stored."""
+
+    ttl_seconds: int
+    """Cache lifetime in seconds; 0 means this entry should never be used."""
+
+
+class ResponseCache:
+    """Bounded LRU in-memory cache for tool responses.
+
+    Uses ``collections.OrderedDict`` to implement LRU eviction:
+    - On every ``get`` hit the entry is moved to the end (most-recent).
+    - On ``put`` when the cache is full the front entry (least-recent) is evicted.
+    """
+
+    def __init__(self, max_entries: int = _DEFAULT_MAX_ENTRIES) -> None:
+        self._max = max_entries
+        self._store: OrderedDict[str, CacheEntry] = OrderedDict()
+        self._base_time = time.time() - time.monotonic()  # wall-clock offset
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def compute_hash(self, arguments: dict[str, object]) -> str:
+        """Compute a deterministic SHA-256 hash of *arguments*.
+
+        Keys are sorted to ensure hash stability regardless of insertion order.
+
+        Args:
+            arguments: Arbitrary JSON-serialisable dict of tool arguments.
+
+        Returns:
+            Lowercase hex-encoded SHA-256 digest.
+        """
+        serialized = json.dumps(arguments, sort_keys=True, ensure_ascii=False)
+        return hashlib.sha256(serialized.encode()).hexdigest()
+
+    def get(self, tool_id: str, arguments_hash: str) -> dict[str, object] | None:
+        """Retrieve a cached response if it exists and has not expired.
+
+        Args:
+            tool_id: Tool identifier.
+            arguments_hash: SHA-256 hash of the arguments (from ``compute_hash``).
+
+        Returns:
+            The cached data dict, or ``None`` if missing or expired.
+        """
+        key = self._make_key(tool_id, arguments_hash)
+        entry = self._store.get(key)
+        if entry is None:
+            return None
+
+        if entry.ttl_seconds == 0:
+            # Should not be stored but guard defensively
+            return None
+
+        age = time.monotonic() - entry.cached_at
+        if age > entry.ttl_seconds:
+            logger.debug("Cache entry expired for tool=%s (age=%.1fs)", tool_id, age)
+            del self._store[key]
+            return None
+
+        # Move to end (most-recently used)
+        self._store.move_to_end(key)
+        logger.debug("Cache hit for tool=%s (age=%.1fs)", tool_id, age)
+        return dict(entry.data)
+
+    def put(
+        self,
+        tool_id: str,
+        arguments_hash: str,
+        data: dict[str, object],
+        ttl_seconds: int,
+    ) -> None:
+        """Store a response in the cache.
+
+        Entries with ``ttl_seconds=0`` are silently discarded (fail-closed).
+
+        Args:
+            tool_id: Tool identifier.
+            arguments_hash: SHA-256 hash of the arguments.
+            data: Response data to cache.
+            ttl_seconds: Lifetime in seconds; 0 disables caching.
+        """
+        if ttl_seconds == 0:
+            return  # fail-closed: do not cache when TTL is 0
+
+        key = self._make_key(tool_id, arguments_hash)
+        entry = CacheEntry(
+            tool_id=tool_id,
+            arguments_hash=arguments_hash,
+            data=data,
+            cached_at=time.monotonic(),
+            ttl_seconds=ttl_seconds,
+        )
+        self._store[key] = entry
+        self._store.move_to_end(key)
+
+        # Evict LRU entries if over capacity
+        while len(self._store) > self._max:
+            evicted_key, _ = self._store.popitem(last=False)
+            logger.debug("Cache LRU eviction: %s", evicted_key)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _make_key(tool_id: str, arguments_hash: str) -> str:
+        return f"{tool_id}:{arguments_hash}"

--- a/src/kosmos/recovery/circuit_breaker.py
+++ b/src/kosmos/recovery/circuit_breaker.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Circuit breaker pattern for tool adapter protection.
+
+Implements the standard three-state circuit breaker:
+CLOSED → (failure threshold) → OPEN → (recovery timeout) → HALF_OPEN
+HALF_OPEN → (success) → CLOSED
+HALF_OPEN → (failure) → OPEN
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class CircuitState(StrEnum):
+    """State of a circuit breaker."""
+
+    CLOSED = "closed"
+    """Normal operation; all requests pass through."""
+
+    OPEN = "open"
+    """Circuit tripped; all requests are blocked immediately."""
+
+    HALF_OPEN = "half_open"
+    """Probe mode; a limited number of requests are allowed through."""
+
+
+class CircuitBreakerConfig(BaseModel):
+    """Configuration for a single circuit breaker instance."""
+
+    model_config = ConfigDict(frozen=True)
+
+    failure_threshold: int = 5
+    """Number of consecutive failures before the circuit opens."""
+
+    recovery_timeout: float = 30.0
+    """Seconds after opening before transitioning to HALF_OPEN."""
+
+    half_open_max_calls: int = 1
+    """Maximum probe calls allowed while in HALF_OPEN state."""
+
+
+class CircuitBreaker:
+    """Stateful circuit breaker for a single tool.
+
+    Thread/coroutine safety: Python's GIL makes simple attribute updates atomic
+    for CPython, but callers running multiple coroutines concurrently should be
+    aware that ``allow_request`` / ``record_*`` are not atomic as a pair.
+    """
+
+    def __init__(self, tool_id: str, config: CircuitBreakerConfig | None = None) -> None:
+        self._tool_id = tool_id
+        self._config = config or CircuitBreakerConfig()
+        self._state: CircuitState = CircuitState.CLOSED
+        self._failure_count: int = 0
+        self._opened_at: float = 0.0
+        self._half_open_calls: int = 0
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    @property
+    def state(self) -> CircuitState:
+        """Current circuit state (may transition OPEN→HALF_OPEN on read)."""
+        self._check_recovery()
+        return self._state
+
+    def allow_request(self) -> bool:
+        """Return ``True`` if a new request should be allowed through.
+
+        Side-effects:
+        - Transitions OPEN → HALF_OPEN when recovery_timeout has elapsed.
+        - Increments the half-open call counter.
+        """
+        self._check_recovery()
+
+        if self._state == CircuitState.CLOSED:
+            return True
+
+        if self._state == CircuitState.OPEN:
+            logger.debug("Circuit OPEN for tool %s — request blocked", self._tool_id)
+            return False
+
+        # HALF_OPEN
+        if self._half_open_calls < self._config.half_open_max_calls:
+            self._half_open_calls += 1
+            logger.debug(
+                "Circuit HALF_OPEN for tool %s — probe call %d/%d",
+                self._tool_id,
+                self._half_open_calls,
+                self._config.half_open_max_calls,
+            )
+            return True
+
+        logger.debug(
+            "Circuit HALF_OPEN for tool %s — max probe calls reached, blocking",
+            self._tool_id,
+        )
+        return False
+
+    def record_success(self) -> None:
+        """Record a successful call; resets failure count and closes circuit if HALF_OPEN."""
+        if self._state == CircuitState.HALF_OPEN:
+            logger.info("Circuit HALF_OPEN → CLOSED for tool %s (probe succeeded)", self._tool_id)
+            self._transition_to_closed()
+        elif self._state == CircuitState.CLOSED:
+            self._failure_count = 0
+
+    def record_failure(self) -> None:
+        """Record a failed call; opens the circuit when the threshold is reached."""
+        if self._state == CircuitState.HALF_OPEN:
+            logger.warning("Circuit HALF_OPEN → OPEN for tool %s (probe failed)", self._tool_id)
+            self._transition_to_open()
+            return
+
+        if self._state == CircuitState.OPEN:
+            return  # already open
+
+        # CLOSED
+        self._failure_count += 1
+        if self._failure_count >= self._config.failure_threshold:
+            logger.warning(
+                "Circuit CLOSED → OPEN for tool %s after %d failures",
+                self._tool_id,
+                self._failure_count,
+            )
+            self._transition_to_open()
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _check_recovery(self) -> None:
+        """Transition OPEN → HALF_OPEN if the recovery timeout has elapsed."""
+        if self._state == CircuitState.OPEN:
+            elapsed = time.monotonic() - self._opened_at
+            if elapsed >= self._config.recovery_timeout:
+                logger.info(
+                    "Circuit OPEN → HALF_OPEN for tool %s after %.1fs",
+                    self._tool_id,
+                    elapsed,
+                )
+                self._state = CircuitState.HALF_OPEN
+                self._half_open_calls = 0
+
+    def _transition_to_open(self) -> None:
+        self._state = CircuitState.OPEN
+        self._opened_at = time.monotonic()
+        self._failure_count = 0
+        self._half_open_calls = 0
+
+    def _transition_to_closed(self) -> None:
+        self._state = CircuitState.CLOSED
+        self._failure_count = 0
+        self._half_open_calls = 0
+
+
+class CircuitBreakerRegistry:
+    """Lazy per-tool CircuitBreaker registry.
+
+    Creates a new ``CircuitBreaker`` on first access for each *tool_id*.
+    The default config is used unless a specific config is provided at
+    construction time.
+    """
+
+    def __init__(self, default_config: CircuitBreakerConfig | None = None) -> None:
+        self._default_config = default_config or CircuitBreakerConfig()
+        self._breakers: dict[str, CircuitBreaker] = {}
+
+    def get(self, tool_id: str) -> CircuitBreaker:
+        """Return the ``CircuitBreaker`` for *tool_id*, creating it if needed."""
+        if tool_id not in self._breakers:
+            self._breakers[tool_id] = CircuitBreaker(tool_id, self._default_config)
+            logger.debug("Created circuit breaker for tool %s", tool_id)
+        return self._breakers[tool_id]

--- a/src/kosmos/recovery/classifier.py
+++ b/src/kosmos/recovery/classifier.py
@@ -172,9 +172,7 @@ class DataGoKrErrorClassifier:
                 result_code = self._extract_result_code(parsed)
                 if result_code is not None:
                     result_msg = self._extract_result_msg(parsed)
-                    return self._classify_by_code(
-                        result_code, result_msg, source="data_go_kr_json"
-                    )
+                    return self._classify_by_code(result_code, result_msg, source="data_go_kr_json")
             except (json.JSONDecodeError, TypeError, KeyError, ValueError):
                 logger.debug("Failed to parse JSON body for error classification")
 

--- a/src/kosmos/recovery/classifier.py
+++ b/src/kosmos/recovery/classifier.py
@@ -1,0 +1,308 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Error classifier for data.go.kr API responses.
+
+Translates raw HTTP status codes, response bodies, and exceptions into
+a normalized ``ClassifiedError`` for the recovery pipeline.
+
+NFR-006: No XML parser dependency — gateway XML errors are detected with
+plain string operations only.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from enum import IntEnum, StrEnum
+
+import httpx
+from pydantic import BaseModel, ConfigDict
+
+logger = logging.getLogger(__name__)
+
+
+class DataGoKrErrorCode(IntEnum):
+    """Numeric return codes used by the data.go.kr Open API gateway."""
+
+    NORMAL_CODE = 0
+    APPLICATION_ERROR = 1
+    DB_ERROR = 2
+    NO_DATA = 3
+    HTTP_ERROR = 4
+    SERVICE_TIMEOUT = 5
+    INVALID_REQUEST_PARAMETER = 10
+    NO_REQUIRED_REQUEST_PARAMETER = 11
+    SERVICE_NOT_FOUND = 20
+    TEMPORARILY_DISABLED = 22
+    LIMIT_NUMBER_OF_SERVICE_REQUESTS_EXCEEDED = 30
+    SERVICE_KEY_NOT_REGISTERED = 31
+    DEADLINE_HAS_EXPIRED = 32
+    UNREGISTERED_IP = 33
+    UNKNOWN_ERROR = 99
+
+
+class ErrorClass(StrEnum):
+    """Normalized error classification for the recovery pipeline."""
+
+    TRANSIENT = "transient"
+    """Temporary server-side failure; safe to retry."""
+
+    RATE_LIMIT = "rate_limit"
+    """Request quota exceeded; retry after back-off."""
+
+    AUTH_FAILURE = "auth_failure"
+    """Authentication/authorization failure; do not retry."""
+
+    DATA_MISSING = "data_missing"
+    """No data available for the request parameters; do not retry."""
+
+    INVALID_REQUEST = "invalid_request"
+    """Bad request parameters; do not retry."""
+
+    TIMEOUT = "timeout"
+    """Network or service timeout; safe to retry."""
+
+    DEPRECATED = "deprecated"
+    """Service has been removed or moved; do not retry."""
+
+    APP_ERROR = "app_error"
+    """Application-level error; do not retry."""
+
+    UNKNOWN = "unknown"
+    """Unrecognized error; do not retry (fail-closed)."""
+
+
+# ---------------------------------------------------------------------------
+# Retryable error classes
+# ---------------------------------------------------------------------------
+
+_RETRYABLE: frozenset[ErrorClass] = frozenset(
+    {ErrorClass.TRANSIENT, ErrorClass.RATE_LIMIT, ErrorClass.TIMEOUT}
+)
+
+# ---------------------------------------------------------------------------
+# Mapping from DataGoKrErrorCode → ErrorClass
+# ---------------------------------------------------------------------------
+
+_CODE_TO_CLASS: dict[int, ErrorClass] = {
+    DataGoKrErrorCode.NORMAL_CODE: ErrorClass.UNKNOWN,  # should not appear on failure path
+    DataGoKrErrorCode.APPLICATION_ERROR: ErrorClass.APP_ERROR,
+    DataGoKrErrorCode.DB_ERROR: ErrorClass.TRANSIENT,
+    DataGoKrErrorCode.NO_DATA: ErrorClass.DATA_MISSING,
+    DataGoKrErrorCode.HTTP_ERROR: ErrorClass.TRANSIENT,
+    DataGoKrErrorCode.SERVICE_TIMEOUT: ErrorClass.TRANSIENT,
+    DataGoKrErrorCode.INVALID_REQUEST_PARAMETER: ErrorClass.INVALID_REQUEST,
+    DataGoKrErrorCode.NO_REQUIRED_REQUEST_PARAMETER: ErrorClass.INVALID_REQUEST,
+    DataGoKrErrorCode.SERVICE_NOT_FOUND: ErrorClass.DEPRECATED,
+    DataGoKrErrorCode.TEMPORARILY_DISABLED: ErrorClass.DEPRECATED,
+    DataGoKrErrorCode.LIMIT_NUMBER_OF_SERVICE_REQUESTS_EXCEEDED: ErrorClass.RATE_LIMIT,
+    DataGoKrErrorCode.SERVICE_KEY_NOT_REGISTERED: ErrorClass.AUTH_FAILURE,
+    DataGoKrErrorCode.DEADLINE_HAS_EXPIRED: ErrorClass.AUTH_FAILURE,
+    DataGoKrErrorCode.UNREGISTERED_IP: ErrorClass.AUTH_FAILURE,
+    DataGoKrErrorCode.UNKNOWN_ERROR: ErrorClass.UNKNOWN,
+}
+
+
+class ClassifiedError(BaseModel):
+    """Normalized representation of a classified API error."""
+
+    model_config = ConfigDict(frozen=True)
+
+    error_class: ErrorClass
+    """High-level error category."""
+
+    is_retryable: bool
+    """Whether the recovery pipeline should retry this error."""
+
+    raw_code: int | None = None
+    """Original numeric error code from the gateway, if available."""
+
+    raw_message: str = ""
+    """Human-readable error description from the source."""
+
+    source: str = ""
+    """Origin of the error (e.g. ``"xml_gateway"``, ``"json_body"``, ``"http_status"``,
+    ``"exception"``)."""
+
+
+class DataGoKrErrorClassifier:
+    """Classify errors from data.go.kr API responses and Python exceptions.
+
+    The classifier is stateless and all methods are pure functions; it is safe
+    to reuse a single instance across concurrent coroutines.
+    """
+
+    # XML gateway response prefix (NFR-006: string-only, no XML parser)
+    _XML_GATEWAY_PREFIX: str = "<OpenAPI_ServiceResponse>"
+
+    # XML tag markers for code extraction
+    _XML_CODE_START: str = "<returnReasonCode>"
+    _XML_CODE_END: str = "</returnReasonCode>"
+    _XML_MSG_START: str = "<returnAuthMsg>"
+    _XML_MSG_END: str = "</returnAuthMsg>"
+
+    def classify_response(
+        self,
+        status_code: int,
+        body: str,
+        content_type: str = "",
+    ) -> ClassifiedError:
+        """Classify an HTTP response from the data.go.kr gateway.
+
+        Detection order:
+        1. XML gateway error (HTTP 200 with XML body despite requesting JSON).
+        2. JSON ``resultCode`` field.
+        3. HTTP status code.
+
+        Args:
+            status_code: HTTP response status code.
+            body: Response body as a decoded string.
+            content_type: Value of the Content-Type header (may be empty).
+
+        Returns:
+            A ``ClassifiedError`` describing the error class and retryability.
+        """
+        # --- 1. XML gateway detection (NFR-006: no XML parser) ---
+        if body.startswith(self._XML_GATEWAY_PREFIX):
+            return self._classify_xml_gateway(body)
+
+        # --- 2. JSON body with resultCode ---
+        if "resultCode" in body:
+            try:
+                parsed = json.loads(body)
+                result_code = self._extract_result_code(parsed)
+                if result_code is not None:
+                    return self._classify_by_code(result_code, body, source="json_body")
+            except (json.JSONDecodeError, TypeError, KeyError, ValueError):
+                logger.debug("Failed to parse JSON body for error classification")
+
+        # --- 3. HTTP status code fallback ---
+        return self._classify_by_http_status(status_code, body)
+
+    def classify_exception(self, exc: BaseException) -> ClassifiedError:
+        """Classify a Python exception raised during an API call.
+
+        Args:
+            exc: The exception to classify.
+
+        Returns:
+            A ``ClassifiedError`` describing the error class and retryability.
+        """
+        if isinstance(exc, (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.PoolTimeout)):
+            return ClassifiedError(
+                error_class=ErrorClass.TIMEOUT,
+                is_retryable=True,
+                raw_code=None,
+                raw_message=str(exc),
+                source="exception",
+            )
+
+        if isinstance(exc, httpx.TimeoutException):
+            return ClassifiedError(
+                error_class=ErrorClass.TIMEOUT,
+                is_retryable=True,
+                raw_code=None,
+                raw_message=str(exc),
+                source="exception",
+            )
+
+        if isinstance(exc, httpx.HTTPStatusError):
+            return self._classify_by_http_status(exc.response.status_code, str(exc))
+
+        return ClassifiedError(
+            error_class=ErrorClass.APP_ERROR,
+            is_retryable=False,
+            raw_code=None,
+            raw_message=str(exc),
+            source="exception",
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _classify_xml_gateway(self, body: str) -> ClassifiedError:
+        """Extract return code from an XML gateway response without a parser."""
+        raw_code: int | None = None
+        raw_message: str = "XML gateway error"
+
+        code_start = body.find(self._XML_CODE_START)
+        if code_start != -1:
+            code_start += len(self._XML_CODE_START)
+            code_end = body.find(self._XML_CODE_END, code_start)
+            if code_end != -1:
+                code_str = body[code_start:code_end].strip()
+                try:
+                    raw_code = int(code_str)
+                except ValueError:
+                    logger.debug("Could not parse XML gateway returnReasonCode: %r", code_str)
+
+        msg_start = body.find(self._XML_MSG_START)
+        if msg_start != -1:
+            msg_start += len(self._XML_MSG_START)
+            msg_end = body.find(self._XML_MSG_END, msg_start)
+            if msg_end != -1:
+                raw_message = body[msg_start:msg_end].strip()
+
+        if raw_code is not None:
+            return self._classify_by_code(raw_code, raw_message, source="xml_gateway")
+
+        return ClassifiedError(
+            error_class=ErrorClass.UNKNOWN,
+            is_retryable=False,
+            raw_code=None,
+            raw_message=raw_message,
+            source="xml_gateway",
+        )
+
+    def _extract_result_code(self, parsed: object) -> int | None:
+        """Recursively find resultCode in nested JSON structures."""
+        if isinstance(parsed, dict):
+            if "resultCode" in parsed:
+                val = parsed["resultCode"]
+                if isinstance(val, int):
+                    return val
+                if isinstance(val, str) and val.isdigit():
+                    return int(val)
+            # Try nested structures (data.go.kr wraps in response/header)
+            for key in ("response", "header", "OpenAPI_ServiceResponse"):
+                if key in parsed:
+                    result = self._extract_result_code(parsed[key])
+                    if result is not None:
+                        return result
+        return None
+
+    def _classify_by_code(self, code: int, message: str, *, source: str) -> ClassifiedError:
+        """Map a numeric gateway code to an ErrorClass."""
+        error_class = _CODE_TO_CLASS.get(code, ErrorClass.UNKNOWN)
+        return ClassifiedError(
+            error_class=error_class,
+            is_retryable=error_class in _RETRYABLE,
+            raw_code=code,
+            raw_message=message,
+            source=source,
+        )
+
+    def _classify_by_http_status(self, status_code: int, message: str) -> ClassifiedError:
+        """Classify based purely on HTTP status code."""
+        if status_code == 429:
+            error_class = ErrorClass.RATE_LIMIT
+        elif status_code in (401, 403):
+            error_class = ErrorClass.AUTH_FAILURE
+        elif status_code in (502, 503, 504):
+            error_class = ErrorClass.TRANSIENT
+        elif status_code == 400:
+            error_class = ErrorClass.INVALID_REQUEST
+        elif status_code == 404:
+            error_class = ErrorClass.DATA_MISSING
+        elif status_code == 500:
+            error_class = ErrorClass.APP_ERROR
+        else:
+            error_class = ErrorClass.UNKNOWN
+
+        return ClassifiedError(
+            error_class=error_class,
+            is_retryable=error_class in _RETRYABLE,
+            raw_code=status_code,
+            raw_message=message,
+            source="http_status",
+        )

--- a/src/kosmos/recovery/classifier.py
+++ b/src/kosmos/recovery/classifier.py
@@ -120,8 +120,8 @@ class ClassifiedError(BaseModel):
     """Human-readable error description from the source."""
 
     source: str = ""
-    """Origin of the error (e.g. ``"xml_gateway"``, ``"json_body"``, ``"http_status"``,
-    ``"exception"``)."""
+    """Origin of the error (e.g. ``"data_go_kr_xml"``, ``"data_go_kr_json"``,
+    ``"http_status"``, ``"transport"``, ``"unknown"``)."""
 
 
 class DataGoKrErrorClassifier:
@@ -144,7 +144,7 @@ class DataGoKrErrorClassifier:
         self,
         status_code: int,
         body: str,
-        content_type: str = "",
+        content_type: str | None = None,
     ) -> ClassifiedError:
         """Classify an HTTP response from the data.go.kr gateway.
 
@@ -156,7 +156,7 @@ class DataGoKrErrorClassifier:
         Args:
             status_code: HTTP response status code.
             body: Response body as a decoded string.
-            content_type: Value of the Content-Type header (may be empty).
+            content_type: Value of the Content-Type header (may be None or empty).
 
         Returns:
             A ``ClassifiedError`` describing the error class and retryability.
@@ -171,14 +171,14 @@ class DataGoKrErrorClassifier:
                 parsed = json.loads(body)
                 result_code = self._extract_result_code(parsed)
                 if result_code is not None:
-                    return self._classify_by_code(result_code, body, source="json_body")
+                    return self._classify_by_code(result_code, body, source="data_go_kr_json")
             except (json.JSONDecodeError, TypeError, KeyError, ValueError):
                 logger.debug("Failed to parse JSON body for error classification")
 
         # --- 3. HTTP status code fallback ---
         return self._classify_by_http_status(status_code, body)
 
-    def classify_exception(self, exc: BaseException) -> ClassifiedError:
+    def classify_exception(self, exc: Exception) -> ClassifiedError:
         """Classify a Python exception raised during an API call.
 
         Args:
@@ -187,13 +187,13 @@ class DataGoKrErrorClassifier:
         Returns:
             A ``ClassifiedError`` describing the error class and retryability.
         """
-        if isinstance(exc, (httpx.ConnectTimeout, httpx.ReadTimeout, httpx.PoolTimeout)):
+        if isinstance(exc, (httpx.ConnectTimeout, httpx.ReadTimeout)):
             return ClassifiedError(
                 error_class=ErrorClass.TIMEOUT,
                 is_retryable=True,
                 raw_code=None,
                 raw_message=str(exc),
-                source="exception",
+                source="transport",
             )
 
         if isinstance(exc, httpx.TimeoutException):
@@ -202,18 +202,26 @@ class DataGoKrErrorClassifier:
                 is_retryable=True,
                 raw_code=None,
                 raw_message=str(exc),
-                source="exception",
+                source="transport",
             )
 
         if isinstance(exc, httpx.HTTPStatusError):
-            return self._classify_by_http_status(exc.response.status_code, str(exc))
+            try:
+                content_type = exc.response.headers.get("content-type")
+                return self.classify_response(
+                    exc.response.status_code,
+                    exc.response.text,
+                    content_type,
+                )
+            except Exception:  # noqa: BLE001
+                return self._classify_by_http_status(exc.response.status_code, str(exc))
 
         return ClassifiedError(
             error_class=ErrorClass.APP_ERROR,
             is_retryable=False,
             raw_code=None,
             raw_message=str(exc),
-            source="exception",
+            source="unknown",
         )
 
     # ------------------------------------------------------------------
@@ -244,14 +252,14 @@ class DataGoKrErrorClassifier:
                 raw_message = body[msg_start:msg_end].strip()
 
         if raw_code is not None:
-            return self._classify_by_code(raw_code, raw_message, source="xml_gateway")
+            return self._classify_by_code(raw_code, raw_message, source="data_go_kr_xml")
 
         return ClassifiedError(
             error_class=ErrorClass.UNKNOWN,
             is_retryable=False,
             raw_code=None,
             raw_message=raw_message,
-            source="xml_gateway",
+            source="data_go_kr_xml",
         )
 
     def _extract_result_code(self, parsed: object) -> int | None:

--- a/src/kosmos/recovery/classifier.py
+++ b/src/kosmos/recovery/classifier.py
@@ -171,7 +171,10 @@ class DataGoKrErrorClassifier:
                 parsed = json.loads(body)
                 result_code = self._extract_result_code(parsed)
                 if result_code is not None:
-                    return self._classify_by_code(result_code, body, source="data_go_kr_json")
+                    result_msg = self._extract_result_msg(parsed)
+                    return self._classify_by_code(
+                        result_code, result_msg, source="data_go_kr_json"
+                    )
             except (json.JSONDecodeError, TypeError, KeyError, ValueError):
                 logger.debug("Failed to parse JSON body for error classification")
 
@@ -261,6 +264,21 @@ class DataGoKrErrorClassifier:
             raw_message=raw_message,
             source="data_go_kr_xml",
         )
+
+    def _extract_result_msg(self, parsed: object) -> str:
+        """Recursively find resultMsg in nested JSON structures.
+
+        Returns the message string, or an empty string if not found.
+        """
+        if isinstance(parsed, dict):
+            if "resultMsg" in parsed:
+                return str(parsed["resultMsg"])
+            for key in ("response", "header", "OpenAPI_ServiceResponse"):
+                if key in parsed:
+                    result = self._extract_result_msg(parsed[key])
+                    if result:
+                        return result
+        return ""
 
     def _extract_result_code(self, parsed: object) -> int | None:
         """Recursively find resultCode in nested JSON structures."""

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -1,0 +1,337 @@
+# SPDX-License-Identifier: Apache-2.0
+"""RecoveryExecutor — orchestrates retry, circuit breaker, and cache fallback.
+
+This module is the single integration point for Layer 6 error recovery.
+It wraps a tool adapter call with the full recovery pipeline:
+
+    1. Circuit breaker check (if open → degradation message immediately)
+    2. Cache lookup (if hit → return cached data)
+    3. Retry loop (exponential back-off with full jitter)
+    4. Cache store on success
+    5. Cache fallback on final failure (if stale data available)
+    6. Degradation message as last resort
+
+The ``RecoveryExecutor`` NEVER raises — all error paths are captured in the
+returned ``RecoveryResult``.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from collections.abc import Awaitable, Callable
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict
+
+from kosmos.recovery.cache import ResponseCache
+from kosmos.recovery.circuit_breaker import (
+    CircuitBreakerConfig,
+    CircuitBreakerRegistry,
+    CircuitState,
+)
+from kosmos.recovery.classifier import (
+    ClassifiedError,
+    DataGoKrErrorClassifier,
+    ErrorClass,
+)
+from kosmos.recovery.messages import build_degradation_message
+from kosmos.recovery.retry import ToolRetryPolicy, retry_tool_call
+from kosmos.tools.models import GovAPITool, ToolResult
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+AdapterFn = Callable[..., Awaitable[dict[str, object]]]
+
+
+# ---------------------------------------------------------------------------
+# Context models
+# ---------------------------------------------------------------------------
+
+
+class ErrorContext(BaseModel):
+    """Diagnostic information about the error recovery attempt."""
+
+    model_config = ConfigDict(frozen=True)
+
+    attempt_count: int
+    """Total number of adapter call attempts made."""
+
+    elapsed_seconds: float
+    """Wall-clock time spent in the recovery pipeline."""
+
+    error_class: ErrorClass | None
+    """Classified error class from the last failure, or ``None`` on success."""
+
+    is_cached_fallback: bool
+    """``True`` if the result data came from an expired/stale cache entry."""
+
+    circuit_state: CircuitState
+    """State of the circuit breaker at the time of the result."""
+
+    tool_id: str
+    """Identifier of the tool that was called."""
+
+
+class RecoveryResult(BaseModel):
+    """Outcome of a ``RecoveryExecutor.execute()`` call."""
+
+    model_config = ConfigDict(frozen=True)
+
+    tool_result: ToolResult
+    """The final ``ToolResult`` (may represent a degraded / cached response)."""
+
+    error_context: ErrorContext | None = None
+    """Recovery diagnostics; ``None`` on clean success."""
+
+
+# ---------------------------------------------------------------------------
+# RecoveryExecutor
+# ---------------------------------------------------------------------------
+
+
+class RecoveryExecutor:
+    """Orchestrate retry, circuit breaker, and cache fallback for tool calls.
+
+    All state (circuit breakers, cache) is held per ``RecoveryExecutor``
+    instance.  Typically one instance is shared across the application and
+    injected into ``ToolExecutor``.
+    """
+
+    def __init__(
+        self,
+        retry_policy: ToolRetryPolicy | None = None,
+        circuit_config: CircuitBreakerConfig | None = None,
+        max_cache_entries: int = 256,
+    ) -> None:
+        self._policy = retry_policy or ToolRetryPolicy()
+        self._classifier = DataGoKrErrorClassifier()
+        self._registry = CircuitBreakerRegistry(default_config=circuit_config)
+        self._cache = ResponseCache(max_entries=max_cache_entries)
+
+    # ------------------------------------------------------------------
+    # Public interface
+    # ------------------------------------------------------------------
+
+    async def execute(
+        self,
+        tool: GovAPITool,
+        adapter: AdapterFn,
+        validated_input: object,
+        *,
+        is_foreground: bool = True,
+    ) -> RecoveryResult:
+        """Execute *adapter* with full error-recovery orchestration.
+
+        Pipeline:
+        1. Circuit breaker check → immediate degradation if OPEN.
+        2. Cache lookup → return cached data if fresh.
+        3. Retry loop with exponential back-off.
+        4. On success: update circuit breaker + cache store.
+        5. On exhaustion: try stale cache fallback.
+        6. Last resort: return degradation message as a failed ToolResult.
+
+        Args:
+            tool: The GovAPITool being called (used for cache TTL and messages).
+            adapter: Async callable that performs the actual API call.
+            validated_input: Pre-validated Pydantic model instance to pass to adapter.
+            is_foreground: Whether this is a user-facing call (affects retry cap).
+
+        Returns:
+            A ``RecoveryResult`` that never represents an un-caught exception.
+        """
+        start = time.monotonic()
+        tool_id = tool.id
+        breaker = self._registry.get(tool_id)
+
+        # --- 1. Circuit breaker check ---
+        if not breaker.allow_request():
+            elapsed = time.monotonic() - start
+            circuit_open_error = ClassifiedError(
+                error_class=ErrorClass.APP_ERROR,
+                is_retryable=False,
+                raw_code=None,
+                raw_message="Circuit breaker is OPEN",
+                source="circuit_open",
+            )
+            degradation = build_degradation_message(tool, circuit_open_error)
+            logger.warning("Circuit breaker OPEN for tool %s — returning degradation", tool_id)
+            return RecoveryResult(
+                tool_result=ToolResult(
+                    tool_id=tool_id,
+                    success=False,
+                    error=degradation,
+                    error_type="circuit_open",
+                ),
+                error_context=ErrorContext(
+                    attempt_count=0,
+                    elapsed_seconds=elapsed,
+                    error_class=ErrorClass.APP_ERROR,
+                    is_cached_fallback=False,
+                    circuit_state=CircuitState.OPEN,
+                    tool_id=tool_id,
+                ),
+            )
+
+        # --- 2. Cache lookup ---
+        input_dict = self._model_to_dict(validated_input)
+        args_hash = self._cache.compute_hash(input_dict)
+        if tool.cache_ttl_seconds > 0:
+            cached = self._cache.get(tool_id, args_hash)
+            if cached is not None:
+                elapsed = time.monotonic() - start
+                logger.debug("Cache hit for tool %s", tool_id)
+                return RecoveryResult(
+                    tool_result=ToolResult(
+                        tool_id=tool_id,
+                        success=True,
+                        data=cached,
+                    ),
+                    error_context=None,
+                )
+
+        # --- 3. Retry loop ---
+        result_dict, last_error, attempt_count = await retry_tool_call(
+            adapter,
+            validated_input,
+            self._classifier,
+            self._policy,
+            is_foreground=is_foreground,
+        )
+
+        elapsed = time.monotonic() - start
+
+        # --- 4. Success path ---
+        if result_dict is not None:
+            breaker.record_success()
+            if tool.cache_ttl_seconds > 0:
+                self._cache.put(tool_id, args_hash, result_dict, tool.cache_ttl_seconds)
+            return RecoveryResult(
+                tool_result=ToolResult(
+                    tool_id=tool_id,
+                    success=True,
+                    data=result_dict,
+                ),
+                error_context=None,
+            )
+
+        # --- Failure: record to circuit breaker ---
+        breaker.record_failure()
+
+        # --- 5. Stale cache fallback (only if cache_ttl_seconds > 0) ---
+        if tool.cache_ttl_seconds > 0:
+            stale = self._get_stale_cache(tool_id, args_hash)
+            if stale is not None:
+                logger.warning(
+                    "Returning stale cache fallback for tool %s after %d attempt(s)",
+                    tool_id,
+                    attempt_count,
+                )
+                return RecoveryResult(
+                    tool_result=ToolResult(
+                        tool_id=tool_id,
+                        success=True,
+                        data=stale,
+                    ),
+                    error_context=ErrorContext(
+                        attempt_count=attempt_count,
+                        elapsed_seconds=elapsed,
+                        error_class=last_error.error_class if last_error else None,
+                        is_cached_fallback=True,
+                        circuit_state=breaker.state,
+                        tool_id=tool_id,
+                    ),
+                )
+
+        # --- 6. Degradation message ---
+        assert last_error is not None  # retry_tool_call guarantees this when result is None
+        degradation = build_degradation_message(tool, last_error)
+        error_type = self._error_class_to_error_type(last_error.error_class)
+        logger.error(
+            "Tool %s recovery exhausted after %d attempt(s): class=%s",
+            tool_id,
+            attempt_count,
+            last_error.error_class,
+        )
+        return RecoveryResult(
+            tool_result=ToolResult(
+                tool_id=tool_id,
+                success=False,
+                error=degradation,
+                error_type=error_type,
+            ),
+            error_context=ErrorContext(
+                attempt_count=attempt_count,
+                elapsed_seconds=elapsed,
+                error_class=last_error.error_class,
+                is_cached_fallback=False,
+                circuit_state=breaker.state,
+                tool_id=tool_id,
+            ),
+        )
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _model_to_dict(self, model: object) -> dict[str, object]:
+        """Convert a Pydantic model to a plain dict for cache key computation."""
+        from pydantic import BaseModel as _BaseModel  # local import to avoid circular
+
+        if isinstance(model, _BaseModel):
+            return dict(model.model_dump())
+        if isinstance(model, dict):
+            return model
+        return {}
+
+    def _get_stale_cache(self, tool_id: str, args_hash: str) -> dict[str, object] | None:
+        """Look up raw cache store for a stale (expired) entry."""
+        key = f"{tool_id}:{args_hash}"
+        entry = self._cache._store.get(key)  # noqa: SLF001
+        if entry is not None and entry.ttl_seconds > 0:
+            return dict(entry.data)
+        return None
+
+    @staticmethod
+    def _error_class_to_error_type(
+        error_class: ErrorClass,
+    ) -> Literal[
+        "validation",
+        "rate_limit",
+        "not_found",
+        "execution",
+        "schema_mismatch",
+        "permission_denied",
+        "timeout",
+        "circuit_open",
+        "api_error",
+        "auth_expired",
+    ]:
+        """Map ErrorClass to ToolResult.error_type literal string."""
+        mapping: dict[
+            ErrorClass,
+            Literal[
+                "validation",
+                "rate_limit",
+                "not_found",
+                "execution",
+                "timeout",
+                "api_error",
+                "auth_expired",
+            ],
+        ] = {
+            ErrorClass.TRANSIENT: "api_error",
+            ErrorClass.RATE_LIMIT: "rate_limit",
+            ErrorClass.AUTH_FAILURE: "auth_expired",
+            ErrorClass.DATA_MISSING: "not_found",
+            ErrorClass.INVALID_REQUEST: "validation",
+            ErrorClass.TIMEOUT: "timeout",
+            ErrorClass.DEPRECATED: "not_found",
+            ErrorClass.APP_ERROR: "execution",
+            ErrorClass.UNKNOWN: "api_error",
+        }
+        return mapping.get(error_class, "execution")

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -289,12 +289,8 @@ class RecoveryExecutor:
         return {}
 
     def _get_stale_cache(self, tool_id: str, args_hash: str) -> dict[str, object] | None:
-        """Look up raw cache store for a stale (expired) entry."""
-        key = f"{tool_id}:{args_hash}"
-        entry = self._cache._store.get(key)  # noqa: SLF001
-        if entry is not None and entry.ttl_seconds > 0:
-            return dict(entry.data)
-        return None
+        """Look up a stale (possibly expired) cache entry via the public API."""
+        return self._cache.get_stale(tool_id, args_hash)
 
     @staticmethod
     def _error_class_to_error_type(

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -220,8 +220,11 @@ class RecoveryExecutor:
                 error_context=None,
             )
 
-        # --- Failure: record to circuit breaker ---
-        breaker.record_failure()
+        # --- Failure: record to circuit breaker only for transient/retryable
+        #     errors.  Client errors (INVALID_REQUEST, AUTH_FAILURE, etc.) are
+        #     the caller's fault and should not count against service health. ---
+        if last_error is not None and last_error.is_retryable:
+            breaker.record_failure()
 
         # --- 5. Stale cache fallback (only if cache_ttl_seconds > 0) ---
         if tool.cache_ttl_seconds > 0:

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -4,8 +4,8 @@
 This module is the single integration point for Layer 6 error recovery.
 It wraps a tool adapter call with the full recovery pipeline:
 
-    1. Circuit breaker check (if open → degradation message immediately)
-    2. Cache lookup (if hit → return cached data)
+    1. Cache lookup (if hit → return cached data, no side-effects)
+    2. Circuit breaker check (if open → degradation message immediately)
     3. Retry loop (exponential back-off with full jitter)
     4. Cache store on success
     5. Cache fallback on final failure (if stale data available)
@@ -128,8 +128,8 @@ class RecoveryExecutor:
         """Execute *adapter* with full error-recovery orchestration.
 
         Pipeline:
-        1. Circuit breaker check → immediate degradation if OPEN.
-        2. Cache lookup → return cached data if fresh.
+        1. Cache lookup → return cached data if fresh (no side-effects).
+        2. Circuit breaker check → immediate degradation if OPEN.
         3. Retry loop with exponential back-off.
         4. On success: update circuit breaker + cache store.
         5. On exhaustion: try stale cache fallback.
@@ -148,7 +148,25 @@ class RecoveryExecutor:
         tool_id = tool.id
         breaker = self._registry.get(tool_id)
 
-        # --- 1. Circuit breaker check ---
+        # --- 1. Cache lookup (before circuit breaker to avoid wasting a
+        #     HALF_OPEN probe allowance on a cache hit) ---
+        input_dict = self._model_to_dict(validated_input)
+        args_hash = self._cache.compute_hash(input_dict)
+        if tool.cache_ttl_seconds > 0:
+            cached = self._cache.get(tool_id, args_hash)
+            if cached is not None:
+                elapsed = time.monotonic() - start
+                logger.debug("Cache hit for tool %s", tool_id)
+                return RecoveryResult(
+                    tool_result=ToolResult(
+                        tool_id=tool_id,
+                        success=True,
+                        data=cached,
+                    ),
+                    error_context=None,
+                )
+
+        # --- 2. Circuit breaker check ---
         if not breaker.allow_request():
             elapsed = time.monotonic() - start
             circuit_open_error = ClassifiedError(
@@ -176,23 +194,6 @@ class RecoveryExecutor:
                     tool_id=tool_id,
                 ),
             )
-
-        # --- 2. Cache lookup ---
-        input_dict = self._model_to_dict(validated_input)
-        args_hash = self._cache.compute_hash(input_dict)
-        if tool.cache_ttl_seconds > 0:
-            cached = self._cache.get(tool_id, args_hash)
-            if cached is not None:
-                elapsed = time.monotonic() - start
-                logger.debug("Cache hit for tool %s", tool_id)
-                return RecoveryResult(
-                    tool_result=ToolResult(
-                        tool_id=tool_id,
-                        success=True,
-                        data=cached,
-                    ),
-                    error_context=None,
-                )
 
         # --- 3. Retry loop ---
         result_dict, last_error, attempt_count = await retry_tool_call(

--- a/src/kosmos/recovery/messages.py
+++ b/src/kosmos/recovery/messages.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Degradation message builder for data.go.kr API errors.
+
+Produces Korean-language user-facing messages for common error scenarios.
+All message templates use ``name_ko`` from the GovAPITool definition.
+"""
+
+from __future__ import annotations
+
+from kosmos.recovery.classifier import ClassifiedError, ErrorClass
+from kosmos.tools.models import GovAPITool
+
+
+def build_degradation_message(tool: GovAPITool, error: ClassifiedError) -> str:
+    """Build a Korean-language degradation message for a tool error.
+
+    Args:
+        tool: The GovAPITool whose call failed.
+        error: The classified error from the recovery pipeline.
+
+    Returns:
+        A human-readable Korean string suitable for display to the end user.
+    """
+    name = tool.name_ko
+
+    if error.error_class == ErrorClass.DEPRECATED:
+        return f"{name} 서비스가 종료되었거나 변경되었습니다."
+
+    if error.error_class == ErrorClass.AUTH_FAILURE:
+        return f"{name} 서비스 인증이 만료되었습니다. 관리자에게 문의해주세요."
+
+    # circuit_open is signalled by the caller passing a specific error_class;
+    # map APP_ERROR used for circuit-open signalling via the executor.
+    # The executor sets error_class=APP_ERROR with source="circuit_open".
+    if error.source == "circuit_open":
+        return f"{name} 서비스가 현재 점검 중이거나 일시적으로 중단되었습니다."
+
+    return f"{name} 서비스 응답 오류가 발생했습니다. 잠시 후 다시 시도해주세요."

--- a/src/kosmos/recovery/messages.py
+++ b/src/kosmos/recovery/messages.py
@@ -29,9 +29,8 @@ def build_degradation_message(tool: GovAPITool, error: ClassifiedError) -> str:
     if error.error_class == ErrorClass.AUTH_FAILURE:
         return f"{name} 서비스 인증이 만료되었습니다. 관리자에게 문의해주세요."
 
-    # circuit_open is signalled by the caller passing a specific error_class;
-    # map APP_ERROR used for circuit-open signalling via the executor.
-    # The executor sets error_class=APP_ERROR with source="circuit_open".
+    # Circuit-open is detected via error.source == "circuit_open", set by
+    # RecoveryExecutor when the circuit breaker is OPEN.
     if error.source == "circuit_open":
         return f"{name} 서비스가 현재 점검 중이거나 일시적으로 중단되었습니다."
 

--- a/src/kosmos/recovery/retry.py
+++ b/src/kosmos/recovery/retry.py
@@ -1,0 +1,142 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Retry policy and retry loop for tool adapter calls.
+
+Implements exponential back-off with full jitter per AWS guidance:
+    delay = random.uniform(0, min(max_delay, base_delay * multiplier ** attempt))
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from collections.abc import Awaitable, Callable
+
+from pydantic import BaseModel, ConfigDict
+
+from kosmos.recovery.classifier import ClassifiedError, DataGoKrErrorClassifier, ErrorClass
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Types
+# ---------------------------------------------------------------------------
+
+AdapterFn = Callable[..., Awaitable[dict[str, object]]]
+
+
+# ---------------------------------------------------------------------------
+# Policy
+# ---------------------------------------------------------------------------
+
+
+class ToolRetryPolicy(BaseModel):
+    """Configuration for the retry behaviour of a single tool call."""
+
+    model_config = ConfigDict(frozen=True)
+
+    max_retries: int = 3
+    """Maximum number of retry attempts (not counting the initial attempt)."""
+
+    base_delay: float = 1.0
+    """Initial back-off delay in seconds before the first retry."""
+
+    multiplier: float = 2.0
+    """Back-off multiplier applied on each successive retry."""
+
+    max_delay: float = 30.0
+    """Upper bound on back-off delay in seconds."""
+
+    retryable_classes: frozenset[ErrorClass] = frozenset(
+        {ErrorClass.TRANSIENT, ErrorClass.RATE_LIMIT, ErrorClass.TIMEOUT}
+    )
+    """Set of error classes that are eligible for retry."""
+
+
+# ---------------------------------------------------------------------------
+# Retry loop
+# ---------------------------------------------------------------------------
+
+
+async def retry_tool_call(
+    adapter: AdapterFn,
+    args: object,
+    classifier: DataGoKrErrorClassifier,
+    policy: ToolRetryPolicy,
+    *,
+    is_foreground: bool = True,
+) -> tuple[dict[str, object] | None, ClassifiedError | None, int]:
+    """Call *adapter* with *args*, retrying on classified retryable errors.
+
+    Back-off formula (full jitter):
+        delay = random.uniform(0, min(max_delay, base_delay * multiplier ** attempt))
+
+    For foreground calls the full ``max_retries`` budget is used.  For
+    background calls the budget is capped at ``min(1, max_retries)`` to
+    avoid holding background resources for extended periods.
+
+    Args:
+        adapter: Async callable that performs the actual API call.
+        args: Input argument passed verbatim to *adapter*.
+        classifier: Classifier instance for translating exceptions.
+        policy: Retry configuration.
+        is_foreground: ``True`` (default) for user-facing calls; ``False`` for
+            background / batch calls where a tighter retry cap applies.
+
+    Returns:
+        A 3-tuple ``(result_dict, last_classified_error, attempt_count)`` where:
+        - ``result_dict`` is the successful adapter output, or ``None`` on failure.
+        - ``last_classified_error`` is the last error seen, or ``None`` on success.
+        - ``attempt_count`` is the total number of attempts made (1 = no retry).
+    """
+    effective_max = policy.max_retries if is_foreground else min(1, policy.max_retries)
+
+    last_error: ClassifiedError | None = None
+    attempt = 0
+
+    while attempt <= effective_max:
+        try:
+            result = await adapter(args)
+            return result, None, attempt + 1
+        except Exception as exc:  # noqa: BLE001
+            classified = classifier.classify_exception(exc)
+            last_error = classified
+
+            not_retryable = (
+                not classified.is_retryable
+                or classified.error_class not in policy.retryable_classes
+            )
+            if not_retryable:
+                logger.warning(
+                    "Non-retryable error on attempt %d: class=%s message=%s",
+                    attempt + 1,
+                    classified.error_class,
+                    classified.raw_message,
+                )
+                return None, last_error, attempt + 1
+
+            if attempt >= effective_max:
+                logger.warning(
+                    "Retry budget exhausted after %d attempt(s): class=%s message=%s",
+                    attempt + 1,
+                    classified.error_class,
+                    classified.raw_message,
+                )
+                return None, last_error, attempt + 1
+
+            delay = random.uniform(  # noqa: S311
+                0,
+                min(policy.max_delay, policy.base_delay * (policy.multiplier**attempt)),
+            )
+            logger.warning(
+                "Retryable error on attempt %d, retrying in %.2fs: class=%s message=%s",
+                attempt + 1,
+                delay,
+                classified.error_class,
+                classified.raw_message,
+            )
+            await asyncio.sleep(delay)
+            attempt += 1
+
+    # Should be unreachable but satisfies the type checker
+    return None, last_error, attempt + 1  # pragma: no cover

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -33,10 +33,12 @@ class ToolExecutor:
     The dispatch pipeline (in order):
     1. Lookup tool in registry.
     2. Parse and validate JSON arguments against input_schema.
-    3. Verify adapter exists (before consuming a rate-limit slot).
-    4. Check rate limit.
-    5. Record rate-limit timestamp and execute adapter
-       (delegated to RecoveryExecutor when one is present).
+    3. Verify adapter exists.
+    4. If RecoveryExecutor is absent: check and record rate limit, then call
+       adapter directly.
+    5. If RecoveryExecutor is present: delegate to it for retry / circuit-breaker /
+       cache — rate limiting is handled internally by RecoveryExecutor to avoid
+       charging a slot before a circuit-open or cache-hit short-circuit.
     6. Validate adapter output against output_schema.
     7. Return ToolResult(success=True, data=...).
 
@@ -119,22 +121,18 @@ class ToolExecutor:
                 error_type="execution",
             )
 
-        # Step 4: Check rate limit
-        rate_limiter = self._registry.get_rate_limiter(tool_name)
-        if not rate_limiter.check():
-            logger.warning("Rate limit exceeded for tool: %s", tool_name)
-            return ToolResult(
-                tool_id=tool_name,
-                success=False,
-                error=f"Rate limit exceeded for tool {tool_name!r}",
-                error_type="rate_limit",
-            )
-
-        # Step 5: Record call and execute adapter
-        rate_limiter.record()
-
+        # Step 4/5: Execute adapter — rate limiting placement depends on recovery mode.
+        #
+        # When RecoveryExecutor is present, skip rate limiting here and delegate
+        # everything to it.  RecoveryExecutor may short-circuit via a circuit-open
+        # check or a cache hit *before* reaching the actual adapter call, so
+        # charging a rate-limit slot at this point would be premature.
+        #
+        # When RecoveryExecutor is absent, apply rate limiting as usual around
+        # the direct adapter invocation.
         if self._recovery_executor is not None:
-            # Delegate to RecoveryExecutor for retry / circuit-breaker / cache
+            # Delegate to RecoveryExecutor for retry / circuit-breaker / cache.
+            # Rate limiting is handled internally by RecoveryExecutor.
             recovery_result = await self._recovery_executor.execute(
                 tool,
                 adapter,
@@ -146,6 +144,16 @@ class ToolExecutor:
                 return tool_result
             result_dict = dict(tool_result.data or {})
         else:
+            rate_limiter = self._registry.get_rate_limiter(tool_name)
+            if not rate_limiter.check():
+                logger.warning("Rate limit exceeded for tool: %s", tool_name)
+                return ToolResult(
+                    tool_id=tool_name,
+                    success=False,
+                    error=f"Rate limit exceeded for tool {tool_name!r}",
+                    error_type="rate_limit",
+                )
+            rate_limiter.record()
             try:
                 result_dict = await adapter(validated_input)
             except Exception as exc:

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -11,13 +11,16 @@ from __future__ import annotations
 import json
 import logging
 from collections.abc import Awaitable, Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ValidationError
 
 from kosmos.tools.errors import ToolNotFoundError
 from kosmos.tools.models import ToolResult
 from kosmos.tools.registry import ToolRegistry
+
+if TYPE_CHECKING:
+    from kosmos.recovery.executor import RecoveryExecutor
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +35,8 @@ class ToolExecutor:
     2. Parse and validate JSON arguments against input_schema.
     3. Verify adapter exists (before consuming a rate-limit slot).
     4. Check rate limit.
-    5. Record rate-limit timestamp and execute adapter.
+    5. Record rate-limit timestamp and execute adapter
+       (delegated to RecoveryExecutor when one is present).
     6. Validate adapter output against output_schema.
     7. Return ToolResult(success=True, data=...).
 
@@ -40,14 +44,22 @@ class ToolExecutor:
     appropriate error_type. The executor itself never raises.
     """
 
-    def __init__(self, registry: ToolRegistry) -> None:
+    def __init__(
+        self,
+        registry: ToolRegistry,
+        recovery_executor: RecoveryExecutor | None = None,
+    ) -> None:
         """Initialize the executor with a ToolRegistry.
 
         Args:
             registry: The tool registry used for lookup and rate-limit access.
+            recovery_executor: Optional RecoveryExecutor providing Layer 6
+                error recovery (retry, circuit breaker, cache fallback).
+                When absent, the adapter is called directly (backward-compatible).
         """
         self._registry = registry
         self._adapters: dict[str, AdapterFn] = {}
+        self._recovery_executor = recovery_executor
 
     def register_adapter(self, tool_id: str, adapter: AdapterFn) -> None:
         """Register an async adapter function for a tool.
@@ -121,16 +133,29 @@ class ToolExecutor:
         # Step 5: Record call and execute adapter
         rate_limiter.record()
 
-        try:
-            result_dict = await adapter(validated_input)
-        except Exception as exc:
-            logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)
-            return ToolResult(
-                tool_id=tool_name,
-                success=False,
-                error=str(exc),
-                error_type="execution",
+        if self._recovery_executor is not None:
+            # Delegate to RecoveryExecutor for retry / circuit-breaker / cache
+            recovery_result = await self._recovery_executor.execute(
+                tool,
+                adapter,
+                validated_input,
+                is_foreground=True,
             )
+            tool_result = recovery_result.tool_result
+            if not tool_result.success:
+                return tool_result
+            result_dict = dict(tool_result.data or {})
+        else:
+            try:
+                result_dict = await adapter(validated_input)
+            except Exception as exc:
+                logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)
+                return ToolResult(
+                    tool_id=tool_name,
+                    success=False,
+                    error=str(exc),
+                    error_type="execution",
+                )
 
         # Step 6: Validate output
         try:

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -34,11 +34,9 @@ class ToolExecutor:
     1. Lookup tool in registry.
     2. Parse and validate JSON arguments against input_schema.
     3. Verify adapter exists.
-    4. If RecoveryExecutor is absent: check and record rate limit, then call
-       adapter directly.
-    5. If RecoveryExecutor is present: delegate to it for retry / circuit-breaker /
-       cache — rate limiting is handled internally by RecoveryExecutor to avoid
-       charging a slot before a circuit-open or cache-hit short-circuit.
+    4. Check and record rate limit.
+    5. If RecoveryExecutor is present: delegate for retry / circuit-breaker /
+       cache.  If absent: call adapter directly.
     6. Validate adapter output against output_schema.
     7. Return ToolResult(success=True, data=...).
 
@@ -121,18 +119,24 @@ class ToolExecutor:
                 error_type="execution",
             )
 
-        # Step 4/5: Execute adapter — rate limiting placement depends on recovery mode.
+        # Step 4/5: Execute adapter with rate limiting + optional recovery.
         #
-        # When RecoveryExecutor is present, skip rate limiting here and delegate
-        # everything to it.  RecoveryExecutor may short-circuit via a circuit-open
-        # check or a cache hit *before* reaching the actual adapter call, so
-        # charging a rate-limit slot at this point would be premature.
-        #
-        # When RecoveryExecutor is absent, apply rate limiting as usual around
-        # the direct adapter invocation.
+        # Rate limiting is always enforced regardless of recovery mode.
+        # RecoveryExecutor may short-circuit via a cache hit or circuit-open
+        # check, but the rate limiter still governs overall call frequency.
+        rate_limiter = self._registry.get_rate_limiter(tool_name)
+        if not rate_limiter.check():
+            logger.warning("Rate limit exceeded for tool: %s", tool_name)
+            return ToolResult(
+                tool_id=tool_name,
+                success=False,
+                error=f"Rate limit exceeded for tool {tool_name!r}",
+                error_type="rate_limit",
+            )
+        rate_limiter.record()
+
         if self._recovery_executor is not None:
             # Delegate to RecoveryExecutor for retry / circuit-breaker / cache.
-            # Rate limiting is handled internally by RecoveryExecutor.
             recovery_result = await self._recovery_executor.execute(
                 tool,
                 adapter,
@@ -144,16 +148,6 @@ class ToolExecutor:
                 return tool_result
             result_dict = dict(tool_result.data or {})
         else:
-            rate_limiter = self._registry.get_rate_limiter(tool_name)
-            if not rate_limiter.check():
-                logger.warning("Rate limit exceeded for tool: %s", tool_name)
-                return ToolResult(
-                    tool_id=tool_name,
-                    success=False,
-                    error=f"Rate limit exceeded for tool {tool_name!r}",
-                    error_type="rate_limit",
-                )
-            rate_limiter.record()
             try:
                 result_dict = await adapter(validated_input)
             except Exception as exc:

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -147,6 +147,10 @@ class ToolResult(BaseModel):
             "execution",
             "schema_mismatch",
             "permission_denied",
+            "timeout",
+            "circuit_open",
+            "api_error",
+            "auth_expired",
         ]
         | None
     ) = None

--- a/tests/recovery/__init__.py
+++ b/tests/recovery/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the KOSMOS recovery package."""

--- a/tests/recovery/conftest.py
+++ b/tests/recovery/conftest.py
@@ -1,0 +1,187 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for the recovery package tests."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Awaitable, Callable
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from kosmos.tools.models import GovAPITool
+
+
+class _DummyInput(BaseModel):
+    """Minimal input schema for test fixtures."""
+
+    query: str
+
+
+class _DummyOutput(BaseModel):
+    """Minimal output schema for test fixtures."""
+
+    result: str
+
+
+# ---------------------------------------------------------------------------
+# Adapter factory fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def make_success_adapter() -> Callable[[], Callable[[object], Awaitable[dict[str, object]]]]:
+    """Return a factory that creates an async adapter returning ``{"result": "ok"}``."""
+
+    def _factory() -> Callable[[object], Awaitable[dict[str, object]]]:
+        async def _adapter(args: object) -> dict[str, object]:
+            return {"result": "ok"}
+
+        return _adapter
+
+    return _factory
+
+
+@pytest.fixture()
+def make_failure_adapter() -> Callable[
+    [int, str, str | None], Callable[[object], Awaitable[dict[str, object]]]
+]:
+    """Return a factory that creates an async adapter raising ``httpx.HTTPStatusError``."""
+
+    def _factory(
+        status_code: int,
+        body: str = "",
+        content_type: str | None = None,
+    ) -> Callable[[object], Awaitable[dict[str, object]]]:
+        headers = {}
+        if content_type is not None:
+            headers["content-type"] = content_type
+
+        request = httpx.Request("GET", "https://api.example.com/test")
+        response = httpx.Response(status_code, text=body, headers=headers, request=request)
+        exc = httpx.HTTPStatusError(
+            f"HTTP {status_code}",
+            request=request,
+            response=response,
+        )
+
+        async def _adapter(args: object) -> dict[str, object]:
+            raise exc
+
+        return _adapter
+
+    return _factory
+
+
+@pytest.fixture()
+def make_timeout_adapter() -> Callable[[], Callable[[object], Awaitable[dict[str, object]]]]:
+    """Return a factory that creates an async adapter raising ``httpx.ReadTimeout``."""
+
+    def _factory() -> Callable[[object], Awaitable[dict[str, object]]]:
+        async def _adapter(args: object) -> dict[str, object]:
+            raise httpx.ReadTimeout("read timed out")
+
+        return _adapter
+
+    return _factory
+
+
+# ---------------------------------------------------------------------------
+# Response body helper fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_xml_gateway_response() -> Callable[[int | str, str], str]:
+    """Return a helper that builds a data.go.kr XML gateway response body."""
+
+    def _make(code: int | str, message: str = "") -> str:
+        return (
+            "<OpenAPI_ServiceResponse>"
+            "<cmmMsgHeader>"
+            f"<returnReasonCode>{code}</returnReasonCode>"
+            f"<returnAuthMsg>{message}</returnAuthMsg>"
+            "</cmmMsgHeader>"
+            "</OpenAPI_ServiceResponse>"
+        )
+
+    return _make
+
+
+@pytest.fixture()
+def sample_json_error_response() -> Callable[[int | str, str], str]:
+    """Return a helper that builds a data.go.kr JSON error response body."""
+
+    def _make(code: int | str, message: str = "") -> str:
+        return json.dumps({"resultCode": code, "resultMsg": message})
+
+    return _make
+
+
+# ---------------------------------------------------------------------------
+# Tool fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mock_gov_api_tool() -> GovAPITool:
+    """Return a ``GovAPITool`` with test values for use in recovery tests."""
+    return GovAPITool(
+        id="test_tool",
+        name_ko="테스트 도구",
+        provider="테스트 기관",
+        category=["test"],
+        endpoint="https://api.example.com/test",
+        auth_type="api_key",
+        input_schema=_DummyInput,
+        output_schema=_DummyOutput,
+        search_hint="test 테스트 tool adapter",
+        requires_auth=False,
+        is_concurrency_safe=True,
+        is_personal_data=False,
+        cache_ttl_seconds=3600,
+        rate_limit_per_minute=60,
+    )
+
+
+@pytest.fixture()
+def sample_tool() -> GovAPITool:
+    """Return a minimal GovAPITool for use in recovery tests."""
+    return GovAPITool(
+        id="test_tool",
+        name_ko="테스트 도구",
+        provider="테스트 기관",
+        category=["test"],
+        endpoint="https://api.example.com/test",
+        auth_type="api_key",
+        input_schema=_DummyInput,
+        output_schema=_DummyOutput,
+        search_hint="test 테스트",
+        requires_auth=False,
+        is_concurrency_safe=True,
+        is_personal_data=False,
+        cache_ttl_seconds=60,
+        rate_limit_per_minute=100,
+    )
+
+
+@pytest.fixture()
+def no_cache_tool() -> GovAPITool:
+    """Return a GovAPITool with cache_ttl_seconds=0 (no caching)."""
+    return GovAPITool(
+        id="no_cache_tool",
+        name_ko="캐시 없는 도구",
+        provider="테스트 기관",
+        category=["test"],
+        endpoint="https://api.example.com/no-cache",
+        auth_type="api_key",
+        input_schema=_DummyInput,
+        output_schema=_DummyOutput,
+        search_hint="no cache 캐시없음",
+        requires_auth=False,
+        is_concurrency_safe=False,
+        is_personal_data=False,
+        cache_ttl_seconds=0,
+        rate_limit_per_minute=10,
+    )

--- a/tests/recovery/test_cache_and_messages.py
+++ b/tests/recovery/test_cache_and_messages.py
@@ -1,0 +1,182 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ResponseCache and build_degradation_message."""
+
+from __future__ import annotations
+
+import pytest
+
+from kosmos.recovery.cache import CacheEntry, ResponseCache
+from kosmos.recovery.classifier import ClassifiedError, ErrorClass
+from kosmos.recovery.messages import build_degradation_message
+from kosmos.tools.models import GovAPITool
+
+# ---------------------------------------------------------------------------
+# ResponseCache
+# ---------------------------------------------------------------------------
+
+
+class TestResponseCache:
+    def test_put_and_get_hit(self) -> None:
+        cache = ResponseCache()
+        h = cache.compute_hash({"q": "test"})
+        cache.put("tool_a", h, {"result": "ok"}, ttl_seconds=60)
+        result = cache.get("tool_a", h)
+        assert result == {"result": "ok"}
+
+    def test_get_miss_returns_none(self) -> None:
+        cache = ResponseCache()
+        h = cache.compute_hash({"q": "test"})
+        result = cache.get("tool_a", h)
+        assert result is None
+
+    def test_ttl_zero_not_stored(self) -> None:
+        cache = ResponseCache()
+        h = cache.compute_hash({"q": "test"})
+        cache.put("tool_a", h, {"result": "ok"}, ttl_seconds=0)
+        result = cache.get("tool_a", h)
+        assert result is None
+
+    def test_expired_entry_returns_none(self) -> None:
+        cache = ResponseCache()
+        h = cache.compute_hash({"q": "test"})
+        cache.put("tool_a", h, {"result": "ok"}, ttl_seconds=1)
+        # Manually age the entry
+        old_entry = cache._store[f"tool_a:{h}"]  # noqa: SLF001
+        aged_entry = CacheEntry(
+            tool_id=old_entry.tool_id,
+            arguments_hash=old_entry.arguments_hash,
+            data=old_entry.data,
+            cached_at=old_entry.cached_at - 2,  # 2 seconds in the past
+            ttl_seconds=1,
+        )
+        cache._store[f"tool_a:{h}"] = aged_entry  # noqa: SLF001
+        result = cache.get("tool_a", h)
+        assert result is None
+
+    def test_lru_eviction(self) -> None:
+        cache = ResponseCache(max_entries=3)
+        for i in range(3):
+            h = cache.compute_hash({"i": i})
+            cache.put(f"tool_{i}", h, {"n": i}, ttl_seconds=60)
+
+        # Access tool_0 to make it most-recently used
+        h0 = cache.compute_hash({"i": 0})
+        cache.get("tool_0", h0)
+
+        # Add a 4th entry — should evict LRU (tool_1, the oldest untouched)
+        h3 = cache.compute_hash({"i": 3})
+        cache.put("tool_3", h3, {"n": 3}, ttl_seconds=60)
+
+        assert len(cache._store) == 3  # noqa: SLF001
+        # tool_1 should have been evicted (least recently used)
+        h1 = cache.compute_hash({"i": 1})
+        assert cache.get("tool_1", h1) is None
+
+    def test_hash_deterministic(self) -> None:
+        cache = ResponseCache()
+        h1 = cache.compute_hash({"b": 2, "a": 1})
+        h2 = cache.compute_hash({"a": 1, "b": 2})
+        assert h1 == h2
+
+    def test_hash_different_values(self) -> None:
+        cache = ResponseCache()
+        h1 = cache.compute_hash({"q": "foo"})
+        h2 = cache.compute_hash({"q": "bar"})
+        assert h1 != h2
+
+    def test_get_returns_copy(self) -> None:
+        """Returned dict should be a copy to prevent mutation of cached data."""
+        cache = ResponseCache()
+        h = cache.compute_hash({"q": "test"})
+        cache.put("tool_a", h, {"result": "ok"}, ttl_seconds=60)
+        result = cache.get("tool_a", h)
+        assert result is not None
+        result["result"] = "mutated"
+        # Second get should return original
+        result2 = cache.get("tool_a", h)
+        assert result2 == {"result": "ok"}
+
+
+# ---------------------------------------------------------------------------
+# build_degradation_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sample_tool() -> GovAPITool:
+    from pydantic import BaseModel
+
+    class _In(BaseModel):
+        q: str
+
+    class _Out(BaseModel):
+        r: str
+
+    return GovAPITool(
+        id="test_tool",
+        name_ko="테스트 도구",
+        provider="기관",
+        category=["test"],
+        endpoint="https://api.example.com/",
+        auth_type="api_key",
+        input_schema=_In,
+        output_schema=_Out,
+        search_hint="test 테스트",
+        requires_auth=False,
+        is_concurrency_safe=False,
+        is_personal_data=False,
+        cache_ttl_seconds=0,
+        rate_limit_per_minute=10,
+    )
+
+
+class TestBuildDegradationMessage:
+    def _make_error(
+        self,
+        error_class: ErrorClass,
+        source: str = "json_body",
+    ) -> ClassifiedError:
+        return ClassifiedError(
+            error_class=error_class,
+            is_retryable=False,
+            raw_code=None,
+            raw_message="test error",
+            source=source,
+        )
+
+    def test_general_error_message(self, sample_tool: GovAPITool) -> None:
+        err = self._make_error(ErrorClass.TRANSIENT)
+        msg = build_degradation_message(sample_tool, err)
+        assert "테스트 도구" in msg
+        assert "잠시 후 다시 시도해주세요" in msg
+
+    def test_circuit_open_message(self, sample_tool: GovAPITool) -> None:
+        err = self._make_error(ErrorClass.APP_ERROR, source="circuit_open")
+        msg = build_degradation_message(sample_tool, err)
+        assert "테스트 도구" in msg
+        assert "점검 중" in msg or "일시적으로 중단" in msg
+
+    def test_deprecated_message(self, sample_tool: GovAPITool) -> None:
+        err = self._make_error(ErrorClass.DEPRECATED)
+        msg = build_degradation_message(sample_tool, err)
+        assert "테스트 도구" in msg
+        assert "종료" in msg or "변경" in msg
+
+    def test_auth_expired_message(self, sample_tool: GovAPITool) -> None:
+        err = self._make_error(ErrorClass.AUTH_FAILURE)
+        msg = build_degradation_message(sample_tool, err)
+        assert "테스트 도구" in msg
+        assert "인증이 만료" in msg
+
+    def test_name_ko_included_in_all_messages(self, sample_tool: GovAPITool) -> None:
+        for ec in [ErrorClass.TRANSIENT, ErrorClass.RATE_LIMIT, ErrorClass.TIMEOUT]:
+            err = self._make_error(ec)
+            msg = build_degradation_message(sample_tool, err)
+            assert sample_tool.name_ko in msg
+
+    def test_message_is_korean(self, sample_tool: GovAPITool) -> None:
+        """Messages contain Korean characters (verify they're not pure ASCII)."""
+        err = self._make_error(ErrorClass.TRANSIENT)
+        msg = build_degradation_message(sample_tool, err)
+        has_korean = any("\uac00" <= ch <= "\ud7a3" for ch in msg)
+        assert has_korean, f"Expected Korean text in: {msg!r}"

--- a/tests/recovery/test_circuit_breaker.py
+++ b/tests/recovery/test_circuit_breaker.py
@@ -1,0 +1,194 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the CircuitBreaker and CircuitBreakerRegistry."""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from kosmos.recovery.circuit_breaker import (
+    CircuitBreaker,
+    CircuitBreakerConfig,
+    CircuitBreakerRegistry,
+    CircuitState,
+)
+
+
+@pytest.fixture()
+def config() -> CircuitBreakerConfig:
+    return CircuitBreakerConfig(
+        failure_threshold=3,
+        recovery_timeout=0.05,  # 50 ms for fast tests
+        half_open_max_calls=1,
+    )
+
+
+@pytest.fixture()
+def cb(config: CircuitBreakerConfig) -> CircuitBreaker:
+    return CircuitBreaker("test_tool", config)
+
+
+# ---------------------------------------------------------------------------
+# Initial state
+# ---------------------------------------------------------------------------
+
+
+class TestInitialState:
+    def test_starts_closed(self, cb: CircuitBreaker) -> None:
+        assert cb.state == CircuitState.CLOSED
+
+    def test_allows_requests_when_closed(self, cb: CircuitBreaker) -> None:
+        assert cb.allow_request() is True
+
+
+# ---------------------------------------------------------------------------
+# CLOSED → OPEN transition
+# ---------------------------------------------------------------------------
+
+
+class TestClosedToOpen:
+    def test_opens_after_failure_threshold(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_blocks_after_open(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        assert cb.allow_request() is False
+
+    def test_does_not_open_before_threshold(self, cb: CircuitBreaker) -> None:
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_success_resets_failure_count(self, cb: CircuitBreaker) -> None:
+        cb.record_failure()
+        cb.record_failure()
+        cb.record_success()  # resets to 0
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.state == CircuitState.CLOSED  # only 2 failures since reset
+
+
+# ---------------------------------------------------------------------------
+# OPEN → HALF_OPEN transition
+# ---------------------------------------------------------------------------
+
+
+class TestOpenToHalfOpen:
+    def test_transitions_to_half_open_after_timeout(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+        time.sleep(0.06)  # exceed 50 ms recovery timeout
+        assert cb.state == CircuitState.HALF_OPEN
+
+    def test_allows_probe_call_in_half_open(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        time.sleep(0.06)
+        assert cb.allow_request() is True
+
+    def test_blocks_extra_calls_in_half_open(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        time.sleep(0.06)
+        cb.allow_request()  # consumes the one allowed probe call
+        assert cb.allow_request() is False
+
+
+# ---------------------------------------------------------------------------
+# HALF_OPEN → CLOSED on success
+# ---------------------------------------------------------------------------
+
+
+class TestHalfOpenToClosedOnSuccess:
+    def test_closes_on_probe_success(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        time.sleep(0.06)
+        cb.allow_request()
+        cb.record_success()
+        assert cb.state == CircuitState.CLOSED
+
+    def test_allows_requests_after_close(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        time.sleep(0.06)
+        cb.allow_request()
+        cb.record_success()
+        assert cb.allow_request() is True
+
+
+# ---------------------------------------------------------------------------
+# HALF_OPEN → OPEN on failure
+# ---------------------------------------------------------------------------
+
+
+class TestHalfOpenToOpenOnFailure:
+    def test_reopens_on_probe_failure(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        time.sleep(0.06)
+        cb.allow_request()
+        cb.record_failure()
+        assert cb.state == CircuitState.OPEN
+
+    def test_blocks_immediately_after_reopen(self, cb: CircuitBreaker) -> None:
+        for _ in range(3):
+            cb.record_failure()
+        time.sleep(0.06)
+        cb.allow_request()
+        cb.record_failure()
+        assert cb.allow_request() is False
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreakerRegistry:
+    def test_lazy_creation(self) -> None:
+        registry = CircuitBreakerRegistry()
+        cb = registry.get("tool_a")
+        assert isinstance(cb, CircuitBreaker)
+        assert cb.state == CircuitState.CLOSED
+
+    def test_same_instance_on_second_call(self) -> None:
+        registry = CircuitBreakerRegistry()
+        cb1 = registry.get("tool_a")
+        cb2 = registry.get("tool_a")
+        assert cb1 is cb2
+
+    def test_separate_instances_for_different_tools(self) -> None:
+        registry = CircuitBreakerRegistry()
+        cb1 = registry.get("tool_a")
+        cb2 = registry.get("tool_b")
+        assert cb1 is not cb2
+
+    def test_default_config_applied(self) -> None:
+        config = CircuitBreakerConfig(failure_threshold=7)
+        registry = CircuitBreakerRegistry(default_config=config)
+        cb = registry.get("tool_x")
+        assert cb._config.failure_threshold == 7  # noqa: SLF001
+
+
+# ---------------------------------------------------------------------------
+# Concurrent HALF_OPEN: second probe is blocked
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentHalfOpen:
+    def test_second_probe_blocked_in_half_open(self, cb: CircuitBreaker) -> None:
+        """With half_open_max_calls=1, only one probe is allowed at a time."""
+        for _ in range(3):
+            cb.record_failure()
+        time.sleep(0.06)
+        # First call transitions to HALF_OPEN and allows the probe
+        first = cb.allow_request()
+        second = cb.allow_request()
+        assert first is True
+        assert second is False

--- a/tests/recovery/test_classifier.py
+++ b/tests/recovery/test_classifier.py
@@ -1,0 +1,332 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the DataGoKrErrorClassifier and related models."""
+
+from __future__ import annotations
+
+import json
+
+import httpx
+import pytest
+
+from kosmos.recovery.classifier import (
+    ClassifiedError,
+    DataGoKrErrorClassifier,
+    DataGoKrErrorCode,
+    ErrorClass,
+)
+
+
+@pytest.fixture()
+def classifier() -> DataGoKrErrorClassifier:
+    return DataGoKrErrorClassifier()
+
+
+# ---------------------------------------------------------------------------
+# ErrorCode mapping tests
+# ---------------------------------------------------------------------------
+
+
+class TestDataGoKrErrorCodes:
+    def test_all_codes_defined(self) -> None:
+        """All 15 error codes specified in the design are present."""
+        expected_codes = {0, 1, 2, 3, 4, 5, 10, 11, 20, 22, 30, 31, 32, 33, 99}
+        actual_codes = {int(c) for c in DataGoKrErrorCode}
+        assert expected_codes == actual_codes
+
+    def test_code_values(self) -> None:
+        assert DataGoKrErrorCode.NORMAL_CODE == 0
+        assert DataGoKrErrorCode.APPLICATION_ERROR == 1
+        assert DataGoKrErrorCode.DB_ERROR == 2
+        assert DataGoKrErrorCode.NO_DATA == 3
+        assert DataGoKrErrorCode.HTTP_ERROR == 4
+        assert DataGoKrErrorCode.SERVICE_TIMEOUT == 5
+        assert DataGoKrErrorCode.INVALID_REQUEST_PARAMETER == 10
+        assert DataGoKrErrorCode.NO_REQUIRED_REQUEST_PARAMETER == 11
+        assert DataGoKrErrorCode.SERVICE_NOT_FOUND == 20
+        assert DataGoKrErrorCode.TEMPORARILY_DISABLED == 22
+        assert DataGoKrErrorCode.LIMIT_NUMBER_OF_SERVICE_REQUESTS_EXCEEDED == 30
+        assert DataGoKrErrorCode.SERVICE_KEY_NOT_REGISTERED == 31
+        assert DataGoKrErrorCode.DEADLINE_HAS_EXPIRED == 32
+        assert DataGoKrErrorCode.UNREGISTERED_IP == 33
+        assert DataGoKrErrorCode.UNKNOWN_ERROR == 99
+
+
+# ---------------------------------------------------------------------------
+# XML gateway detection
+# ---------------------------------------------------------------------------
+
+
+class TestXmlGatewayDetection:
+    def test_xml_gateway_with_code_30(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = (
+            "<OpenAPI_ServiceResponse>"
+            "<returnAuthMsg>LIMITED_NUMBER_OF_SERVICE_REQUESTS_EXCEEDS_ERROR</returnAuthMsg>"
+            "<returnReasonCode>30</returnReasonCode>"
+            "</OpenAPI_ServiceResponse>"
+        )
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.RATE_LIMIT
+        assert result.is_retryable is True
+        assert result.raw_code == 30
+        assert result.source == "xml_gateway"
+
+    def test_xml_gateway_with_code_31(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = (
+            "<OpenAPI_ServiceResponse>"
+            "<returnAuthMsg>SERVICE_KEY_NOT_REGISTERED_ERROR</returnAuthMsg>"
+            "<returnReasonCode>31</returnReasonCode>"
+            "</OpenAPI_ServiceResponse>"
+        )
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.AUTH_FAILURE
+        assert result.is_retryable is False
+        assert result.raw_code == 31
+
+    def test_xml_gateway_with_code_32(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = (
+            "<OpenAPI_ServiceResponse>"
+            "<returnReasonCode>32</returnReasonCode>"
+            "</OpenAPI_ServiceResponse>"
+        )
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.AUTH_FAILURE
+        assert result.raw_code == 32
+
+    def test_xml_gateway_with_code_33(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = (
+            "<OpenAPI_ServiceResponse>"
+            "<returnReasonCode>33</returnReasonCode>"
+            "</OpenAPI_ServiceResponse>"
+        )
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.AUTH_FAILURE
+        assert result.raw_code == 33
+
+    def test_xml_gateway_without_code(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = (
+            "<OpenAPI_ServiceResponse>"
+            "<returnAuthMsg>Unknown</returnAuthMsg>"
+            "</OpenAPI_ServiceResponse>"
+        )
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.UNKNOWN
+        assert result.raw_code is None
+        assert result.source == "xml_gateway"
+
+    def test_non_xml_body_not_treated_as_xml(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = '{"resultCode": "00", "resultMsg": "NORMAL SERVICE."}'
+        result = classifier.classify_response(200, body)
+        # Should NOT trigger xml gateway path
+        assert result.source != "xml_gateway"
+
+
+# ---------------------------------------------------------------------------
+# JSON body classification
+# ---------------------------------------------------------------------------
+
+
+class TestJsonBodyClassification:
+    def _make_body(self, code: int, msg: str = "test") -> str:
+        return json.dumps({"response": {"header": {"resultCode": code, "resultMsg": msg}}})
+
+    def test_code_0_normal_maps_to_unknown(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 0, "resultMsg": "NORMAL SERVICE."})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.UNKNOWN  # code 0 on failure path = unknown
+        assert result.raw_code == 0
+
+    def test_code_1_application_error(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 1})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.APP_ERROR
+        assert result.is_retryable is False
+
+    def test_code_2_db_error_is_transient(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 2})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.TRANSIENT
+        assert result.is_retryable is True
+
+    def test_code_3_no_data(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 3})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.DATA_MISSING
+        assert result.is_retryable is False
+
+    def test_code_4_http_error_is_transient(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 4})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.TRANSIENT
+
+    def test_code_5_service_timeout_is_transient(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 5})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.TRANSIENT
+
+    def test_code_10_invalid_param(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 10})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.INVALID_REQUEST
+        assert result.is_retryable is False
+
+    def test_code_11_missing_param(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 11})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.INVALID_REQUEST
+
+    def test_code_20_service_not_found(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 20})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.DEPRECATED
+
+    def test_code_22_temporarily_disabled(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 22})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.DEPRECATED
+
+    def test_code_30_rate_limit(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 30})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.RATE_LIMIT
+        assert result.is_retryable is True
+
+    def test_code_31_key_not_registered(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 31})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.AUTH_FAILURE
+
+    def test_code_99_unknown(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": 99})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.UNKNOWN
+        assert result.is_retryable is False
+
+    def test_string_result_code(self, classifier: DataGoKrErrorClassifier) -> None:
+        body = json.dumps({"resultCode": "30"})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.RATE_LIMIT
+
+
+# ---------------------------------------------------------------------------
+# HTTP status classification
+# ---------------------------------------------------------------------------
+
+
+class TestHttpStatusClassification:
+    def test_429_rate_limit(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(429, "Too Many Requests")
+        assert result.error_class == ErrorClass.RATE_LIMIT
+        assert result.is_retryable is True
+        assert result.source == "http_status"
+
+    def test_401_auth_failure(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(401, "Unauthorized")
+        assert result.error_class == ErrorClass.AUTH_FAILURE
+        assert result.is_retryable is False
+
+    def test_403_auth_failure(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(403, "Forbidden")
+        assert result.error_class == ErrorClass.AUTH_FAILURE
+
+    def test_502_transient(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(502, "Bad Gateway")
+        assert result.error_class == ErrorClass.TRANSIENT
+        assert result.is_retryable is True
+
+    def test_503_transient(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(503, "Service Unavailable")
+        assert result.error_class == ErrorClass.TRANSIENT
+
+    def test_504_transient(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(504, "Gateway Timeout")
+        assert result.error_class == ErrorClass.TRANSIENT
+
+    def test_400_invalid_request(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(400, "Bad Request")
+        assert result.error_class == ErrorClass.INVALID_REQUEST
+        assert result.is_retryable is False
+        assert result.source == "http_status"
+
+    def test_404_data_missing(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(404, "Not Found")
+        assert result.error_class == ErrorClass.DATA_MISSING
+        assert result.is_retryable is False
+        assert result.source == "http_status"
+
+    def test_500_app_error(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(500, "Internal Server Error")
+        assert result.error_class == ErrorClass.APP_ERROR
+        assert result.is_retryable is False
+        assert result.source == "http_status"
+
+    def test_418_unknown(self, classifier: DataGoKrErrorClassifier) -> None:
+        result = classifier.classify_response(418, "I'm a teapot")
+        assert result.error_class == ErrorClass.UNKNOWN
+        assert result.is_retryable is False
+
+
+# ---------------------------------------------------------------------------
+# Exception classification
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionClassification:
+    def test_connect_timeout(self, classifier: DataGoKrErrorClassifier) -> None:
+        exc = httpx.ConnectTimeout("connection timed out")
+        result = classifier.classify_exception(exc)
+        assert result.error_class == ErrorClass.TIMEOUT
+        assert result.is_retryable is True
+        assert result.source == "exception"
+
+    def test_read_timeout(self, classifier: DataGoKrErrorClassifier) -> None:
+        exc = httpx.ReadTimeout("read timed out")
+        result = classifier.classify_exception(exc)
+        assert result.error_class == ErrorClass.TIMEOUT
+        assert result.is_retryable is True
+
+    def test_pool_timeout(self, classifier: DataGoKrErrorClassifier) -> None:
+        exc = httpx.PoolTimeout("pool timed out")
+        result = classifier.classify_exception(exc)
+        assert result.error_class == ErrorClass.TIMEOUT
+        assert result.is_retryable is True
+
+    def test_http_status_error_401(self, classifier: DataGoKrErrorClassifier) -> None:
+        request = httpx.Request("GET", "https://api.example.com/")
+        response = httpx.Response(401, request=request)
+        exc = httpx.HTTPStatusError("401 Unauthorized", request=request, response=response)
+        result = classifier.classify_exception(exc)
+        assert result.error_class == ErrorClass.AUTH_FAILURE
+        assert result.is_retryable is False
+
+    def test_http_status_error_503(self, classifier: DataGoKrErrorClassifier) -> None:
+        request = httpx.Request("GET", "https://api.example.com/")
+        response = httpx.Response(503, request=request)
+        exc = httpx.HTTPStatusError("503 Service Unavailable", request=request, response=response)
+        result = classifier.classify_exception(exc)
+        assert result.error_class == ErrorClass.TRANSIENT
+        assert result.is_retryable is True
+
+    def test_generic_exception_app_error(self, classifier: DataGoKrErrorClassifier) -> None:
+        exc = ValueError("something went wrong")
+        result = classifier.classify_exception(exc)
+        assert result.error_class == ErrorClass.APP_ERROR
+        assert result.is_retryable is False
+        assert result.source == "exception"
+
+
+# ---------------------------------------------------------------------------
+# ClassifiedError model
+# ---------------------------------------------------------------------------
+
+
+class TestClassifiedError:
+    def test_frozen(self) -> None:
+        err = ClassifiedError(
+            error_class=ErrorClass.TRANSIENT,
+            is_retryable=True,
+            raw_code=5,
+            raw_message="timeout",
+            source="json_body",
+        )
+        with pytest.raises((ValueError, TypeError, AttributeError)):
+            err.error_class = ErrorClass.UNKNOWN  # type: ignore[misc]

--- a/tests/recovery/test_classifier.py
+++ b/tests/recovery/test_classifier.py
@@ -52,55 +52,85 @@ class TestDataGoKrErrorCodes:
 
 
 # ---------------------------------------------------------------------------
-# XML gateway detection
+# XML gateway detection via sample_xml_gateway_response fixture
 # ---------------------------------------------------------------------------
 
 
 class TestXmlGatewayDetection:
-    def test_xml_gateway_with_code_30(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = (
-            "<OpenAPI_ServiceResponse>"
-            "<returnAuthMsg>LIMITED_NUMBER_OF_SERVICE_REQUESTS_EXCEEDS_ERROR</returnAuthMsg>"
-            "<returnReasonCode>30</returnReasonCode>"
-            "</OpenAPI_ServiceResponse>"
-        )
+    def test_xml_gateway_with_code_30(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(30, "LIMITED_NUMBER_OF_SERVICE_REQUESTS_EXCEEDS_ERROR")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.RATE_LIMIT
         assert result.is_retryable is True
         assert result.raw_code == 30
-        assert result.source == "xml_gateway"
+        assert result.source == "data_go_kr_xml"
 
-    def test_xml_gateway_with_code_31(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = (
-            "<OpenAPI_ServiceResponse>"
-            "<returnAuthMsg>SERVICE_KEY_NOT_REGISTERED_ERROR</returnAuthMsg>"
-            "<returnReasonCode>31</returnReasonCode>"
-            "</OpenAPI_ServiceResponse>"
-        )
+    def test_xml_gateway_with_code_31(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(31, "SERVICE_KEY_NOT_REGISTERED_ERROR")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.AUTH_FAILURE
         assert result.is_retryable is False
         assert result.raw_code == 31
+        assert result.source == "data_go_kr_xml"
 
-    def test_xml_gateway_with_code_32(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = (
-            "<OpenAPI_ServiceResponse>"
-            "<returnReasonCode>32</returnReasonCode>"
-            "</OpenAPI_ServiceResponse>"
-        )
+    def test_xml_gateway_with_code_32(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(32, "DEADLINE_EXPIRED")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.AUTH_FAILURE
         assert result.raw_code == 32
 
-    def test_xml_gateway_with_code_33(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = (
-            "<OpenAPI_ServiceResponse>"
-            "<returnReasonCode>33</returnReasonCode>"
-            "</OpenAPI_ServiceResponse>"
-        )
+    def test_xml_gateway_with_code_33(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(33, "UNREGISTERED_IP")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.AUTH_FAILURE
         assert result.raw_code == 33
+
+    def test_xml_gateway_code_2_transient(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(2, "DB_ERROR")  # type: ignore[operator]
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.TRANSIENT
+        assert result.is_retryable is True
+
+    def test_xml_gateway_code_3_data_missing(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(3, "NO_DATA")  # type: ignore[operator]
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.DATA_MISSING
+        assert result.is_retryable is False
+
+    def test_xml_gateway_code_10_invalid_request(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(10, "INVALID_REQUEST_PARAMETER")  # type: ignore[operator]
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.INVALID_REQUEST
+        assert result.is_retryable is False
+
+    def test_xml_gateway_code_20_deprecated(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(20, "SERVICE_NOT_FOUND")  # type: ignore[operator]
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.DEPRECATED
+
+    def test_xml_gateway_code_99_unknown(
+        self, classifier: DataGoKrErrorClassifier, sample_xml_gateway_response: object
+    ) -> None:
+        body = sample_xml_gateway_response(99, "UNKNOWN_ERROR")  # type: ignore[operator]
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.UNKNOWN
+        assert result.is_retryable is False
 
     def test_xml_gateway_without_code(self, classifier: DataGoKrErrorClassifier) -> None:
         body = (
@@ -111,92 +141,132 @@ class TestXmlGatewayDetection:
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.UNKNOWN
         assert result.raw_code is None
-        assert result.source == "xml_gateway"
+        assert result.source == "data_go_kr_xml"
 
     def test_non_xml_body_not_treated_as_xml(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = '{"resultCode": "00", "resultMsg": "NORMAL SERVICE."}'
+        body = '{"resultCode": 0, "resultMsg": "NORMAL SERVICE."}'
         result = classifier.classify_response(200, body)
         # Should NOT trigger xml gateway path
-        assert result.source != "xml_gateway"
+        assert result.source != "data_go_kr_xml"
+
+    def test_xml_gateway_prefix_detection(self, classifier: DataGoKrErrorClassifier) -> None:
+        """Verify <OpenAPI_ServiceResponse> prefix triggers XML gateway path."""
+        body = (
+            "<OpenAPI_ServiceResponse>"
+            "<returnReasonCode>30</returnReasonCode>"
+            "</OpenAPI_ServiceResponse>"
+        )
+        result = classifier.classify_response(200, body)
+        assert result.source == "data_go_kr_xml"
 
 
 # ---------------------------------------------------------------------------
-# JSON body classification
+# JSON body classification via sample_json_error_response fixture
 # ---------------------------------------------------------------------------
 
 
 class TestJsonBodyClassification:
-    def _make_body(self, code: int, msg: str = "test") -> str:
-        return json.dumps({"response": {"header": {"resultCode": code, "resultMsg": msg}}})
-
-    def test_code_0_normal_maps_to_unknown(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 0, "resultMsg": "NORMAL SERVICE."})
+    def test_code_0_normal_maps_to_unknown(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(0, "NORMAL SERVICE.")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.UNKNOWN  # code 0 on failure path = unknown
         assert result.raw_code == 0
 
-    def test_code_1_application_error(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 1})
+    def test_code_1_application_error(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(1, "APPLICATION_ERROR")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.APP_ERROR
         assert result.is_retryable is False
 
-    def test_code_2_db_error_is_transient(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 2})
+    def test_code_2_db_error_is_transient(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(2, "DB_ERROR")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.TRANSIENT
         assert result.is_retryable is True
 
-    def test_code_3_no_data(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 3})
+    def test_code_3_no_data(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(3, "NO_DATA")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.DATA_MISSING
         assert result.is_retryable is False
 
-    def test_code_4_http_error_is_transient(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 4})
+    def test_code_4_http_error_is_transient(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(4, "HTTP_ERROR")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.TRANSIENT
 
-    def test_code_5_service_timeout_is_transient(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 5})
+    def test_code_5_service_timeout_is_transient(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(5, "SERVICE_TIMEOUT")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.TRANSIENT
 
-    def test_code_10_invalid_param(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 10})
+    def test_code_10_invalid_param(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(10, "INVALID_REQUEST_PARAMETER")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.INVALID_REQUEST
         assert result.is_retryable is False
 
-    def test_code_11_missing_param(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 11})
+    def test_code_11_missing_param(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(11, "NO_REQUIRED_REQUEST_PARAMETER")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.INVALID_REQUEST
 
-    def test_code_20_service_not_found(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 20})
+    def test_code_20_service_not_found(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(20, "SERVICE_NOT_FOUND")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.DEPRECATED
 
-    def test_code_22_temporarily_disabled(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 22})
+    def test_code_22_temporarily_disabled(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(22, "TEMPORARILY_DISABLED")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.DEPRECATED
 
-    def test_code_30_rate_limit(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 30})
+    def test_code_30_rate_limit(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(30, "LIMIT_EXCEEDED")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.RATE_LIMIT
         assert result.is_retryable is True
 
-    def test_code_31_key_not_registered(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 31})
+    def test_code_31_key_not_registered(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(31, "SERVICE_KEY_NOT_REGISTERED")  # type: ignore[operator]
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.AUTH_FAILURE
 
-    def test_code_99_unknown(self, classifier: DataGoKrErrorClassifier) -> None:
-        body = json.dumps({"resultCode": 99})
+    def test_code_99_unknown(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(99, "UNKNOWN_ERROR")  # type: ignore[operator]
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.UNKNOWN
+        assert result.is_retryable is False
+
+    def test_unknown_result_code(self, classifier: DataGoKrErrorClassifier) -> None:
+        """Unknown resultCode should map to UNKNOWN with is_retryable=False."""
+        body = json.dumps({"resultCode": 777, "resultMsg": "unexpected"})
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.UNKNOWN
         assert result.is_retryable is False
@@ -205,6 +275,13 @@ class TestJsonBodyClassification:
         body = json.dumps({"resultCode": "30"})
         result = classifier.classify_response(200, body)
         assert result.error_class == ErrorClass.RATE_LIMIT
+
+    def test_json_source_label(
+        self, classifier: DataGoKrErrorClassifier, sample_json_error_response: object
+    ) -> None:
+        body = sample_json_error_response(1, "APP_ERROR")  # type: ignore[operator]
+        result = classifier.classify_response(200, body)
+        assert result.source == "data_go_kr_json"
 
 
 # ---------------------------------------------------------------------------
@@ -259,9 +336,15 @@ class TestHttpStatusClassification:
         assert result.is_retryable is False
         assert result.source == "http_status"
 
-    def test_418_unknown(self, classifier: DataGoKrErrorClassifier) -> None:
+    def test_other_4xx_unknown(self, classifier: DataGoKrErrorClassifier) -> None:
         result = classifier.classify_response(418, "I'm a teapot")
         assert result.error_class == ErrorClass.UNKNOWN
+        assert result.is_retryable is False
+
+    def test_empty_body(self, classifier: DataGoKrErrorClassifier) -> None:
+        """Empty response body with non-special status falls back to HTTP status."""
+        result = classifier.classify_response(500, "")
+        assert result.error_class == ErrorClass.APP_ERROR
         assert result.is_retryable is False
 
 
@@ -276,19 +359,14 @@ class TestExceptionClassification:
         result = classifier.classify_exception(exc)
         assert result.error_class == ErrorClass.TIMEOUT
         assert result.is_retryable is True
-        assert result.source == "exception"
+        assert result.source == "transport"
 
     def test_read_timeout(self, classifier: DataGoKrErrorClassifier) -> None:
         exc = httpx.ReadTimeout("read timed out")
         result = classifier.classify_exception(exc)
         assert result.error_class == ErrorClass.TIMEOUT
         assert result.is_retryable is True
-
-    def test_pool_timeout(self, classifier: DataGoKrErrorClassifier) -> None:
-        exc = httpx.PoolTimeout("pool timed out")
-        result = classifier.classify_exception(exc)
-        assert result.error_class == ErrorClass.TIMEOUT
-        assert result.is_retryable is True
+        assert result.source == "transport"
 
     def test_http_status_error_401(self, classifier: DataGoKrErrorClassifier) -> None:
         request = httpx.Request("GET", "https://api.example.com/")
@@ -311,7 +389,15 @@ class TestExceptionClassification:
         result = classifier.classify_exception(exc)
         assert result.error_class == ErrorClass.APP_ERROR
         assert result.is_retryable is False
-        assert result.source == "exception"
+        assert result.source == "unknown"
+
+    def test_non_httpx_exception(self, classifier: DataGoKrErrorClassifier) -> None:
+        """Any non-httpx exception should be classified as APP_ERROR with source=unknown."""
+        exc = RuntimeError("crash")
+        result = classifier.classify_exception(exc)
+        assert result.error_class == ErrorClass.APP_ERROR
+        assert result.is_retryable is False
+        assert result.source == "unknown"
 
 
 # ---------------------------------------------------------------------------
@@ -326,7 +412,24 @@ class TestClassifiedError:
             is_retryable=True,
             raw_code=5,
             raw_message="timeout",
-            source="json_body",
+            source="data_go_kr_json",
         )
-        with pytest.raises((ValueError, TypeError, AttributeError)):
+        with pytest.raises(Exception):  # noqa: B017
             err.error_class = ErrorClass.UNKNOWN  # type: ignore[misc]
+
+    def test_defaults_for_optional_fields(self) -> None:
+        """raw_message and source have empty string defaults."""
+        err = ClassifiedError(
+            error_class=ErrorClass.UNKNOWN,
+            is_retryable=False,
+        )
+        assert err.raw_message == ""
+        assert err.source == ""
+        assert err.raw_code is None
+
+    def test_normal_code_handling(self, classifier: DataGoKrErrorClassifier) -> None:
+        """Normal code (0) on the failure path should produce UNKNOWN, not retryable."""
+        body = json.dumps({"resultCode": 0, "resultMsg": "NORMAL SERVICE."})
+        result = classifier.classify_response(200, body)
+        assert result.error_class == ErrorClass.UNKNOWN
+        assert result.is_retryable is False

--- a/tests/recovery/test_executor.py
+++ b/tests/recovery/test_executor.py
@@ -1,0 +1,240 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for RecoveryExecutor."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from kosmos.recovery.circuit_breaker import CircuitBreakerConfig, CircuitState
+from kosmos.recovery.executor import RecoveryExecutor
+from kosmos.recovery.retry import ToolRetryPolicy
+from kosmos.tools.models import GovAPITool
+
+
+class _DummyInput(BaseModel):
+    query: str
+
+
+class _DummyOutput(BaseModel):
+    result: str
+
+
+@pytest.fixture()
+def cacheable_tool() -> GovAPITool:
+    return GovAPITool(
+        id="cache_tool",
+        name_ko="캐시 도구",
+        provider="기관",
+        category=["test"],
+        endpoint="https://api.example.com/",
+        auth_type="api_key",
+        input_schema=_DummyInput,
+        output_schema=_DummyOutput,
+        search_hint="cache test",
+        requires_auth=False,
+        is_concurrency_safe=False,
+        is_personal_data=False,
+        cache_ttl_seconds=60,
+        rate_limit_per_minute=100,
+    )
+
+
+@pytest.fixture()
+def no_cache_tool() -> GovAPITool:
+    return GovAPITool(
+        id="no_cache_tool",
+        name_ko="캐시없음 도구",
+        provider="기관",
+        category=["test"],
+        endpoint="https://api.example.com/",
+        auth_type="api_key",
+        input_schema=_DummyInput,
+        output_schema=_DummyOutput,
+        search_hint="no cache test",
+        requires_auth=False,
+        is_concurrency_safe=False,
+        is_personal_data=False,
+        cache_ttl_seconds=0,
+        rate_limit_per_minute=100,
+    )
+
+
+@pytest.fixture()
+def fast_executor() -> RecoveryExecutor:
+    """RecoveryExecutor with zero delays and tight circuit config for testing."""
+    return RecoveryExecutor(
+        retry_policy=ToolRetryPolicy(
+            max_retries=2,
+            base_delay=0.0,
+            multiplier=1.0,
+            max_delay=0.0,
+        ),
+        circuit_config=CircuitBreakerConfig(
+            failure_threshold=3,
+            recovery_timeout=60.0,  # won't auto-recover in tests
+            half_open_max_calls=1,
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+async def test_success_returns_tool_result(
+    fast_executor: RecoveryExecutor,
+    no_cache_tool: GovAPITool,
+) -> None:
+    async def adapter(args: object) -> dict[str, object]:
+        return {"result": "ok"}
+
+    result = await fast_executor.execute(no_cache_tool, adapter, _DummyInput(query="hi"))
+    assert result.tool_result.success is True
+    assert result.tool_result.data == {"result": "ok"}
+    assert result.error_context is None
+
+
+# ---------------------------------------------------------------------------
+# Cache hit
+# ---------------------------------------------------------------------------
+
+
+async def test_cache_hit_on_second_call(
+    fast_executor: RecoveryExecutor,
+    cacheable_tool: GovAPITool,
+) -> None:
+    call_count = 0
+
+    async def adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        return {"result": "cached"}
+
+    inp = _DummyInput(query="hello")
+    await fast_executor.execute(cacheable_tool, adapter, inp)
+    result2 = await fast_executor.execute(cacheable_tool, adapter, inp)
+
+    assert call_count == 1  # second call used cache
+    assert result2.tool_result.success is True
+    assert result2.tool_result.data == {"result": "cached"}
+    assert result2.error_context is None
+
+
+# ---------------------------------------------------------------------------
+# No cache when ttl=0
+# ---------------------------------------------------------------------------
+
+
+async def test_no_cache_when_ttl_zero(
+    fast_executor: RecoveryExecutor,
+    no_cache_tool: GovAPITool,
+) -> None:
+    call_count = 0
+
+    async def adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        return {"result": "fresh"}
+
+    inp = _DummyInput(query="hello")
+    await fast_executor.execute(no_cache_tool, adapter, inp)
+    await fast_executor.execute(no_cache_tool, adapter, inp)
+    assert call_count == 2
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker blocks after threshold
+# ---------------------------------------------------------------------------
+
+
+async def test_circuit_open_blocks_after_threshold(
+    fast_executor: RecoveryExecutor,
+    no_cache_tool: GovAPITool,
+) -> None:
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(503, request=request)
+    exc = httpx.HTTPStatusError("503", request=request, response=response)
+
+    async def always_fail(args: object) -> dict[str, object]:
+        raise exc
+
+    inp = _DummyInput(query="test")
+    # 3 failures needed to open circuit (threshold=3, max_retries=2 so each call = 3 attempts)
+    for _ in range(3):
+        await fast_executor.execute(no_cache_tool, always_fail, inp)
+
+    # Now circuit should be OPEN
+    breaker = fast_executor._registry.get(no_cache_tool.id)  # noqa: SLF001
+    assert breaker.state == CircuitState.OPEN
+
+    # Next call should return circuit_open error
+    result = await fast_executor.execute(no_cache_tool, always_fail, inp)
+    assert result.tool_result.success is False
+    assert result.tool_result.error_type == "circuit_open"
+    assert result.error_context is not None
+    assert result.error_context.circuit_state == CircuitState.OPEN
+
+
+# ---------------------------------------------------------------------------
+# Degradation message on exhaustion
+# ---------------------------------------------------------------------------
+
+
+async def test_degradation_message_on_exhaustion(
+    fast_executor: RecoveryExecutor,
+    no_cache_tool: GovAPITool,
+) -> None:
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(503, request=request)
+    exc = httpx.HTTPStatusError("503", request=request, response=response)
+
+    async def always_fail(args: object) -> dict[str, object]:
+        raise exc
+
+    result = await fast_executor.execute(no_cache_tool, always_fail, _DummyInput(query="test"))
+    assert result.tool_result.success is False
+    assert result.tool_result.error is not None
+    assert no_cache_tool.name_ko in result.tool_result.error
+    assert result.error_context is not None
+    assert result.error_context.attempt_count > 0
+
+
+# ---------------------------------------------------------------------------
+# Error context populated on failure
+# ---------------------------------------------------------------------------
+
+
+async def test_error_context_populated(
+    fast_executor: RecoveryExecutor,
+    no_cache_tool: GovAPITool,
+) -> None:
+    async def always_fail(args: object) -> dict[str, object]:
+        raise httpx.ReadTimeout("timeout")
+
+    result = await fast_executor.execute(no_cache_tool, always_fail, _DummyInput(query="x"))
+    assert result.error_context is not None
+    ctx = result.error_context
+    assert ctx.tool_id == no_cache_tool.id
+    assert ctx.attempt_count > 0
+    assert ctx.elapsed_seconds >= 0.0
+    assert ctx.is_cached_fallback is False
+
+
+# ---------------------------------------------------------------------------
+# Never raises
+# ---------------------------------------------------------------------------
+
+
+async def test_executor_never_raises(
+    fast_executor: RecoveryExecutor,
+    no_cache_tool: GovAPITool,
+) -> None:
+    async def raise_runtime(args: object) -> dict[str, object]:
+        raise RuntimeError("unexpected crash")
+
+    # Should not raise
+    result = await fast_executor.execute(no_cache_tool, raise_runtime, _DummyInput(query="boom"))
+    assert result.tool_result.success is False

--- a/tests/recovery/test_integration.py
+++ b/tests/recovery/test_integration.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests: RecoveryExecutor wired into ToolExecutor."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from pydantic import BaseModel
+
+from kosmos.recovery.executor import RecoveryExecutor
+from kosmos.recovery.retry import ToolRetryPolicy
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
+
+
+class _In(BaseModel):
+    query: str
+
+
+class _Out(BaseModel):
+    result: str
+
+
+@pytest.fixture()
+def tool() -> GovAPITool:
+    return GovAPITool(
+        id="integ_tool",
+        name_ko="통합 테스트 도구",
+        provider="기관",
+        category=["test"],
+        endpoint="https://api.example.com/",
+        auth_type="api_key",
+        input_schema=_In,
+        output_schema=_Out,
+        search_hint="integration test 통합테스트",
+        requires_auth=False,
+        is_concurrency_safe=False,
+        is_personal_data=False,
+        cache_ttl_seconds=0,
+        rate_limit_per_minute=100,
+    )
+
+
+@pytest.fixture()
+def recovery() -> RecoveryExecutor:
+    return RecoveryExecutor(
+        retry_policy=ToolRetryPolicy(
+            max_retries=1,
+            base_delay=0.0,
+            multiplier=1.0,
+            max_delay=0.0,
+        ),
+    )
+
+
+@pytest.fixture()
+def registry_with_tool(tool: GovAPITool) -> ToolRegistry:
+    registry = ToolRegistry()
+    registry.register(tool)
+    return registry
+
+
+# ---------------------------------------------------------------------------
+# Backward compatibility: no RecoveryExecutor
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_executor_without_recovery(
+    tool: GovAPITool,
+    registry_with_tool: ToolRegistry,
+) -> None:
+    """ToolExecutor works normally without a RecoveryExecutor."""
+    executor = ToolExecutor(registry=registry_with_tool)
+
+    async def adapter(args: _In) -> dict[str, object]:
+        return {"result": "direct"}
+
+    executor.register_adapter("integ_tool", adapter)
+    result = await executor.dispatch("integ_tool", '{"query": "hello"}')
+    assert result.success is True
+    assert result.data == {"result": "direct"}
+
+
+# ---------------------------------------------------------------------------
+# With RecoveryExecutor: success path
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_executor_with_recovery_success(
+    tool: GovAPITool,
+    registry_with_tool: ToolRegistry,
+    recovery: RecoveryExecutor,
+) -> None:
+    """ToolExecutor with RecoveryExecutor succeeds on clean adapter."""
+    executor = ToolExecutor(registry=registry_with_tool, recovery_executor=recovery)
+
+    async def adapter(args: _In) -> dict[str, object]:
+        return {"result": "via_recovery"}
+
+    executor.register_adapter("integ_tool", adapter)
+    result = await executor.dispatch("integ_tool", '{"query": "hello"}')
+    assert result.success is True
+    assert result.data == {"result": "via_recovery"}
+
+
+# ---------------------------------------------------------------------------
+# With RecoveryExecutor: retried failure
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_executor_with_recovery_retries(
+    tool: GovAPITool,
+    registry_with_tool: ToolRegistry,
+    recovery: RecoveryExecutor,
+) -> None:
+    """ToolExecutor delegates retries to RecoveryExecutor."""
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(503, request=request)
+    exc = httpx.HTTPStatusError("503", request=request, response=response)
+
+    async def flaky_adapter(args: _In) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 2:
+            raise exc
+        return {"result": "recovered"}
+
+    executor = ToolExecutor(registry=registry_with_tool, recovery_executor=recovery)
+    executor.register_adapter("integ_tool", flaky_adapter)
+    result = await executor.dispatch("integ_tool", '{"query": "test"}')
+    assert result.success is True
+    assert call_count == 2  # one retry
+
+
+# ---------------------------------------------------------------------------
+# With RecoveryExecutor: non-retryable failure passes through
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_executor_with_recovery_non_retryable(
+    tool: GovAPITool,
+    registry_with_tool: ToolRegistry,
+    recovery: RecoveryExecutor,
+) -> None:
+    """Non-retryable errors result in ToolResult(success=False)."""
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(401, request=request)
+    exc = httpx.HTTPStatusError("401", request=request, response=response)
+
+    async def auth_fail_adapter(args: _In) -> dict[str, object]:
+        raise exc
+
+    executor = ToolExecutor(registry=registry_with_tool, recovery_executor=recovery)
+    executor.register_adapter("integ_tool", auth_fail_adapter)
+    result = await executor.dispatch("integ_tool", '{"query": "test"}')
+    assert result.success is False
+    assert result.error_type in ("auth_expired", "execution", "api_error")

--- a/tests/recovery/test_retry.py
+++ b/tests/recovery/test_retry.py
@@ -1,0 +1,266 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the retry policy and retry_tool_call loop."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+from kosmos.recovery.classifier import DataGoKrErrorClassifier, ErrorClass
+from kosmos.recovery.retry import ToolRetryPolicy, retry_tool_call
+
+
+@pytest.fixture()
+def classifier() -> DataGoKrErrorClassifier:
+    return DataGoKrErrorClassifier()
+
+
+@pytest.fixture()
+def fast_policy() -> ToolRetryPolicy:
+    """Policy with zero delays for testing."""
+    return ToolRetryPolicy(
+        max_retries=3,
+        base_delay=0.0,
+        multiplier=1.0,
+        max_delay=0.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Success path
+# ---------------------------------------------------------------------------
+
+
+async def test_success_on_first_attempt(
+    classifier: DataGoKrErrorClassifier,
+    fast_policy: ToolRetryPolicy,
+) -> None:
+    call_count = 0
+
+    async def good_adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        return {"data": "ok"}
+
+    result, err, attempts = await retry_tool_call(
+        good_adapter, None, classifier, fast_policy, is_foreground=True
+    )
+    assert result == {"data": "ok"}
+    assert err is None
+    assert attempts == 1
+    assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Retry on 429 (rate limit)
+# ---------------------------------------------------------------------------
+
+
+async def test_retry_on_rate_limit_429(
+    classifier: DataGoKrErrorClassifier,
+    fast_policy: ToolRetryPolicy,
+) -> None:
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(429, request=request)
+    exc = httpx.HTTPStatusError("429", request=request, response=response)
+
+    async def flaky_adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            raise exc
+        return {"data": "ok"}
+
+    result, err, attempts = await retry_tool_call(
+        flaky_adapter, None, classifier, fast_policy, is_foreground=True
+    )
+    assert result == {"data": "ok"}
+    assert err is None
+    assert attempts == 3
+    assert call_count == 3
+
+
+# ---------------------------------------------------------------------------
+# Retry on timeout
+# ---------------------------------------------------------------------------
+
+
+async def test_retry_on_timeout(
+    classifier: DataGoKrErrorClassifier,
+    fast_policy: ToolRetryPolicy,
+) -> None:
+    call_count = 0
+
+    async def timeout_adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            raise httpx.ReadTimeout("read timed out")
+        return {"data": "ok"}
+
+    result, err, attempts = await retry_tool_call(
+        timeout_adapter, None, classifier, fast_policy, is_foreground=True
+    )
+    assert result == {"data": "ok"}
+    assert attempts == 2
+
+
+# ---------------------------------------------------------------------------
+# No retry on non-retryable errors
+# ---------------------------------------------------------------------------
+
+
+async def test_no_retry_on_400(
+    classifier: DataGoKrErrorClassifier,
+    fast_policy: ToolRetryPolicy,
+) -> None:
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(400, request=request)
+    exc = httpx.HTTPStatusError("400 Bad Request", request=request, response=response)
+
+    async def bad_adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        raise exc
+
+    result, err, attempts = await retry_tool_call(
+        bad_adapter, None, classifier, fast_policy, is_foreground=True
+    )
+    assert result is None
+    assert err is not None
+    assert err.error_class == ErrorClass.INVALID_REQUEST
+    assert attempts == 1
+    assert call_count == 1
+
+
+async def test_no_retry_on_401(
+    classifier: DataGoKrErrorClassifier,
+    fast_policy: ToolRetryPolicy,
+) -> None:
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(401, request=request)
+    exc = httpx.HTTPStatusError("401", request=request, response=response)
+
+    async def auth_fail_adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        raise exc
+
+    result, err, attempts = await retry_tool_call(
+        auth_fail_adapter, None, classifier, fast_policy, is_foreground=True
+    )
+    assert result is None
+    assert err is not None
+    assert err.error_class == ErrorClass.AUTH_FAILURE
+    assert attempts == 1
+    assert call_count == 1  # no retries
+
+
+# ---------------------------------------------------------------------------
+# max_retries=0
+# ---------------------------------------------------------------------------
+
+
+async def test_max_retries_zero(
+    classifier: DataGoKrErrorClassifier,
+) -> None:
+    policy = ToolRetryPolicy(max_retries=0, base_delay=0.0, multiplier=1.0, max_delay=0.0)
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(503, request=request)
+    exc = httpx.HTTPStatusError("503", request=request, response=response)
+
+    async def fail_adapter(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        raise exc
+
+    result, err, attempts = await retry_tool_call(
+        fail_adapter, None, classifier, policy, is_foreground=True
+    )
+    assert result is None
+    assert err is not None
+    assert attempts == 1
+    assert call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Foreground vs background retry cap
+# ---------------------------------------------------------------------------
+
+
+async def test_background_retry_cap(
+    classifier: DataGoKrErrorClassifier,
+) -> None:
+    """Background calls should be capped at min(1, max_retries)."""
+    policy = ToolRetryPolicy(max_retries=3, base_delay=0.0, multiplier=1.0, max_delay=0.0)
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(429, request=request)
+    exc = httpx.HTTPStatusError("429", request=request, response=response)
+
+    async def always_fail(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        raise exc
+
+    result, err, attempts = await retry_tool_call(
+        always_fail, None, classifier, policy, is_foreground=False
+    )
+    assert result is None
+    # Background: min(1, 3) = 1, so total attempts = initial + 1 = 2
+    assert call_count <= 2
+
+
+async def test_foreground_uses_full_budget(
+    classifier: DataGoKrErrorClassifier,
+) -> None:
+    """Foreground calls use the full max_retries budget."""
+    policy = ToolRetryPolicy(max_retries=3, base_delay=0.0, multiplier=1.0, max_delay=0.0)
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(503, request=request)
+    exc = httpx.HTTPStatusError("503", request=request, response=response)
+
+    async def always_fail(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        raise exc
+
+    result, err, attempts = await retry_tool_call(
+        always_fail, None, classifier, policy, is_foreground=True
+    )
+    assert result is None
+    assert call_count == 4  # 1 initial + 3 retries
+
+
+# ---------------------------------------------------------------------------
+# Returns attempt count correctly on exhaustion
+# ---------------------------------------------------------------------------
+
+
+async def test_attempt_count_on_exhaustion(
+    classifier: DataGoKrErrorClassifier,
+    fast_policy: ToolRetryPolicy,
+) -> None:
+    call_count = 0
+    request = httpx.Request("GET", "https://api.example.com/")
+    response = httpx.Response(503, request=request)
+    exc = httpx.HTTPStatusError("503", request=request, response=response)
+
+    async def always_fail(args: object) -> dict[str, object]:
+        nonlocal call_count
+        call_count += 1
+        raise exc
+
+    result, err, attempts = await retry_tool_call(
+        always_fail, None, classifier, fast_policy, is_foreground=True
+    )
+    assert result is None
+    assert err is not None
+    assert err.error_class == ErrorClass.TRANSIENT
+    assert attempts == 4  # 1 initial + 3 retries
+    assert call_count == 4

--- a/tests/recovery/test_streaming_retry.py
+++ b/tests/recovery/test_streaming_retry.py
@@ -1,0 +1,167 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for StreamInterruptedError retry logic in query.py."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+
+from kosmos.engine.config import QueryEngineConfig
+from kosmos.engine.events import QueryEvent, StopReason
+from kosmos.engine.models import QueryContext, QueryState
+from kosmos.engine.query import query
+from kosmos.llm.client import LLMClient  # noqa: F401 — needed for model_rebuild
+from kosmos.llm.errors import StreamInterruptedError
+from kosmos.llm.models import ChatMessage, StreamEvent, TokenUsage
+from kosmos.llm.usage import UsageTracker
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.registry import ToolRegistry
+
+# Rebuild QueryContext so model_construct() works with mock llm_client objects
+QueryContext.model_rebuild()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _content_event(text: str) -> StreamEvent:
+    return StreamEvent(
+        type="content_delta",
+        content=text,
+        tool_call_index=None,
+        tool_call_id=None,
+        function_name=None,
+        function_args_delta=None,
+        usage=None,
+    )
+
+
+def _usage_event() -> StreamEvent:
+    return StreamEvent(
+        type="usage",
+        content=None,
+        tool_call_index=None,
+        tool_call_id=None,
+        function_name=None,
+        function_args_delta=None,
+        usage=TokenUsage(input_tokens=10, output_tokens=5),
+    )
+
+
+async def _collect(ctx: QueryContext) -> list[QueryEvent]:
+    events: list[QueryEvent] = []
+    async for event in query(ctx):  # type: ignore[arg-type]
+        events.append(event)
+    return events
+
+
+# ---------------------------------------------------------------------------
+# Mock LLM client
+# ---------------------------------------------------------------------------
+
+
+class _MockInterruptingClient:
+    """LLM client that raises StreamInterruptedError on the first call,
+    then yields normal events on subsequent calls."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.usage = UsageTracker(budget=100_000)
+
+    async def stream(
+        self,
+        messages: list[ChatMessage],
+        **kwargs: object,
+    ) -> AsyncIterator[StreamEvent]:
+        self.call_count += 1
+        if self.call_count == 1:
+            raise StreamInterruptedError("stream cut on first call")
+        yield _content_event("hello")
+        yield _usage_event()
+
+
+class _MockAlwaysInterruptingClient:
+    """LLM client that always raises StreamInterruptedError."""
+
+    def __init__(self) -> None:
+        self.call_count = 0
+        self.usage = UsageTracker(budget=100_000)
+
+    async def stream(
+        self,
+        messages: list[ChatMessage],
+        **kwargs: object,
+    ) -> AsyncIterator[StreamEvent]:
+        self.call_count += 1
+        raise StreamInterruptedError("stream always cut")
+        yield  # type: ignore[misc]  # make it an async generator
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_ctx(llm_client: object) -> QueryContext:
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry=registry)
+    usage = UsageTracker(budget=100_000)
+    state = QueryState(
+        usage=usage,
+        messages=[ChatMessage(role="user", content="hello")],
+    )
+    config = QueryEngineConfig(max_iterations=5)
+    return QueryContext.model_construct(
+        state=state,
+        config=config,
+        llm_client=llm_client,
+        tool_registry=registry,
+        tool_executor=executor,
+        permission_pipeline=None,
+        session_context=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStreamInterruptedErrorRetry:
+    async def test_first_interruption_retries(self) -> None:
+        """On the first StreamInterruptedError, query retries and succeeds."""
+        client = _MockInterruptingClient()
+        ctx = _make_ctx(client)
+
+        events = await _collect(ctx)
+
+        stop_events = [e for e in events if e.type == "stop"]
+        assert len(stop_events) == 1
+        assert stop_events[0].stop_reason == StopReason.end_turn
+        assert client.call_count == 2
+
+    async def test_second_interruption_is_unrecoverable(self) -> None:
+        """On the second StreamInterruptedError, query stops with error_unrecoverable."""
+        client = _MockAlwaysInterruptingClient()
+        ctx = _make_ctx(client)
+
+        events = await _collect(ctx)
+
+        stop_events = [e for e in events if e.type == "stop"]
+        assert len(stop_events) == 1
+        assert stop_events[0].stop_reason == StopReason.error_unrecoverable
+        assert "interrupted" in (stop_events[0].stop_message or "").lower()
+        assert client.call_count == 2  # initial + one retry
+
+    async def test_interruption_count_resets_across_turns(self) -> None:
+        """The interrupted count tracks per iteration of the while loop."""
+        # Each call to stream() raises StreamInterruptedError; after 2 raises
+        # the engine gives up with error_unrecoverable.
+        client = _MockAlwaysInterruptingClient()
+        ctx = _make_ctx(client)
+
+        events = await _collect(ctx)
+
+        stop_events = [e for e in events if e.type == "stop"]
+        assert stop_events[-1].stop_reason == StopReason.error_unrecoverable


### PR DESCRIPTION
## Summary

Closes #10

- Adds complete `src/kosmos/recovery/` package implementing Layer 6 Error Recovery for `data.go.kr` tool calls
- **DataGoKrErrorClassifier**: maps HTTP status, JSON `resultCode`, and XML gateway errors to normalized `ErrorClass` values (string-only parsing, no XML parser per NFR-006)
- **ToolRetryPolicy + retry_tool_call**: exponential back-off with full jitter, foreground/background retry budget split
- **CircuitBreaker + CircuitBreakerRegistry**: 3-state machine (CLOSED/OPEN/HALF_OPEN) with configurable threshold and recovery timeout
- **ResponseCache**: bounded LRU in-memory cache (SHA-256 key, TTL-aware)
- **build_degradation_message**: Korean-language citizen-facing error messages
- **RecoveryExecutor**: orchestrates all components; never raises; integrates into `ToolExecutor` as optional dependency (backward-compatible)
- Extends `ToolResult.error_type` with 4 new values: `timeout`, `circuit_open`, `api_error`, `auth_expired`
- Adds `StreamInterruptedError` single-retry logic to `query()` generator

## Quality

- **105 tests** passing (94% coverage)
- mypy strict clean
- ruff lint + format clean
- Full test suite: **772 passed**, no regressions

## Test plan

- [x] `uv run pytest tests/recovery/ -v` — all 105 tests pass
- [x] `uv run pytest` — full suite 772 passed, no regressions
- [x] `uv run mypy src/kosmos/recovery/` — strict clean
- [x] `uv run ruff check src/kosmos/recovery/` — clean
- [x] Coverage >= 80% (actual: 93.86%)