### PR TITLE
feat(cli): implement Python CLI rapid prototype (Phase A)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,7 +74,18 @@ Conventional Commits. Branches: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, 
 
 Cloudflare Worker (`infra/copilot-gate-app/`) → Check Run gate. **CRITICAL >= 1 → fail**, **IMPORTANT >= 3 → fail**, else pass. Deploy: `cd infra/copilot-gate-app && npx wrangler deploy`.
 
-GraphQL `requestReviewsByLogin` has **~1/3 failure rate**. After every push: if gate stays `in_progress` for 2+ min, manually re-request Copilot review. If that also fails, add label `copilot-review-bypass`. Full procedure: `docs/copilot-gate.md`.
+**After every push (including fix commits from Copilot review feedback):**
+1. Read Copilot review comments (`gh api 'repos/OWNER/REPO/pulls/N/comments'`), fix issues, commit and push.
+2. **Always** re-request Copilot review via GraphQL after push — it does NOT auto-trigger:
+   ```bash
+   PR_NODE_ID=$(gh api repos/umyunsang/KOSMOS/pulls/<N> --jq '.node_id')
+   gh api graphql -f query='mutation($input: RequestReviewsByLoginInput!) { requestReviewsByLogin(input: $input) { pullRequest { id } } }' \
+     -F "input[pullRequestId]=$PR_NODE_ID" -F 'input[botLogins][]=copilot-pull-request-reviewer[bot]' -F 'input[union]:=true'
+   ```
+3. If gate stays `pending`/`in_progress` for 2+ min after re-request, add label `copilot-review-bypass`.
+4. `requestReviewsByLogin` has **~1/3 failure rate** — retry once before resorting to bypass label.
+
+Full procedure: `docs/copilot-gate.md`.
 
 ## New tool adapter
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,11 @@ dependencies = [
     "pydantic-settings>=2.0",
     "typer>=0.24.1",
     "rich>=13.0",
+    "prompt-toolkit>=3.0",
 ]
+
+[project.scripts]
+kosmos = "kosmos.cli.app:main"
 
 [project.optional-dependencies]
 dev = [

--- a/src/kosmos/cli/__init__.py
+++ b/src/kosmos/cli/__init__.py
@@ -1,0 +1,21 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KOSMOS CLI package — Python rapid-prototype CLI for the citizen conversation loop."""
+
+from __future__ import annotations
+
+from kosmos.cli.app import main
+from kosmos.cli.config import CLIConfig
+from kosmos.cli.models import COMMANDS, SlashCommand
+from kosmos.cli.permissions import ConsentPromptHandler
+from kosmos.cli.renderer import EventRenderer
+from kosmos.cli.repl import REPLLoop
+
+__all__ = [
+    "main",
+    "CLIConfig",
+    "COMMANDS",
+    "SlashCommand",
+    "ConsentPromptHandler",
+    "EventRenderer",
+    "REPLLoop",
+]

--- a/src/kosmos/cli/__main__.py
+++ b/src/kosmos/cli/__main__.py
@@ -1,0 +1,9 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Entry point for ``python -m kosmos.cli``."""
+
+from __future__ import annotations
+
+from kosmos.cli.app import main
+
+if __name__ == "__main__":
+    main()

--- a/src/kosmos/cli/app.py
+++ b/src/kosmos/cli/app.py
@@ -114,7 +114,7 @@ def _run_repl() -> None:
     )
 
     # --- Launch REPL ---
-    renderer = EventRenderer(console, registry=registry)
+    renderer = EventRenderer(console, registry=registry, show_usage=config.show_usage)
     repl = REPLLoop(
         engine=engine,
         registry=registry,

--- a/src/kosmos/cli/app.py
+++ b/src/kosmos/cli/app.py
@@ -1,0 +1,139 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KOSMOS CLI entry point — initialises the backend stack and launches the REPL."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from typing import Annotated
+
+import typer
+from rich.console import Console
+
+from kosmos.cli.config import CLIConfig
+from kosmos.cli.renderer import EventRenderer
+from kosmos.cli.repl import REPLLoop
+
+logger = logging.getLogger(__name__)
+
+# KOSMOS version string
+__version__ = "0.1.0"
+
+# Typer application
+_app = typer.Typer(
+    name="kosmos",
+    help="KOSMOS — Korean Public API Conversational Platform",
+    add_completion=False,
+)
+
+_stderr_console = Console(stderr=True)
+
+
+def _version_callback(value: bool) -> None:
+    if value:
+        typer.echo(f"kosmos {__version__}")
+        raise typer.Exit()
+
+
+@_app.command()
+def _cli_command(
+    version: Annotated[
+        bool,
+        typer.Option(
+            "--version",
+            "-v",
+            help="Show version and exit.",
+            callback=_version_callback,
+            is_eager=True,
+        ),
+    ] = False,
+    debug: Annotated[
+        bool,
+        typer.Option("--debug", help="Enable debug logging."),
+    ] = False,
+) -> None:
+    """Launch the KOSMOS interactive CLI."""
+    if debug:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.WARNING)
+
+    _run_repl()
+
+
+def _run_repl() -> None:
+    """Initialise the full backend stack and run the REPL.
+
+    All initialisation errors are caught and printed as user-friendly messages.
+    """
+    from kosmos.context.builder import ContextBuilder
+    from kosmos.engine.engine import QueryEngine
+    from kosmos.llm.client import LLMClient
+    from kosmos.llm.errors import ConfigurationError
+    from kosmos.tools.executor import ToolExecutor
+    from kosmos.tools.register_all import register_all_tools
+    from kosmos.tools.registry import ToolRegistry
+
+    console = Console()
+
+    # --- Load CLI config ---
+    try:
+        config = CLIConfig()
+    except Exception as exc:  # noqa: BLE001
+        _stderr_console.print(f"[red]CLI 설정 오류:[/red] {exc}")
+        sys.exit(1)
+
+    # --- Initialise LLM client ---
+    try:
+        llm_client = LLMClient()
+    except ConfigurationError as exc:
+        _stderr_console.print(
+            f"[red]설정 오류:[/red] {exc}\n\n"
+            "[dim]KOSMOS_FRIENDLI_TOKEN 환경 변수가 설정되어 있는지 확인하세요.[/dim]"
+        )
+        sys.exit(1)
+    except Exception as exc:  # noqa: BLE001
+        _stderr_console.print(f"[red]LLM 클라이언트 초기화 오류:[/red] {exc}")
+        sys.exit(1)
+
+    # --- Initialise tool registry and executor ---
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry)
+    register_all_tools(registry, executor)
+
+    # --- Initialise context builder ---
+    context_builder = ContextBuilder(registry=registry)
+
+    # --- Initialise query engine ---
+    engine = QueryEngine(
+        llm_client=llm_client,
+        tool_registry=registry,
+        tool_executor=executor,
+        context_builder=context_builder,
+    )
+
+    # --- Launch REPL ---
+    renderer = EventRenderer(console, registry=registry)
+    repl = REPLLoop(
+        engine=engine,
+        registry=registry,
+        console=console,
+        config=config,
+        renderer=renderer,
+    )
+
+    try:
+        asyncio.run(repl.run())
+    except KeyboardInterrupt:
+        console.print("\n[dim]종료합니다.[/dim]")
+        sys.exit(130)
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("Unexpected error in REPL: %s", exc)
+        _stderr_console.print(f"[red]예상치 못한 오류:[/red] {exc}")
+        sys.exit(1)
+
+
+def main() -> None:
+    """Public entry point called by ``[project.scripts]`` and ``__main__.py``."""
+    _app()

--- a/src/kosmos/cli/app.py
+++ b/src/kosmos/cli/app.py
@@ -10,6 +10,7 @@ from typing import Annotated
 
 import typer
 from rich.console import Console
+from rich.markup import escape
 
 from kosmos.cli.config import CLIConfig
 from kosmos.cli.renderer import EventRenderer
@@ -36,7 +37,7 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
-@_app.command()
+@_app.callback(invoke_without_command=True)
 def _cli_command(
     version: Annotated[
         bool,
@@ -81,7 +82,7 @@ def _run_repl() -> None:
     try:
         config = CLIConfig()
     except Exception as exc:  # noqa: BLE001
-        _stderr_console.print(f"[red]CLI 설정 오류:[/red] {exc}")
+        _stderr_console.print(f"[red]CLI 설정 오류:[/red] {escape(str(exc))}")
         sys.exit(1)
 
     # --- Initialise LLM client ---
@@ -89,12 +90,12 @@ def _run_repl() -> None:
         llm_client = LLMClient()
     except ConfigurationError as exc:
         _stderr_console.print(
-            f"[red]설정 오류:[/red] {exc}\n\n"
+            f"[red]설정 오류:[/red] {escape(str(exc))}\n\n"
             "[dim]KOSMOS_FRIENDLI_TOKEN 환경 변수가 설정되어 있는지 확인하세요.[/dim]"
         )
         sys.exit(1)
     except Exception as exc:  # noqa: BLE001
-        _stderr_console.print(f"[red]LLM 클라이언트 초기화 오류:[/red] {exc}")
+        _stderr_console.print(f"[red]LLM 클라이언트 초기화 오류:[/red] {escape(str(exc))}")
         sys.exit(1)
 
     # --- Initialise tool registry and executor ---
@@ -130,7 +131,7 @@ def _run_repl() -> None:
         sys.exit(130)
     except Exception as exc:  # noqa: BLE001
         logger.exception("Unexpected error in REPL: %s", exc)
-        _stderr_console.print(f"[red]예상치 못한 오류:[/red] {exc}")
+        _stderr_console.print(f"[red]예상치 못한 오류:[/red] {escape(str(exc))}")
         sys.exit(1)
 
 

--- a/src/kosmos/cli/config.py
+++ b/src/kosmos/cli/config.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+from pydantic import Field
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
 
@@ -16,7 +17,7 @@ class CLIConfig(BaseSettings):
 
     model_config = SettingsConfigDict(env_prefix="KOSMOS_CLI_")
 
-    history_size: int = 1000
+    history_size: int = Field(default=1000, ge=0)
     """Maximum number of REPL history entries to persist."""
 
     show_usage: bool = True

--- a/src/kosmos/cli/config.py
+++ b/src/kosmos/cli/config.py
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI configuration loaded from environment variables with ``KOSMOS_CLI_`` prefix."""
+
+from __future__ import annotations
+
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+
+class CLIConfig(BaseSettings):
+    """Runtime configuration for the KOSMOS CLI.
+
+    All fields are configurable via environment variables prefixed with
+    ``KOSMOS_CLI_``.  For example, ``KOSMOS_CLI_SHOW_USAGE=false`` disables
+    the per-turn usage summary.
+    """
+
+    model_config = SettingsConfigDict(env_prefix="KOSMOS_CLI_")
+
+    history_size: int = 1000
+    """Maximum number of REPL history entries to persist."""
+
+    show_usage: bool = True
+    """Whether to display token usage after each response."""
+
+    welcome_banner: bool = True
+    """Whether to show the welcome banner on startup."""

--- a/src/kosmos/cli/models.py
+++ b/src/kosmos/cli/models.py
@@ -1,0 +1,38 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Data models and constants for the KOSMOS CLI slash-command system."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SlashCommand(BaseModel):
+    """A CLI slash command definition.
+
+    Attributes:
+        name: Primary command name (e.g. ``"help"``).
+        description: One-line description shown in ``/help`` output.
+        aliases: Additional names that trigger this command.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    name: str
+    description: str
+    aliases: tuple[str, ...] = ()
+
+
+# ---------------------------------------------------------------------------
+# Registry of available slash commands
+# ---------------------------------------------------------------------------
+
+COMMANDS: dict[str, SlashCommand] = {
+    "help": SlashCommand(name="help", description="Show available commands"),
+    "new": SlashCommand(name="new", description="Start a new conversation", aliases=("new",)),
+    "exit": SlashCommand(
+        name="exit",
+        description="Exit KOSMOS",
+        aliases=("exit", "quit"),
+    ),
+    "usage": SlashCommand(name="usage", description="Show token usage for current session"),
+}

--- a/src/kosmos/cli/permissions.py
+++ b/src/kosmos/cli/permissions.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: Apache-2.0
+"""CLI consent prompt handler for tool-execution permission flow."""
+
+from __future__ import annotations
+
+import logging
+
+from rich.console import Console
+from rich.prompt import Confirm
+
+logger = logging.getLogger(__name__)
+
+
+class ConsentPromptHandler:
+    """Interactively prompt the citizen for tool-execution consent.
+
+    Uses ``rich.prompt.Confirm`` for Y/n confirmation so that the prompt
+    integrates naturally with the rest of the Rich output.
+
+    Args:
+        console: Rich console to write prompts and messages to.
+    """
+
+    def __init__(self, console: Console) -> None:
+        self._console = console
+
+    def prompt(self, tool_name: str, provider: str, description: str) -> bool:
+        """Display a Y/n consent prompt and return the user's choice.
+
+        Args:
+            tool_name: Korean display name of the tool.
+            provider: Ministry or agency that owns the API.
+            description: Brief description of what the tool does.
+
+        Returns:
+            ``True`` if the user consented, ``False`` otherwise.
+        """
+        self._console.print(
+            f"\n[bold yellow]도구 실행 요청[/bold yellow]\n"
+            f"  도구: [cyan]{tool_name}[/cyan]\n"
+            f"  제공: [cyan]{provider}[/cyan]\n"
+            f"  설명: {description}"
+        )
+        try:
+            return Confirm.ask("실행을 허용하시겠습니까?", console=self._console, default=False)
+        except (EOFError, KeyboardInterrupt):
+            logger.debug("ConsentPromptHandler: prompt interrupted")
+            return False
+
+    def display_denial(self, tool_name: str, reason: str) -> None:
+        """Show a denial message without offering an override option.
+
+        Args:
+            tool_name: Korean display name of the tool that was denied.
+            reason: Human-readable reason for the denial.
+        """
+        self._console.print(
+            f"\n[red]도구 실행이 거부되었습니다.[/red]\n"
+            f"  도구: [cyan]{tool_name}[/cyan]\n"
+            f"  사유: {reason}"
+        )

--- a/src/kosmos/cli/permissions.py
+++ b/src/kosmos/cli/permissions.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 
 from rich.console import Console
+from rich.markup import escape
 from rich.prompt import Confirm
 
 logger = logging.getLogger(__name__)
@@ -37,9 +38,9 @@ class ConsentPromptHandler:
         """
         self._console.print(
             f"\n[bold yellow]도구 실행 요청[/bold yellow]\n"
-            f"  도구: [cyan]{tool_name}[/cyan]\n"
-            f"  제공: [cyan]{provider}[/cyan]\n"
-            f"  설명: {description}"
+            f"  도구: [cyan]{escape(tool_name)}[/cyan]\n"
+            f"  제공: [cyan]{escape(provider)}[/cyan]\n"
+            f"  설명: {escape(description)}"
         )
         try:
             return Confirm.ask("실행을 허용하시겠습니까?", console=self._console, default=False)
@@ -56,6 +57,6 @@ class ConsentPromptHandler:
         """
         self._console.print(
             f"\n[red]도구 실행이 거부되었습니다.[/red]\n"
-            f"  도구: [cyan]{tool_name}[/cyan]\n"
-            f"  사유: {reason}"
+            f"  도구: [cyan]{escape(tool_name)}[/cyan]\n"
+            f"  사유: {escape(reason)}"
         )

--- a/src/kosmos/cli/renderer.py
+++ b/src/kosmos/cli/renderer.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import logging
 
 from rich.console import Console
-from rich.markdown import Markdown
 from rich.panel import Panel
 from rich.status import Status
 
@@ -36,7 +35,8 @@ class EventRenderer:
     """Render a stream of ``QueryEvent`` objects to a Rich ``Console``.
 
     The renderer maintains internal state across events within a single turn:
-    - ``_text_buffer`` accumulates all ``text_delta`` content.
+    - ``_text_buffer`` accumulates all ``text_delta`` content (for internal
+      tracking only; text is printed incrementally as it arrives).
     - ``_usage`` accumulates the latest token usage snapshot.
     - ``_active_status`` holds the currently displayed spinner (if any).
 
@@ -46,11 +46,20 @@ class EventRenderer:
     Args:
         console: Rich console to write output to.
         registry: Optional tool registry for resolving Korean tool names.
+        show_usage: Whether to display per-turn token usage after each
+            response.  Totals are always tracked internally regardless of
+            this flag (so that the ``/usage`` command can report them).
     """
 
-    def __init__(self, console: Console, registry: ToolRegistry | None = None) -> None:
+    def __init__(
+        self,
+        console: Console,
+        registry: ToolRegistry | None = None,
+        show_usage: bool = True,
+    ) -> None:
         self._console = console
         self._registry = registry
+        self._show_usage = show_usage
         self._text_buffer: str = ""
         self._usage: TokenUsage | None = None
         self._active_status: Status | None = None
@@ -136,23 +145,27 @@ class EventRenderer:
             self._usage = event.usage
 
     def _render_stop(self, event: QueryEvent) -> None:
-        """Re-render the complete response as Markdown; show stop reason and usage."""
+        """Finalise a turn: print stop reason and (optionally) usage summary.
+
+        Text was already printed incrementally via ``_render_text_delta``; we
+        do NOT re-render the buffer here to avoid duplicating assistant text in
+        the terminal.  The buffer is cleared as part of :meth:`reset`.
+        """
         self._stop_active_status()
 
-        # Re-render buffered text as Markdown (if any)
-        if self._text_buffer.strip():
+        # Print a trailing newline after the streamed text block (if any)
+        if self._text_buffer:
             self._console.print()  # newline after streaming deltas
-            self._console.print(Markdown(self._text_buffer))
 
         # Show stop reason message (Korean)
         reason = event.stop_reason
         if reason is not None:
             msg = _STOP_REASON_MESSAGES.get(reason, "")
             if msg:
-                self._console.print(f"\n[dim]{msg}[/dim]")
+                self._console.print(f"[dim]{msg}[/dim]")
 
-        # Show usage summary
-        if self._usage is not None:
+        # Show per-turn usage summary only when the flag is enabled
+        if self._show_usage and self._usage is not None:
             self._console.print(
                 f"[dim]토큰 사용: 입력 {self._usage.input_tokens} "
                 f"/ 출력 {self._usage.output_tokens} "

--- a/src/kosmos/cli/renderer.py
+++ b/src/kosmos/cli/renderer.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""EventRenderer — converts QueryEvent stream into Rich-formatted terminal output."""
+
+from __future__ import annotations
+
+import logging
+
+from rich.console import Console
+from rich.markdown import Markdown
+from rich.panel import Panel
+from rich.status import Status
+
+from kosmos.engine.events import QueryEvent, StopReason
+from kosmos.llm.models import TokenUsage
+from kosmos.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Stop reason → citizen-facing Korean message
+# ---------------------------------------------------------------------------
+
+_STOP_REASON_MESSAGES: dict[StopReason, str] = {
+    StopReason.task_complete: "작업이 완료되었습니다.",
+    StopReason.end_turn: "",  # no extra message; just show the response
+    StopReason.needs_citizen_input: "추가 정보가 필요합니다.",
+    StopReason.needs_authentication: "인증이 필요합니다.",
+    StopReason.api_budget_exceeded: "API 사용량 한도에 도달했습니다.",
+    StopReason.max_iterations_reached: "최대 처리 횟수에 도달했습니다.",
+    StopReason.error_unrecoverable: "처리 중 오류가 발생했습니다.",
+    StopReason.cancelled: "요청이 취소되었습니다.",
+}
+
+
+class EventRenderer:
+    """Render a stream of ``QueryEvent`` objects to a Rich ``Console``.
+
+    The renderer maintains internal state across events within a single turn:
+    - ``_text_buffer`` accumulates all ``text_delta`` content.
+    - ``_usage`` accumulates the latest token usage snapshot.
+    - ``_active_status`` holds the currently displayed spinner (if any).
+
+    After each turn (``stop`` event), the renderer resets its state so it is
+    ready for the next turn.
+
+    Args:
+        console: Rich console to write output to.
+        registry: Optional tool registry for resolving Korean tool names.
+    """
+
+    def __init__(self, console: Console, registry: ToolRegistry | None = None) -> None:
+        self._console = console
+        self._registry = registry
+        self._text_buffer: str = ""
+        self._usage: TokenUsage | None = None
+        self._active_status: Status | None = None
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def render(self, event: QueryEvent) -> None:
+        """Dispatch a single ``QueryEvent`` to the appropriate render method."""
+        if event.type == "text_delta":
+            self._render_text_delta(event)
+        elif event.type == "tool_use":
+            self._render_tool_use(event)
+        elif event.type == "tool_result":
+            self._render_tool_result(event)
+        elif event.type == "usage_update":
+            self._render_usage_update(event)
+        elif event.type == "stop":
+            self._render_stop(event)
+
+    def reset(self) -> None:
+        """Reset per-turn state.  Called automatically by ``_render_stop``."""
+        self._text_buffer = ""
+        self._usage = None
+        self._stop_active_status()
+
+    # ------------------------------------------------------------------
+    # Private render methods
+    # ------------------------------------------------------------------
+
+    def _render_text_delta(self, event: QueryEvent) -> None:
+        """Append incremental text to the internal buffer and print it."""
+        chunk = event.content or ""
+        self._text_buffer += chunk
+        self._console.print(chunk, end="", highlight=False)
+
+    def _render_tool_use(self, event: QueryEvent) -> None:
+        """Show a spinner with the tool's Korean name while it executes."""
+        # Stop any previously active status first
+        self._stop_active_status()
+
+        # Resolve Korean name via registry
+        tool_id = event.tool_name or ""
+        korean_name = tool_id
+        if self._registry is not None:
+            try:
+                tool = self._registry.lookup(tool_id)
+                korean_name = tool.name_ko
+            except Exception:  # noqa: BLE001
+                logger.debug("Could not resolve Korean name for tool %r", tool_id)
+
+        status = Status(f"[bold cyan]{korean_name}[/bold cyan] 조회 중...", console=self._console)
+        status.start()
+        self._active_status = status
+
+    def _render_tool_result(self, event: QueryEvent) -> None:
+        """Replace the spinner with a panel summarising the tool result."""
+        self._stop_active_status()
+
+        result = event.tool_result
+        if result is None:
+            return
+
+        if result.success:
+            panel = Panel(
+                f"[green]성공[/green]  tool_id={result.tool_id!r}",
+                title="[green]도구 결과[/green]",
+                border_style="green",
+            )
+        else:
+            panel = Panel(
+                f"[red]오류[/red]  {result.error}\n"
+                f"error_type={result.error_type!r}  tool_id={result.tool_id!r}",
+                title="[red]도구 오류[/red]",
+                border_style="red",
+            )
+        self._console.print(panel)
+
+    def _render_usage_update(self, event: QueryEvent) -> None:
+        """Buffer the latest token usage snapshot."""
+        if event.usage is not None:
+            self._usage = event.usage
+
+    def _render_stop(self, event: QueryEvent) -> None:
+        """Re-render the complete response as Markdown; show stop reason and usage."""
+        self._stop_active_status()
+
+        # Re-render buffered text as Markdown (if any)
+        if self._text_buffer.strip():
+            self._console.print()  # newline after streaming deltas
+            self._console.print(Markdown(self._text_buffer))
+
+        # Show stop reason message (Korean)
+        reason = event.stop_reason
+        if reason is not None:
+            msg = _STOP_REASON_MESSAGES.get(reason, "")
+            if msg:
+                self._console.print(f"\n[dim]{msg}[/dim]")
+
+        # Show usage summary
+        if self._usage is not None:
+            self._console.print(
+                f"[dim]토큰 사용: 입력 {self._usage.input_tokens} "
+                f"/ 출력 {self._usage.output_tokens} "
+                f"/ 합계 {self._usage.total_tokens}[/dim]"
+            )
+
+        # Reset state for next turn
+        self.reset()
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _stop_active_status(self) -> None:
+        """Stop the active spinner if one is running."""
+        if self._active_status is not None:
+            self._active_status.stop()
+            self._active_status = None

--- a/src/kosmos/cli/renderer.py
+++ b/src/kosmos/cli/renderer.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import logging
 
 from rich.console import Console
+from rich.markup import escape
 from rich.panel import Panel
 from rich.status import Status
 
@@ -95,7 +96,7 @@ class EventRenderer:
         """Append incremental text to the internal buffer and print it."""
         chunk = event.content or ""
         self._text_buffer += chunk
-        self._console.print(chunk, end="", highlight=False)
+        self._console.print(chunk, end="", highlight=False, markup=False)
 
     def _render_tool_use(self, event: QueryEvent) -> None:
         """Show a spinner with the tool's Korean name while it executes."""
@@ -112,7 +113,8 @@ class EventRenderer:
             except Exception:  # noqa: BLE001
                 logger.debug("Could not resolve Korean name for tool %r", tool_id)
 
-        status = Status(f"[bold cyan]{korean_name}[/bold cyan] 조회 중...", console=self._console)
+        label = f"[bold cyan]{escape(str(korean_name))}[/bold cyan] 조회 중..."
+        status = Status(label, console=self._console)
         status.start()
         self._active_status = status
 
@@ -126,14 +128,15 @@ class EventRenderer:
 
         if result.success:
             panel = Panel(
-                f"[green]성공[/green]  tool_id={result.tool_id!r}",
+                f"[green]성공[/green]  tool_id={escape(repr(result.tool_id))}",
                 title="[green]도구 결과[/green]",
                 border_style="green",
             )
         else:
             panel = Panel(
-                f"[red]오류[/red]  {result.error}\n"
-                f"error_type={result.error_type!r}  tool_id={result.tool_id!r}",
+                f"[red]오류[/red]  {escape(str(result.error or ''))}\n"
+                f"error_type={escape(repr(result.error_type))}  "
+                f"tool_id={escape(repr(result.tool_id))}",
                 title="[red]도구 오류[/red]",
                 border_style="red",
             )

--- a/src/kosmos/cli/repl.py
+++ b/src/kosmos/cli/repl.py
@@ -3,7 +3,6 @@
 
 from __future__ import annotations
 
-import logging
 import sys
 import time
 import uuid
@@ -12,6 +11,7 @@ from collections.abc import AsyncGenerator, Iterable
 from prompt_toolkit import PromptSession
 from prompt_toolkit.history import InMemoryHistory
 from rich.console import Console
+from rich.markup import escape
 from rich.rule import Rule
 
 from kosmos.cli.config import CLIConfig
@@ -20,8 +20,6 @@ from kosmos.cli.renderer import EventRenderer
 from kosmos.engine.engine import QueryEngine
 from kosmos.engine.events import QueryEvent
 from kosmos.tools.registry import ToolRegistry
-
-logger = logging.getLogger(__name__)
 
 _WELCOME_BANNER = """[bold cyan]
  ██╗  ██╗ ██████╗ ███████╗███╗   ███╗ ██████╗ ███████╗
@@ -208,7 +206,9 @@ class REPLLoop:
 
         if resolved is None:
             self._console.print(
-                f"[yellow]알 수 없는 명령어:[/yellow] {cmd!r}. /help를 입력해 도움말을 확인하세요."
+                "[yellow]알 수 없는 명령어:[/yellow] "
+                f"{escape(repr(cmd))}. "
+                "/help를 입력해 도움말을 확인하세요."
             )
             return False
 

--- a/src/kosmos/cli/repl.py
+++ b/src/kosmos/cli/repl.py
@@ -7,7 +7,7 @@ import logging
 import sys
 import time
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Iterable
 
 from prompt_toolkit import PromptSession
 from prompt_toolkit.history import InMemoryHistory
@@ -15,6 +15,7 @@ from rich.console import Console
 from rich.rule import Rule
 
 from kosmos.cli.config import CLIConfig
+from kosmos.cli.models import COMMANDS
 from kosmos.cli.renderer import EventRenderer
 from kosmos.engine.engine import QueryEngine
 from kosmos.engine.events import QueryEvent
@@ -34,21 +35,54 @@ _WELCOME_BANNER = """[bold cyan]
 [/bold cyan]
 [dim]대한민국 공공 API 대화형 플랫폼 · Korean Public API Conversational Platform[/dim]"""
 
-_HELP_TEXT = """[bold]사용 가능한 명령어:[/bold]
+def _build_help_text() -> str:
+    """Generate /help output dynamically from the COMMANDS registry."""
+    lines = ["[bold]사용 가능한 명령어:[/bold]\n"]
+    for cmd in COMMANDS.values():
+        aliases = ""
+        if cmd.aliases:
+            # Show any aliases that differ from the primary name
+            extra = [a for a in cmd.aliases if a != cmd.name]
+            if extra:
+                aliases = " (또는 " + ", ".join(f"/{a}" for a in extra) + ")"
+        lines.append(f"  [cyan]/{cmd.name}[/cyan]{aliases}  — {cmd.description}")
+    lines.append(
+        "\n[dim]질문을 입력하고 Enter를 누르세요. Ctrl+C를 두 번 누르면 강제 종료됩니다.[/dim]"
+    )
+    return "\n".join(lines)
 
-  [cyan]/help[/cyan]   — 도움말 표시
-  [cyan]/new[/cyan]    — 새 대화 시작
-  [cyan]/usage[/cyan]  — 세션 토큰 사용량 표시
-  [cyan]/exit[/cyan]   — 종료 (또는 /quit)
 
-[dim]질문을 입력하고 Enter를 누르세요. Ctrl+C를 두 번 누르면 강제 종료됩니다.[/dim]"""
+class _LimitedInMemoryHistory(InMemoryHistory):
+    """InMemoryHistory capped at *max_entries* most-recent entries.
+
+    prompt_toolkit's InMemoryHistory grows unbounded.  This subclass overrides
+    ``store_string`` (called by the base class's ``append_string``) to keep
+    only the ``max_entries`` most-recent entries in ``_loaded_strings``.
+
+    Note: ``_loaded_strings`` is stored newest-first by the base class, so we
+    truncate from the end after inserting.
+    """
+
+    def __init__(self, max_entries: int) -> None:
+        super().__init__()
+        self._max_entries = max_entries
+
+    def load_history_strings(self) -> Iterable[str]:
+        return []
+
+    def store_string(self, string: str) -> None:
+        # Base class already inserted string at index 0 before calling us;
+        # nothing extra to do for persisting.  Just enforce the size cap.
+        if len(self._loaded_strings) > self._max_entries:
+            # Drop the oldest entry (last element — it's stored newest-first)
+            del self._loaded_strings[self._max_entries :]
 
 
 class REPLLoop:
     """Async REPL loop for citizen conversation with the KOSMOS engine.
 
     Handles:
-    - Slash command routing (``/help``, ``/new``, ``/exit``, ``/usage``)
+    - Slash command routing via the ``COMMANDS`` registry
     - Empty/whitespace input skipping
     - Streaming event rendering via ``EventRenderer``
     - Interrupt handling:
@@ -92,7 +126,7 @@ class REPLLoop:
             self._show_welcome()
 
         prompt_session: PromptSession[str] = PromptSession(
-            history=InMemoryHistory(),
+            history=_LimitedInMemoryHistory(self._config.history_size),
         )
 
         while True:
@@ -140,7 +174,8 @@ class REPLLoop:
         )
         try:
             async for event in gen:
-                # Track usage for /usage command
+                # Track usage totals for /usage command (always, regardless of
+                # show_usage flag — the renderer controls per-turn display)
                 if event.type == "usage_update" and event.usage is not None:
                     self._total_input_tokens += event.usage.input_tokens
                     self._total_output_tokens += event.usage.output_tokens
@@ -152,17 +187,43 @@ class REPLLoop:
             self._renderer.reset()
 
     async def _handle_slash_command(self, cmd: str) -> bool:
-        """Route a slash command.  Returns ``True`` if the REPL should exit."""
-        # Normalise: strip leading slash
+        """Route a slash command via the COMMANDS registry.
+
+        Returns ``True`` if the REPL should exit.
+        """
+        # Normalise: strip leading slash and lower-case
         name = cmd.lstrip("/").lower()
 
-        # Check aliases for exit
-        if name in ("exit", "quit"):
+        # Resolve name through the COMMANDS registry (check primary name and
+        # aliases so that e.g. "quit" routes to the "exit" handler)
+        resolved: str | None = None
+        if name in COMMANDS:
+            resolved = name
+        else:
+            for cmd_name, cmd_def in COMMANDS.items():
+                if name in cmd_def.aliases:
+                    resolved = cmd_name
+                    break
+
+        if resolved is None:
+            self._console.print(
+                f"[yellow]알 수 없는 명령어:[/yellow] {cmd!r}. /help를 입력해 도움말을 확인하세요."
+            )
+            return False
+
+        return await self._dispatch_command(resolved)
+
+    async def _dispatch_command(self, name: str) -> bool:
+        """Execute the handler for a resolved command name.
+
+        Returns ``True`` if the REPL should exit.
+        """
+        if name == "exit":
             self._console.print("[dim]종료합니다.[/dim]")
             return True
 
         if name == "help":
-            self._console.print(_HELP_TEXT)
+            self._console.print(_build_help_text())
         elif name == "new":
             self._console.print(
                 Rule("[dim]새 대화 시작[/dim]", style="dim"),
@@ -175,10 +236,6 @@ class REPLLoop:
                 f"  입력: {self._total_input_tokens}\n"
                 f"  출력: {self._total_output_tokens}\n"
                 f"  합계: {total}"
-            )
-        else:
-            self._console.print(
-                f"[yellow]알 수 없는 명령어:[/yellow] {cmd!r}. /help를 입력해 도움말을 확인하세요."
             )
 
         return False

--- a/src/kosmos/cli/repl.py
+++ b/src/kosmos/cli/repl.py
@@ -1,0 +1,192 @@
+# SPDX-License-Identifier: Apache-2.0
+"""REPL loop for the KOSMOS CLI — citizen conversation interface."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+import uuid
+from collections.abc import AsyncGenerator
+
+from prompt_toolkit import PromptSession
+from prompt_toolkit.history import InMemoryHistory
+from rich.console import Console
+from rich.rule import Rule
+
+from kosmos.cli.config import CLIConfig
+from kosmos.cli.renderer import EventRenderer
+from kosmos.engine.engine import QueryEngine
+from kosmos.engine.events import QueryEvent
+from kosmos.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+_WELCOME_BANNER = """[bold cyan]
+ ██╗  ██╗ ██████╗ ███████╗███╗   ███╗ ██████╗ ███████╗
+ ██║ ██╔╝██╔═══██╗██╔════╝████╗ ████║██╔═══██╗██╔════╝
+ █████╔╝ ██║   ██║███████╗██╔████╔██║██║   ██║███████╗
+ ██╔═██╗ ██║   ██║╚════██║██║╚██╔╝██║██║   ██║╚════██║
+ ██║  ██╗╚██████╔╝███████║██║ ╚═╝ ██║╚██████╔╝███████║
+ ╚═╝  ╚═╝ ╚═════╝ ╚══════╝╚═╝     ╚═╝ ╚═════╝ ╚══════╝
+
+                        KOSMOS
+[/bold cyan]
+[dim]대한민국 공공 API 대화형 플랫폼 · Korean Public API Conversational Platform[/dim]"""
+
+_HELP_TEXT = """[bold]사용 가능한 명령어:[/bold]
+
+  [cyan]/help[/cyan]   — 도움말 표시
+  [cyan]/new[/cyan]    — 새 대화 시작
+  [cyan]/usage[/cyan]  — 세션 토큰 사용량 표시
+  [cyan]/exit[/cyan]   — 종료 (또는 /quit)
+
+[dim]질문을 입력하고 Enter를 누르세요. Ctrl+C를 두 번 누르면 강제 종료됩니다.[/dim]"""
+
+
+class REPLLoop:
+    """Async REPL loop for citizen conversation with the KOSMOS engine.
+
+    Handles:
+    - Slash command routing (``/help``, ``/new``, ``/exit``, ``/usage``)
+    - Empty/whitespace input skipping
+    - Streaming event rendering via ``EventRenderer``
+    - Interrupt handling:
+      - Single Ctrl+C during streaming → cancel and append ``[cancelled]``
+      - Double Ctrl+C within 1 second → ``sys.exit(130)``
+      - Ctrl+C at idle prompt → clear input and re-prompt
+
+    Args:
+        engine: Configured ``QueryEngine`` for the session.
+        registry: Tool registry for Korean name resolution.
+        console: Rich console for all output.
+        config: CLI runtime configuration.
+        renderer: Pre-built ``EventRenderer`` bound to ``console``.
+    """
+
+    def __init__(
+        self,
+        engine: QueryEngine,
+        registry: ToolRegistry,
+        console: Console,
+        config: CLIConfig,
+        renderer: EventRenderer,
+    ) -> None:
+        self._engine = engine
+        self._registry = registry
+        self._console = console
+        self._config = config
+        self._renderer = renderer
+        self._session_id = str(uuid.uuid4())
+        self._total_input_tokens = 0
+        self._total_output_tokens = 0
+        self._last_ctrl_c: float = 0.0
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Start the REPL loop.  Returns when the user exits."""
+        if self._config.welcome_banner:
+            self._show_welcome()
+
+        prompt_session: PromptSession[str] = PromptSession(
+            history=InMemoryHistory(),
+        )
+
+        while True:
+            try:
+                user_input = await prompt_session.prompt_async("KOSMOS › ")
+            except KeyboardInterrupt:
+                now = time.monotonic()
+                if now - self._last_ctrl_c < 1.0:
+                    self._console.print("\n[dim]종료합니다.[/dim]")
+                    sys.exit(130)
+                self._last_ctrl_c = now
+                self._console.print("[dim]다시 Ctrl+C를 누르면 강제 종료됩니다.[/dim]")
+                continue
+            except EOFError:
+                self._console.print("\n[dim]종료합니다.[/dim]")
+                break
+
+            stripped = user_input.strip()
+            if not stripped:
+                continue
+
+            # --- Slash command routing ---
+            if stripped.startswith("/") or stripped in ("exit", "quit", "new"):
+                should_exit = await self._handle_slash_command(stripped)
+                if should_exit:
+                    break
+                continue
+
+            # --- Regular citizen message ---
+            await self._run_turn(stripped)
+
+    # ------------------------------------------------------------------
+    # Private methods
+    # ------------------------------------------------------------------
+
+    async def _run_turn(self, user_message: str) -> None:
+        """Execute one engine turn, streaming events to the renderer."""
+        # engine.run() is typed as AsyncIterator but the actual object is an
+        # async generator, which supports aclose().  We cast to AsyncGenerator
+        # so mypy accepts the aclose() call.
+        from typing import cast  # noqa: PLC0415
+
+        gen: AsyncGenerator[QueryEvent, None] = cast(
+            AsyncGenerator[QueryEvent, None], self._engine.run(user_message)
+        )
+        try:
+            async for event in gen:
+                # Track usage for /usage command
+                if event.type == "usage_update" and event.usage is not None:
+                    self._total_input_tokens += event.usage.input_tokens
+                    self._total_output_tokens += event.usage.output_tokens
+                self._renderer.render(event)
+        except KeyboardInterrupt:
+            # Single Ctrl+C during streaming: cancel the generator
+            await gen.aclose()
+            self._console.print("\n[dim][cancelled][/dim]")
+            self._renderer.reset()
+
+    async def _handle_slash_command(self, cmd: str) -> bool:
+        """Route a slash command.  Returns ``True`` if the REPL should exit."""
+        # Normalise: strip leading slash
+        name = cmd.lstrip("/").lower()
+
+        # Check aliases for exit
+        if name in ("exit", "quit"):
+            self._console.print("[dim]종료합니다.[/dim]")
+            return True
+
+        if name == "help":
+            self._console.print(_HELP_TEXT)
+        elif name == "new":
+            self._console.print(
+                Rule("[dim]새 대화 시작[/dim]", style="dim"),
+            )
+            self._console.print("[dim]새 대화가 시작되었습니다.[/dim]")
+        elif name == "usage":
+            total = self._total_input_tokens + self._total_output_tokens
+            self._console.print(
+                f"[bold]세션 토큰 사용량[/bold]\n"
+                f"  입력: {self._total_input_tokens}\n"
+                f"  출력: {self._total_output_tokens}\n"
+                f"  합계: {total}"
+            )
+        else:
+            self._console.print(
+                f"[yellow]알 수 없는 명령어:[/yellow] {cmd!r}. /help를 입력해 도움말을 확인하세요."
+            )
+
+        return False
+
+    def _show_welcome(self) -> None:
+        """Display the welcome banner with session ID."""
+        self._console.print(_WELCOME_BANNER)
+        self._console.print(f"[dim]세션 ID: {self._session_id}[/dim]")
+        self._console.print(
+            "[dim]/help 를 입력하면 사용 가능한 명령어를 확인할 수 있습니다.[/dim]\n"
+        )

--- a/src/kosmos/cli/repl.py
+++ b/src/kosmos/cli/repl.py
@@ -226,10 +226,15 @@ class REPLLoop:
         if name == "help":
             self._console.print(_build_help_text())
         elif name == "new":
+            self._engine.reset()
+            self._session_id = str(uuid.uuid4())
+            self._total_input_tokens = 0
+            self._total_output_tokens = 0
+            self._renderer.reset()
             self._console.print(
                 Rule("[dim]새 대화 시작[/dim]", style="dim"),
             )
-            self._console.print("[dim]새 대화가 시작되었습니다.[/dim]")
+            self._console.print(f"[dim]새 대화가 시작되었습니다. 세션 ID: {self._session_id}[/dim]")
         elif name == "usage":
             total = self._total_input_tokens + self._total_output_tokens
             self._console.print(

--- a/src/kosmos/cli/repl.py
+++ b/src/kosmos/cli/repl.py
@@ -120,7 +120,12 @@ class REPLLoop:
     # ------------------------------------------------------------------
 
     async def run(self) -> None:
-        """Start the REPL loop.  Returns when the user exits."""
+        """Start the REPL loop.
+
+        Returns when the user exits normally (``/exit``, ``/quit``, or EOF).
+        Calls ``sys.exit(130)`` on double Ctrl+C within 1 second at the
+        idle prompt.
+        """
         if self._config.welcome_banner:
             self._show_welcome()
 
@@ -180,7 +185,15 @@ class REPLLoop:
                     self._total_output_tokens += event.usage.output_tokens
                 self._renderer.render(event)
         except KeyboardInterrupt:
-            # Single Ctrl+C during streaming: cancel the generator
+            # Ctrl+C during streaming: cancel the generator.
+            # Update _last_ctrl_c so a second Ctrl+C at the next idle
+            # prompt within 1 second triggers the forced-exit path.
+            now = time.monotonic()
+            if now - self._last_ctrl_c < 1.0:
+                await gen.aclose()
+                self._console.print("\n[dim]종료합니다.[/dim]")
+                sys.exit(130)
+            self._last_ctrl_c = now
             await gen.aclose()
             self._console.print("\n[dim][cancelled][/dim]")
             self._renderer.reset()

--- a/src/kosmos/cli/repl.py
+++ b/src/kosmos/cli/repl.py
@@ -35,6 +35,7 @@ _WELCOME_BANNER = """[bold cyan]
 [/bold cyan]
 [dim]대한민국 공공 API 대화형 플랫폼 · Korean Public API Conversational Platform[/dim]"""
 
+
 def _build_help_text() -> str:
     """Generate /help output dynamically from the COMMANDS registry."""
     lines = ["[bold]사용 가능한 명령어:[/bold]\n"]

--- a/src/kosmos/engine/engine.py
+++ b/src/kosmos/engine/engine.py
@@ -184,6 +184,20 @@ class QueryEngine:
                 len(self._state.messages),
             )
 
+    def reset(self) -> None:
+        """Reset the conversation state for a new session.
+
+        Clears the message history (re-initialises with the system message),
+        resets the turn counter, and preserves the existing token usage tracker
+        so that the budget continues from where it left off.
+        """
+        system_msg = self._context_builder.build_system_message()
+        self._state = QueryState(
+            usage=self._llm_client.usage,
+            messages=[system_msg],
+        )
+        logger.info("QueryEngine reset: conversation cleared")
+
     # ------------------------------------------------------------------
     # Properties
     # ------------------------------------------------------------------

--- a/tests/cli/__init__.py
+++ b/tests/cli/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the KOSMOS CLI package."""

--- a/tests/cli/conftest.py
+++ b/tests/cli/conftest.py
@@ -1,0 +1,104 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Shared fixtures for CLI tests."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import BaseModel
+from rich.console import Console
+
+from kosmos.engine.events import QueryEvent, StopReason
+from kosmos.llm.models import TokenUsage
+from kosmos.tools.models import GovAPITool
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _MockQueryEngine:
+    """Minimal mock engine that replays a pre-baked list of QueryEvent objects."""
+
+    def __init__(self, events: list[QueryEvent]) -> None:
+        self._events = events
+
+    async def run(self, user_message: str) -> AsyncIterator[QueryEvent]:  # noqa: ARG002
+        for event in self._events:
+            yield event
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def simple_text_events() -> list[QueryEvent]:
+    """A minimal sequence: text_delta → usage_update → stop."""
+    return [
+        QueryEvent(type="text_delta", content="안녕하세요"),
+        QueryEvent(
+            type="usage_update",
+            usage=TokenUsage(input_tokens=10, output_tokens=5),
+        ),
+        QueryEvent(
+            type="stop",
+            stop_reason=StopReason.task_complete,
+            stop_message="done",
+        ),
+    ]
+
+
+@pytest.fixture
+def mock_query_engine(simple_text_events: list[QueryEvent]) -> _MockQueryEngine:
+    """Mock engine that yields a simple text + stop sequence."""
+    return _MockQueryEngine(simple_text_events)
+
+
+@pytest.fixture
+def mock_console() -> Console:
+    """Rich Console that writes to a StringIO buffer for output capture."""
+    return Console(file=io.StringIO(), force_terminal=True, width=120)
+
+
+class _DummyInput(BaseModel):
+    """Dummy input schema for test tools."""
+
+    query: str
+
+
+class _DummyOutput(BaseModel):
+    """Dummy output schema for test tools."""
+
+    result: str
+
+
+@pytest.fixture
+def sample_tool() -> GovAPITool:
+    """A minimal GovAPITool for testing registry lookup."""
+    return GovAPITool(
+        id="test_tool",
+        name_ko="테스트 도구",
+        provider="테스트 기관",
+        category=["test"],
+        endpoint="https://example.com/api",
+        auth_type="public",
+        input_schema=_DummyInput,
+        output_schema=_DummyOutput,
+        search_hint="test 테스트",
+        requires_auth=False,
+        is_personal_data=False,
+    )
+
+
+@pytest.fixture
+def mock_tool_registry(sample_tool: GovAPITool) -> Any:
+    """Mock ToolRegistry whose lookup() returns the sample_tool."""
+    registry = MagicMock()
+    registry.lookup.return_value = sample_tool
+    return registry

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -61,9 +61,11 @@ class TestRunReplSuccess:
     def test_repl_launched_on_success(self) -> None:
         """Full REPL init path: mock all dependencies and verify run is called."""
         mock_repl_instance = MagicMock()
+        run_called = False
 
         async def mock_run() -> None:
-            return None
+            nonlocal run_called
+            run_called = True
 
         mock_repl_instance.run = mock_run
 
@@ -74,12 +76,13 @@ class TestRunReplSuccess:
             patch("kosmos.tools.register_all.register_all_tools"),
             patch("kosmos.context.builder.ContextBuilder"),
             patch("kosmos.engine.engine.QueryEngine"),
-            patch("kosmos.cli.renderer.EventRenderer"),
-            patch("kosmos.cli.repl.REPLLoop", return_value=mock_repl_instance),
+            patch("kosmos.cli.app.EventRenderer"),
+            patch("kosmos.cli.app.REPLLoop", return_value=mock_repl_instance) as mock_repl_cls,
         ):
             result = runner.invoke(_app, [])
-        # The REPL exits cleanly
         assert result.exit_code == 0
+        mock_repl_cls.assert_called_once()
+        assert run_called, "REPLLoop.run() was never awaited"
 
     def test_keyboard_interrupt_exits_130(self) -> None:
         """KeyboardInterrupt from the REPL results in exit code 130."""
@@ -111,8 +114,8 @@ class TestRunReplSuccess:
             patch("kosmos.tools.register_all.register_all_tools"),
             patch("kosmos.context.builder.ContextBuilder"),
             patch("kosmos.engine.engine.QueryEngine"),
-            patch("kosmos.cli.renderer.EventRenderer"),
-            patch("kosmos.cli.repl.REPLLoop", return_value=mock_repl_instance),
+            patch("kosmos.cli.app.EventRenderer"),
+            patch("kosmos.cli.app.REPLLoop", return_value=mock_repl_instance),
             patch("kosmos.cli.app.logging.basicConfig") as mock_logging,
         ):
             runner.invoke(_app, ["--debug"])

--- a/tests/cli/test_app.py
+++ b/tests/cli/test_app.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for CLI app entry point."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from kosmos.cli.app import __version__, _app, main
+
+runner = CliRunner()
+
+
+class TestVersionFlag:
+    def test_version_flag(self) -> None:
+        result = runner.invoke(_app, ["--version"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+    def test_version_short_flag(self) -> None:
+        result = runner.invoke(_app, ["-v"])
+        assert result.exit_code == 0
+        assert __version__ in result.output
+
+
+class TestMainEntry:
+    def test_main_callable(self) -> None:
+        """main() is a callable that delegates to typer app."""
+        # Just test that calling main with --version works
+        with pytest.raises(SystemExit) as exc_info, patch("sys.argv", ["kosmos", "--version"]):
+            main()
+        # typer exits with 0 for --version
+        assert exc_info.value.code == 0
+
+
+class TestRunReplConfigurationError:
+    def test_configuration_error_exits_1(self) -> None:
+        """ConfigurationError during LLM init results in exit code 1."""
+        from kosmos.llm.errors import ConfigurationError
+
+        with patch("kosmos.llm.client.LLMClient", side_effect=ConfigurationError("missing token")):
+            result = runner.invoke(_app, [])
+        assert result.exit_code == 1
+
+    def test_generic_llm_error_exits_1(self) -> None:
+        """Any unexpected error during LLM init results in exit code 1."""
+        with patch("kosmos.llm.client.LLMClient", side_effect=RuntimeError("boom")):
+            result = runner.invoke(_app, [])
+        assert result.exit_code == 1
+
+    def test_cli_config_error_exits_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CLIConfig init failure results in exit code 1."""
+        monkeypatch.setenv("KOSMOS_CLI_HISTORY_SIZE", "not_a_number")
+        result = runner.invoke(_app, [])
+        assert result.exit_code == 1
+
+
+class TestRunReplSuccess:
+    def test_repl_launched_on_success(self) -> None:
+        """Full REPL init path: mock all dependencies and verify run is called."""
+        mock_repl_instance = MagicMock()
+
+        async def mock_run() -> None:
+            return None
+
+        mock_repl_instance.run = mock_run
+
+        with (
+            patch("kosmos.llm.client.LLMClient"),
+            patch("kosmos.tools.registry.ToolRegistry"),
+            patch("kosmos.tools.executor.ToolExecutor"),
+            patch("kosmos.tools.register_all.register_all_tools"),
+            patch("kosmos.context.builder.ContextBuilder"),
+            patch("kosmos.engine.engine.QueryEngine"),
+            patch("kosmos.cli.renderer.EventRenderer"),
+            patch("kosmos.cli.repl.REPLLoop", return_value=mock_repl_instance),
+        ):
+            result = runner.invoke(_app, [])
+        # The REPL exits cleanly
+        assert result.exit_code == 0
+
+    def test_keyboard_interrupt_exits_130(self) -> None:
+        """KeyboardInterrupt from the REPL results in exit code 130."""
+        # Patch _run_repl directly so sys.exit(130) propagates through typer.
+        with patch("kosmos.cli.app._run_repl", side_effect=SystemExit(130)):
+            result = runner.invoke(_app, [])
+        assert result.exit_code == 130
+
+    def test_unexpected_error_exits_1(self) -> None:
+        """Unexpected error from REPL results in exit code 1."""
+        # Patch _run_repl directly so sys.exit(1) propagates through typer.
+        with patch("kosmos.cli.app._run_repl", side_effect=SystemExit(1)):
+            result = runner.invoke(_app, [])
+        assert result.exit_code == 1
+
+    def test_debug_flag_sets_logging(self) -> None:
+        """--debug flag enables DEBUG level logging."""
+        mock_repl_instance = MagicMock()
+
+        async def mock_run() -> None:
+            return None
+
+        mock_repl_instance.run = mock_run
+
+        with (
+            patch("kosmos.llm.client.LLMClient"),
+            patch("kosmos.tools.registry.ToolRegistry"),
+            patch("kosmos.tools.executor.ToolExecutor"),
+            patch("kosmos.tools.register_all.register_all_tools"),
+            patch("kosmos.context.builder.ContextBuilder"),
+            patch("kosmos.engine.engine.QueryEngine"),
+            patch("kosmos.cli.renderer.EventRenderer"),
+            patch("kosmos.cli.repl.REPLLoop", return_value=mock_repl_instance),
+            patch("kosmos.cli.app.logging.basicConfig") as mock_logging,
+        ):
+            runner.invoke(_app, ["--debug"])
+        import logging
+
+        mock_logging.assert_called_once_with(level=logging.DEBUG)

--- a/tests/cli/test_config.py
+++ b/tests/cli/test_config.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for CLIConfig."""
+
+from __future__ import annotations
+
+import pytest
+
+from kosmos.cli.config import CLIConfig
+
+
+class TestCLIConfigDefaults:
+    def test_default_history_size(self) -> None:
+        cfg = CLIConfig()
+        assert cfg.history_size == 1000
+
+    def test_default_show_usage(self) -> None:
+        cfg = CLIConfig()
+        assert cfg.show_usage is True
+
+    def test_default_welcome_banner(self) -> None:
+        cfg = CLIConfig()
+        assert cfg.welcome_banner is True
+
+
+class TestCLIConfigEnvOverride:
+    def test_history_size_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KOSMOS_CLI_HISTORY_SIZE", "500")
+        cfg = CLIConfig()
+        assert cfg.history_size == 500
+
+    def test_show_usage_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KOSMOS_CLI_SHOW_USAGE", "false")
+        cfg = CLIConfig()
+        assert cfg.show_usage is False
+
+    def test_welcome_banner_false(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("KOSMOS_CLI_WELCOME_BANNER", "false")
+        cfg = CLIConfig()
+        assert cfg.welcome_banner is False

--- a/tests/cli/test_integration.py
+++ b/tests/cli/test_integration.py
@@ -34,6 +34,10 @@ class _MockEngine:
         for event in events:
             yield event
 
+    def reset(self) -> None:
+        """Reset mock engine state."""
+        self._call_count = 0
+
 
 def _make_repl_with_engine(engine: Any) -> tuple[REPLLoop, Console]:
     console = _make_console()

--- a/tests/cli/test_integration.py
+++ b/tests/cli/test_integration.py
@@ -1,0 +1,179 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration tests for the CLI with a mock LLM."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from rich.console import Console
+
+from kosmos.cli.config import CLIConfig
+from kosmos.cli.renderer import EventRenderer
+from kosmos.cli.repl import REPLLoop
+from kosmos.engine.events import QueryEvent, StopReason
+from kosmos.llm.models import TokenUsage
+from kosmos.tools.models import ToolResult
+from kosmos.tools.registry import ToolRegistry
+
+
+def _make_console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=True, width=120)
+
+
+class _MockEngine:
+    def __init__(self, turn_responses: list[list[QueryEvent]]) -> None:
+        self._responses = turn_responses
+        self._call_count = 0
+
+    async def run(self, user_message: str) -> AsyncIterator[QueryEvent]:  # noqa: ARG002
+        events = self._responses[min(self._call_count, len(self._responses) - 1)]
+        self._call_count += 1
+        for event in events:
+            yield event
+
+
+def _make_repl_with_engine(engine: Any) -> tuple[REPLLoop, Console]:
+    console = _make_console()
+    registry = MagicMock(spec=ToolRegistry)
+    config = CLIConfig(welcome_banner=False, show_usage=True)
+    renderer = EventRenderer(console, registry=registry)
+    repl = REPLLoop(
+        engine=engine,
+        registry=registry,
+        console=console,
+        config=config,
+        renderer=renderer,
+    )
+    return repl, console
+
+
+class TestEndToEndTurn:
+    async def test_text_response_displayed(self) -> None:
+        """Full turn: user input → text_delta → usage_update → stop."""
+        events = [
+            QueryEvent(type="text_delta", content="안녕하세요! 무엇을 도와드릴까요?"),
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=20, output_tokens=10)),
+            QueryEvent(type="stop", stop_reason=StopReason.task_complete),
+        ]
+        engine = _MockEngine([events])
+        repl, console = _make_repl_with_engine(engine)
+
+        inputs = ["안녕하세요", "/exit"]
+        idx = 0
+
+        async def mock_prompt(prompt_str: str) -> str:
+            nonlocal idx
+            val = inputs[idx]
+            idx += 1
+            return val
+
+        mock_session = MagicMock()
+        mock_session.prompt_async = mock_prompt
+        with patch("kosmos.cli.repl.PromptSession", return_value=mock_session):
+            await repl.run()
+
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "안녕하세요" in output
+        assert "작업이 완료되었습니다" in output
+
+    async def test_usage_tracked_across_turns(self) -> None:
+        """Token usage accumulates across multiple turns."""
+        events_turn1 = [
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=10, output_tokens=5)),
+            QueryEvent(type="stop", stop_reason=StopReason.end_turn),
+        ]
+        events_turn2 = [
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=15, output_tokens=8)),
+            QueryEvent(type="stop", stop_reason=StopReason.end_turn),
+        ]
+        engine = _MockEngine([events_turn1, events_turn2])
+        repl, console = _make_repl_with_engine(engine)
+
+        inputs = ["질문 1", "질문 2", "/exit"]
+        idx = 0
+
+        async def mock_prompt(prompt_str: str) -> str:
+            nonlocal idx
+            val = inputs[idx]
+            idx += 1
+            return val
+
+        mock_session = MagicMock()
+        mock_session.prompt_async = mock_prompt
+        with patch("kosmos.cli.repl.PromptSession", return_value=mock_session):
+            await repl.run()
+
+        assert repl._total_input_tokens == 25
+        assert repl._total_output_tokens == 13
+
+    async def test_tool_use_and_result_rendered(self) -> None:
+        """Turn with tool_use + tool_result events displays tool feedback."""
+        events = [
+            QueryEvent(type="tool_use", tool_name="test_tool", tool_call_id="call-1"),
+            QueryEvent(
+                type="tool_result",
+                tool_result=ToolResult(
+                    tool_id="test_tool",
+                    success=True,
+                    data={"result": "data"},
+                ),
+            ),
+            QueryEvent(type="text_delta", content="결과를 찾았습니다."),
+            QueryEvent(type="stop", stop_reason=StopReason.task_complete),
+        ]
+        engine = _MockEngine([events])
+        repl, console = _make_repl_with_engine(engine)
+
+        inputs = ["도로 정보 조회", "/exit"]
+        idx = 0
+
+        async def mock_prompt(prompt_str: str) -> str:
+            nonlocal idx
+            val = inputs[idx]
+            idx += 1
+            return val
+
+        mock_session = MagicMock()
+        mock_session.prompt_async = mock_prompt
+        with patch("kosmos.cli.repl.PromptSession", return_value=mock_session):
+            await repl.run()
+
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "성공" in output
+        assert "결과를 찾았습니다" in output
+
+    async def test_welcome_banner_with_session_id(self) -> None:
+        """Welcome banner is shown when welcome_banner=True."""
+        console = _make_console()
+        registry = MagicMock(spec=ToolRegistry)
+        config = CLIConfig(welcome_banner=True)
+        renderer = EventRenderer(console, registry=registry)
+        engine = _MockEngine([[]])
+        repl = REPLLoop(
+            engine=engine,
+            registry=registry,
+            console=console,
+            config=config,
+            renderer=renderer,
+        )
+
+        inputs = ["/exit"]
+        idx = 0
+
+        async def mock_prompt(prompt_str: str) -> str:
+            nonlocal idx
+            val = inputs[idx]
+            idx += 1
+            return val
+
+        mock_session = MagicMock()
+        mock_session.prompt_async = mock_prompt
+        with patch("kosmos.cli.repl.PromptSession", return_value=mock_session):
+            await repl.run()
+
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "KOSMOS" in output
+        assert repl._session_id in output

--- a/tests/cli/test_models.py
+++ b/tests/cli/test_models.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for CLI models and slash command registry."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from kosmos.cli.models import COMMANDS, SlashCommand
+
+
+class TestSlashCommand:
+    def test_frozen(self) -> None:
+        cmd = SlashCommand(name="test", description="A test command")
+        with pytest.raises(ValidationError):
+            cmd.name = "other"  # type: ignore[misc]
+
+    def test_default_aliases(self) -> None:
+        cmd = SlashCommand(name="foo", description="foo command")
+        assert cmd.aliases == ()
+
+    def test_aliases_stored(self) -> None:
+        cmd = SlashCommand(name="exit", description="Exit", aliases=("exit", "quit"))
+        assert "exit" in cmd.aliases
+        assert "quit" in cmd.aliases
+
+
+class TestCommandsRegistry:
+    def test_help_present(self) -> None:
+        assert "help" in COMMANDS
+
+    def test_new_present(self) -> None:
+        assert "new" in COMMANDS
+
+    def test_exit_present(self) -> None:
+        assert "exit" in COMMANDS
+
+    def test_usage_present(self) -> None:
+        assert "usage" in COMMANDS
+
+    def test_exit_has_aliases(self) -> None:
+        cmd = COMMANDS["exit"]
+        assert "exit" in cmd.aliases
+        assert "quit" in cmd.aliases
+
+    def test_new_has_alias(self) -> None:
+        cmd = COMMANDS["new"]
+        assert "new" in cmd.aliases
+
+    def test_all_commands_have_descriptions(self) -> None:
+        for name, cmd in COMMANDS.items():
+            assert cmd.description, f"Command '{name}' has empty description"

--- a/tests/cli/test_permissions.py
+++ b/tests/cli/test_permissions.py
@@ -1,0 +1,69 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for ConsentPromptHandler."""
+
+from __future__ import annotations
+
+import io
+from unittest.mock import patch
+
+from rich.console import Console
+
+from kosmos.cli.permissions import ConsentPromptHandler
+
+
+def _make_console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=True, width=120)
+
+
+class TestConsentPromptHandler:
+    def test_prompt_true_when_confirmed(self) -> None:
+        console = _make_console()
+        handler = ConsentPromptHandler(console)
+        with patch("kosmos.cli.permissions.Confirm.ask", return_value=True):
+            result = handler.prompt("테스트 도구", "테스트 기관", "테스트 설명")
+        assert result is True
+
+    def test_prompt_false_when_denied(self) -> None:
+        console = _make_console()
+        handler = ConsentPromptHandler(console)
+        with patch("kosmos.cli.permissions.Confirm.ask", return_value=False):
+            result = handler.prompt("테스트 도구", "테스트 기관", "테스트 설명")
+        assert result is False
+
+    def test_prompt_false_on_eof(self) -> None:
+        console = _make_console()
+        handler = ConsentPromptHandler(console)
+        with patch("kosmos.cli.permissions.Confirm.ask", side_effect=EOFError):
+            result = handler.prompt("테스트 도구", "테스트 기관", "테스트 설명")
+        assert result is False
+
+    def test_prompt_false_on_keyboard_interrupt(self) -> None:
+        console = _make_console()
+        handler = ConsentPromptHandler(console)
+        with patch("kosmos.cli.permissions.Confirm.ask", side_effect=KeyboardInterrupt):
+            result = handler.prompt("테스트 도구", "테스트 기관", "테스트 설명")
+        assert result is False
+
+    def test_prompt_shows_tool_info(self) -> None:
+        console = _make_console()
+        handler = ConsentPromptHandler(console)
+        with patch("kosmos.cli.permissions.Confirm.ask", return_value=False):
+            handler.prompt("도로 검색", "국토부", "도로 정보 조회")
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "도로 검색" in output
+        assert "국토부" in output
+
+    def test_display_denial_shows_reason(self) -> None:
+        console = _make_console()
+        handler = ConsentPromptHandler(console)
+        handler.display_denial("테스트 도구", "권한이 없습니다")
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "거부" in output
+        assert "권한이 없습니다" in output
+
+    def test_display_denial_shows_tool_name(self) -> None:
+        console = _make_console()
+        handler = ConsentPromptHandler(console)
+        handler.display_denial("날씨 조회", "인증 실패")
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "날씨 조회" in output

--- a/tests/cli/test_renderer.py
+++ b/tests/cli/test_renderer.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for EventRenderer."""
+
+from __future__ import annotations
+
+import io
+from typing import Any
+from unittest.mock import MagicMock
+
+from rich.console import Console
+
+from kosmos.cli.renderer import EventRenderer
+from kosmos.engine.events import QueryEvent, StopReason
+from kosmos.llm.models import TokenUsage
+from kosmos.tools.models import ToolResult
+
+
+def _make_console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=True, width=120)
+
+
+class TestTextDeltaRendering:
+    def test_buffer_accumulates(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(QueryEvent(type="text_delta", content="Hello"))
+        renderer.render(QueryEvent(type="text_delta", content=" World"))
+        assert renderer._text_buffer == "Hello World"
+
+    def test_output_contains_text(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(QueryEvent(type="text_delta", content="테스트"))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "테스트" in output
+
+
+class TestUsageUpdateRendering:
+    def test_usage_buffered(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        usage = TokenUsage(input_tokens=10, output_tokens=5)
+        renderer.render(QueryEvent(type="usage_update", usage=usage))
+        assert renderer._usage == usage
+
+    def test_usage_overwritten_on_multiple_updates(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=10, output_tokens=5))
+        )
+        renderer.render(
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=20, output_tokens=10))
+        )
+        assert renderer._usage is not None
+        assert renderer._usage.input_tokens == 20
+
+
+class TestStopRendering:
+    def test_stop_resets_buffer(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(QueryEvent(type="text_delta", content="some text"))
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.task_complete))
+        assert renderer._text_buffer == ""
+
+    def test_stop_shows_korean_message_task_complete(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.task_complete))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "작업이 완료되었습니다" in output
+
+    def test_stop_shows_korean_message_error(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.error_unrecoverable))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "처리 중 오류가 발생했습니다" in output
+
+    def test_stop_end_turn_no_extra_message(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(QueryEvent(type="text_delta", content="hi"))
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.end_turn))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        # "end_turn" stop reason should not produce a Korean stop message
+        assert "end_turn" not in output
+
+    def test_stop_shows_usage_summary(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer.render(
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=10, output_tokens=5))
+        )
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.task_complete))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "10" in output
+        assert "5" in output
+
+
+class TestToolUseRendering:
+    def test_tool_use_with_registry(self, mock_tool_registry: Any) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console, registry=mock_tool_registry)
+        renderer.render(QueryEvent(type="tool_use", tool_name="test_tool", tool_call_id="call-123"))
+        # Korean name should have been looked up
+        mock_tool_registry.lookup.assert_called_once_with("test_tool")
+        # Stop the spinner to avoid console state issues
+        renderer._stop_active_status()
+
+    def test_tool_use_fallback_on_registry_error(self) -> None:
+        console = _make_console()
+        bad_registry = MagicMock()
+        bad_registry.lookup.side_effect = KeyError("not found")
+        renderer = EventRenderer(console, registry=bad_registry)
+        # Should not raise; falls back to tool_name
+        renderer.render(
+            QueryEvent(type="tool_use", tool_name="unknown_tool", tool_call_id="call-456")
+        )
+        renderer._stop_active_status()
+
+
+class TestToolResultRendering:
+    def test_success_result(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        result = ToolResult(
+            tool_id="test_tool",
+            success=True,
+            data={"key": "value"},
+        )
+        renderer.render(QueryEvent(type="tool_result", tool_result=result))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "성공" in output
+
+    def test_error_result(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        result = ToolResult(
+            tool_id="test_tool",
+            success=False,
+            error="API error",
+            error_type="execution",
+        )
+        renderer.render(QueryEvent(type="tool_result", tool_result=result))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "오류" in output
+        assert "API error" in output
+
+
+class TestReset:
+    def test_reset_clears_state(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        renderer._text_buffer = "some text"
+        renderer._usage = TokenUsage(input_tokens=5, output_tokens=3)
+        renderer.reset()
+        assert renderer._text_buffer == ""
+        assert renderer._usage is None

--- a/tests/cli/test_renderer.py
+++ b/tests/cli/test_renderer.py
@@ -149,6 +149,61 @@ class TestToolResultRendering:
         assert "API error" in output
 
 
+class TestStopNoDuplication:
+    """Fix 1: text_delta content must NOT be re-printed as Markdown on stop."""
+
+    def test_stop_does_not_reprint_buffered_text(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console)
+        # Stream the text via text_delta
+        renderer.render(QueryEvent(type="text_delta", content="Hello World"))
+        # Record output up to this point
+        output_after_delta = console.file.getvalue()  # type: ignore[union-attr]
+        assert "Hello World" in output_after_delta
+
+        # Now fire the stop event
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.end_turn))
+        output_after_stop = console.file.getvalue()  # type: ignore[union-attr]
+
+        # "Hello World" must appear exactly once — not duplicated by stop
+        assert output_after_stop.count("Hello World") == 1
+
+
+class TestShowUsageFlag:
+    """Fix 2: show_usage flag must gate per-turn usage display."""
+
+    def test_usage_shown_when_flag_true(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console, show_usage=True)
+        renderer.render(
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=10, output_tokens=5))
+        )
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.end_turn))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "10" in output
+        assert "5" in output
+
+    def test_usage_hidden_when_flag_false(self) -> None:
+        console = _make_console()
+        renderer = EventRenderer(console, show_usage=False)
+        renderer.render(
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=10, output_tokens=5))
+        )
+        renderer.render(QueryEvent(type="stop", stop_reason=StopReason.end_turn))
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        # Usage numbers must not appear in output when show_usage=False
+        assert "토큰 사용" not in output
+
+    def test_usage_still_tracked_when_flag_false(self) -> None:
+        """Internal _usage is still populated even when display is suppressed."""
+        console = _make_console()
+        renderer = EventRenderer(console, show_usage=False)
+        usage = TokenUsage(input_tokens=10, output_tokens=5)
+        renderer.render(QueryEvent(type="usage_update", usage=usage))
+        # _usage is set before stop; check it before reset clears it
+        assert renderer._usage == usage
+
+
 class TestReset:
     def test_reset_clears_state(self) -> None:
         console = _make_console()

--- a/tests/cli/test_repl.py
+++ b/tests/cli/test_repl.py
@@ -1,0 +1,212 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for REPLLoop."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+from rich.console import Console
+
+from kosmos.cli.config import CLIConfig
+from kosmos.cli.renderer import EventRenderer
+from kosmos.cli.repl import REPLLoop
+from kosmos.engine.events import QueryEvent, StopReason
+from kosmos.llm.models import TokenUsage
+from kosmos.tools.registry import ToolRegistry
+
+
+def _make_console() -> Console:
+    return Console(file=io.StringIO(), force_terminal=True, width=120)
+
+
+def _make_repl(
+    engine: Any,
+    registry: Any | None = None,
+    config: CLIConfig | None = None,
+) -> tuple[REPLLoop, Console]:
+    console = _make_console()
+    if registry is None:
+        registry = MagicMock(spec=ToolRegistry)
+    if config is None:
+        config = CLIConfig(welcome_banner=False, show_usage=True)
+    renderer = EventRenderer(console, registry=registry)
+    repl = REPLLoop(
+        engine=engine,
+        registry=registry,
+        console=console,
+        config=config,
+        renderer=renderer,
+    )
+    return repl, console
+
+
+class _MockEngine:
+    """Minimal async mock engine."""
+
+    def __init__(self, events: list[QueryEvent]) -> None:
+        self._events = events
+
+    async def run(self, user_message: str) -> AsyncIterator[QueryEvent]:  # noqa: ARG002
+        for event in self._events:
+            yield event
+
+
+class TestSlashCommands:
+    async def test_exit_command_returns_true(self) -> None:
+        engine = _MockEngine([])
+        repl, _ = _make_repl(engine)
+        result = await repl._handle_slash_command("/exit")
+        assert result is True
+
+    async def test_quit_command_returns_true(self) -> None:
+        engine = _MockEngine([])
+        repl, _ = _make_repl(engine)
+        result = await repl._handle_slash_command("/quit")
+        assert result is True
+
+    async def test_help_command_returns_false(self) -> None:
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+        result = await repl._handle_slash_command("/help")
+        assert result is False
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "help" in output
+
+    async def test_new_command_returns_false(self) -> None:
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+        result = await repl._handle_slash_command("/new")
+        assert result is False
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "새 대화" in output
+
+    async def test_usage_command_shows_tokens(self) -> None:
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+        repl._total_input_tokens = 100
+        repl._total_output_tokens = 50
+        result = await repl._handle_slash_command("/usage")
+        assert result is False
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "100" in output
+        assert "50" in output
+
+    async def test_unknown_command_returns_false(self) -> None:
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+        result = await repl._handle_slash_command("/unknown")
+        assert result is False
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "알 수 없는" in output
+
+    async def test_alias_exit_without_slash(self) -> None:
+        engine = _MockEngine([])
+        repl, _ = _make_repl(engine)
+        result = await repl._handle_slash_command("exit")
+        assert result is True
+
+    async def test_alias_quit_without_slash(self) -> None:
+        engine = _MockEngine([])
+        repl, _ = _make_repl(engine)
+        result = await repl._handle_slash_command("quit")
+        assert result is True
+
+
+class TestRunTurn:
+    async def test_run_turn_renders_events(self) -> None:
+        events = [
+            QueryEvent(type="text_delta", content="응답"),
+            QueryEvent(type="stop", stop_reason=StopReason.task_complete),
+        ]
+        engine = _MockEngine(events)
+        repl, console = _make_repl(engine)
+        await repl._run_turn("안녕하세요")
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "응답" in output
+
+    async def test_run_turn_tracks_usage(self) -> None:
+        events = [
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=10, output_tokens=5)),
+            QueryEvent(type="stop", stop_reason=StopReason.end_turn),
+        ]
+        engine = _MockEngine(events)
+        repl, _ = _make_repl(engine)
+        await repl._run_turn("질문")
+        assert repl._total_input_tokens == 10
+        assert repl._total_output_tokens == 5
+
+    async def test_run_turn_accumulates_usage(self) -> None:
+        events = [
+            QueryEvent(type="usage_update", usage=TokenUsage(input_tokens=10, output_tokens=5)),
+            QueryEvent(type="stop", stop_reason=StopReason.end_turn),
+        ]
+        engine = _MockEngine(events)
+        repl, _ = _make_repl(engine)
+        await repl._run_turn("질문1")
+        await repl._run_turn("질문2")
+        assert repl._total_input_tokens == 20
+        assert repl._total_output_tokens == 10
+
+
+class TestWelcomeBanner:
+    def test_welcome_banner_shows_session_id(self) -> None:
+        engine = _MockEngine([])
+        console = _make_console()
+        registry = MagicMock(spec=ToolRegistry)
+        config = CLIConfig(welcome_banner=True)
+        renderer = EventRenderer(console, registry=registry)
+        repl = REPLLoop(
+            engine=engine,
+            registry=registry,
+            console=console,
+            config=config,
+            renderer=renderer,
+        )
+        repl._show_welcome()
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert repl._session_id in output
+
+
+class TestREPLRun:
+    async def test_exit_command_stops_loop(self) -> None:
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+
+        # Simulate: user types "/exit"
+        call_count = 0
+
+        async def mock_prompt_async(prompt_str: str) -> str:
+            nonlocal call_count
+            call_count += 1
+            return "/exit"
+
+        with patch.object(type(repl._engine), "__init__", return_value=None):
+            mock_session = MagicMock()
+            mock_session.prompt_async = mock_prompt_async
+            with patch("kosmos.cli.repl.PromptSession", return_value=mock_session):
+                await repl.run()
+
+        assert call_count == 1
+
+    async def test_empty_input_skipped(self) -> None:
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+        inputs = ["   ", "", "/exit"]
+        idx = 0
+
+        async def mock_prompt_async(prompt_str: str) -> str:
+            nonlocal idx
+            val = inputs[idx]
+            idx += 1
+            return val
+
+        mock_session = MagicMock()
+        mock_session.prompt_async = mock_prompt_async
+        with patch("kosmos.cli.repl.PromptSession", return_value=mock_session):
+            await repl.run()
+
+        # Should have called prompt 3 times (2 empty + 1 exit)
+        assert idx == 3

--- a/tests/cli/test_repl.py
+++ b/tests/cli/test_repl.py
@@ -210,3 +210,71 @@ class TestREPLRun:
 
         # Should have called prompt 3 times (2 empty + 1 exit)
         assert idx == 3
+
+
+class TestHistoryLimit:
+    """Fix 3: CLIConfig.history_size must be applied to prompt history."""
+
+    def test_limited_history_respects_max_entries(self) -> None:
+        from kosmos.cli.repl import _LimitedInMemoryHistory
+
+        hist = _LimitedInMemoryHistory(max_entries=3)
+        for i in range(5):
+            hist.append_string(f"entry{i}")
+        # Only the 3 most-recent entries should remain
+        assert len(hist._loaded_strings) == 3
+
+    def test_limited_history_retains_newest(self) -> None:
+        from kosmos.cli.repl import _LimitedInMemoryHistory
+
+        hist = _LimitedInMemoryHistory(max_entries=2)
+        hist.append_string("old")
+        hist.append_string("newer")
+        hist.append_string("newest")
+        # _loaded_strings is stored newest-first
+        assert hist._loaded_strings[0] == "newest"
+        assert hist._loaded_strings[1] == "newer"
+        assert "old" not in hist._loaded_strings
+
+    def test_history_size_from_config_used(self) -> None:
+        """REPLLoop must use _LimitedInMemoryHistory with history_size from config."""
+        from kosmos.cli.repl import _LimitedInMemoryHistory
+
+        engine = _MockEngine([])
+        config = CLIConfig(welcome_banner=False, history_size=42)
+        repl, _ = _make_repl(engine, config=config)
+
+        # Verify by instantiating the same class the REPL uses
+        hist = _LimitedInMemoryHistory(repl._config.history_size)
+        assert hist._max_entries == 42
+
+
+class TestCommandsRegistryRouting:
+    """Fix 4: slash commands must be routed via the COMMANDS registry."""
+
+    async def test_help_generated_from_registry(self) -> None:
+        """Help output must include all command names from the COMMANDS registry."""
+        from kosmos.cli.models import COMMANDS
+
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+        await repl._handle_slash_command("/help")
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        for name in COMMANDS:
+            assert name in output, f"Command '{name}' missing from /help output"
+
+    async def test_registry_alias_quit_resolves_to_exit(self) -> None:
+        """'quit' alias must resolve to the 'exit' handler via registry."""
+        engine = _MockEngine([])
+        repl, _ = _make_repl(engine)
+        result = await repl._handle_slash_command("/quit")
+        assert result is True
+
+    async def test_unregistered_command_shows_error(self) -> None:
+        """Commands not in the registry must produce an error message."""
+        engine = _MockEngine([])
+        repl, console = _make_repl(engine)
+        result = await repl._handle_slash_command("/notacommand")
+        assert result is False
+        output = console.file.getvalue()  # type: ignore[union-attr]
+        assert "알 수 없는" in output

--- a/tests/cli/test_repl.py
+++ b/tests/cli/test_repl.py
@@ -53,6 +53,9 @@ class _MockEngine:
         for event in self._events:
             yield event
 
+    def reset(self) -> None:
+        """Reset mock engine state."""
+
 
 class TestSlashCommands:
     async def test_exit_command_returns_true(self) -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -390,6 +390,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "rich" },
@@ -421,6 +422,7 @@ requires-dist = [
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.0" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
+    { name = "prompt-toolkit", specifier = ">=3.0" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pydantic-settings", specifier = ">=2.0" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0" },
@@ -772,6 +774,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/79/45/b0847d88d6cfeb4413566738c8bbf1e1995fad3d42515327ff32cc1eb578/prettytable-3.17.0.tar.gz", hash = "sha256:59f2590776527f3c9e8cf9fe7b66dd215837cca96a9c39567414cbc632e8ddb0", size = 67892, upload-time = "2025-11-14T17:33:20.212Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/ee/8c/83087ebc47ab0396ce092363001fa37c17153119ee282700c0713a195853/prettytable-3.17.0-py3-none-any.whl", hash = "sha256:aad69b294ddbe3e1f95ef8886a060ed1666a0b83018bbf56295f6f226c43d287", size = 34433, upload-time = "2025-11-14T17:33:19.093Z" },
+]
+
+[[package]]
+name = "prompt-toolkit"
+version = "3.0.52"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "wcwidth" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
 ]
 
 [[package]]

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -6,3 +6,6 @@ cls  # noqa: F821
 
 # __aexit__ protocol requires *args
 args  # noqa: F821
+
+# typer Option with callback — parameter parsed by typer, never read in function body
+version  # noqa: F821

--- a/vulture_whitelist.py
+++ b/vulture_whitelist.py
@@ -9,3 +9,6 @@ args  # noqa: F821
 
 # typer Option with callback — parameter parsed by typer, never read in function body
 version  # noqa: F821
+
+# InMemoryHistory.store_string override — base class uses string before calling super
+string  # noqa: F821


### PR DESCRIPTION
## Summary

Closes #11

- Adds complete `src/kosmos/cli/` package — Python rapid prototype of the CLI interface using typer + rich + prompt-toolkit
- **CLIConfig**: pydantic-settings with `KOSMOS_CLI_*` prefixed env vars
- **SlashCommand + COMMANDS registry**: `/help`, `/new`, `/exit`, `/usage` with aliases
- **EventRenderer**: Rich-based dispatch renderer for all `QueryEvent` types (text_delta streaming, tool_use spinner with Korean name, tool_result panel, usage summary, citizen-friendly stop messages)
- **ConsentPromptHandler**: Y/n consent prompt for tool execution with bypass-immune denial display
- **REPLLoop**: Main interactive loop with prompt-toolkit, slash command routing, double Ctrl+C exit, streaming cancellation via `aclose()`
- **Entry point**: `python -m kosmos.cli` and `kosmos` script via `[project.scripts]`
- Adds `prompt-toolkit>=3.0` dependency

## Quality

- **65 tests** passing (91.37% coverage)
- mypy strict clean
- ruff lint + format clean
- Full test suite: **732 passed**, no regressions

## Test plan

- [x] `uv run pytest tests/cli/ -v` — all 65 tests pass
- [x] `uv run pytest` — full suite 732 passed, no regressions
- [x] `uv run mypy src/kosmos/cli/` — strict clean
- [x] `uv run ruff check src/kosmos/cli/` — clean
- [x] Coverage >= 80% (actual: 91.37%)
- [x] `uv run python -c "import kosmos.cli"` — works