### PR TITLE
fix(infra): address wave-2 post-merge Copilot review feedback

### DIFF
--- a/src/kosmos/cli/repl.py
+++ b/src/kosmos/cli/repl.py
@@ -195,7 +195,7 @@ class REPLLoop:
                 sys.exit(130)
             self._last_ctrl_c = now
             await gen.aclose()
-            self._console.print("\n[dim][cancelled][/dim]")
+            self._console.print("\n[dim]\\[cancelled][/dim]")
             self._renderer.reset()
 
     async def _handle_slash_command(self, cmd: str) -> bool:
@@ -241,6 +241,10 @@ class REPLLoop:
         elif name == "new":
             self._engine.reset()
             self._session_id = str(uuid.uuid4())
+            # Reset display-level token counters for the new conversation.
+            # Note: the engine's UsageTracker budget is preserved across /new
+            # resets to enforce a per-session spending cap.  These counters
+            # only track display totals shown by /usage.
             self._total_input_tokens = 0
             self._total_output_tokens = 0
             self._renderer.reset()

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -190,7 +190,7 @@ class RecoveryExecutor:
                     elapsed_seconds=elapsed,
                     error_class=ErrorClass.APP_ERROR,
                     is_cached_fallback=False,
-                    circuit_state=CircuitState.OPEN,
+                    circuit_state=breaker.state,
                     tool_id=tool_id,
                 ),
             )
@@ -209,8 +209,17 @@ class RecoveryExecutor:
         # --- 4. Success path ---
         if result_dict is not None:
             breaker.record_success()
+            # Only cache data that passes output_schema validation so that
+            # invalid adapter responses are never served from the cache.
             if tool.cache_ttl_seconds > 0:
-                self._cache.put(tool_id, args_hash, result_dict, tool.cache_ttl_seconds)
+                try:
+                    tool.output_schema.model_validate(result_dict)
+                    self._cache.put(tool_id, args_hash, result_dict, tool.cache_ttl_seconds)
+                except Exception:
+                    logger.debug(
+                        "Skipping cache store for tool %s: output_schema validation failed",
+                        tool_id,
+                    )
             return RecoveryResult(
                 tool_result=ToolResult(
                     tool_id=tool_id,
@@ -283,11 +292,20 @@ class RecoveryExecutor:
     # ------------------------------------------------------------------
 
     def _model_to_dict(self, model: object) -> dict[str, object]:
-        """Convert a Pydantic model to a plain dict for cache key computation."""
+        """Convert a Pydantic model to a plain dict for cache key computation.
+
+        Uses ``mode="json"`` to ensure all values (Enums, datetimes, etc.)
+        are JSON-serialisable primitives.  Falls back to an empty dict on
+        any error to preserve the "never raises" guarantee.
+        """
         from pydantic import BaseModel as _BaseModel  # local import to avoid circular
 
-        if isinstance(model, _BaseModel):
-            return dict(model.model_dump())
+        try:
+            if isinstance(model, _BaseModel):
+                return dict(model.model_dump(mode="json"))
+        except Exception:
+            logger.debug("model_dump(mode='json') failed; falling back to empty dict")
+            return {}
         if isinstance(model, dict):
             return model
         return {}

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -204,13 +204,22 @@ class RecoveryExecutor:
                 ),
             )
 
-        # --- 3. Record rate-limit slot (adapter is about to be called) ---
+        # --- 3. Wrap adapter with per-invocation rate-limit recording ---
+        # Each adapter call (including retries) records a rate-limit slot so
+        # the sliding window accurately reflects actual API call volume.
         if rate_limiter is not None:
-            rate_limiter.record()
+
+            async def _rate_limited_adapter(args: object) -> dict[str, object]:
+                rate_limiter.record()
+                return await adapter(args)
+
+            effective_adapter: AdapterFn = _rate_limited_adapter
+        else:
+            effective_adapter = adapter
 
         # --- 4. Retry loop ---
         result_dict, last_error, attempt_count = await retry_tool_call(
-            adapter,
+            effective_adapter,
             validated_input,
             self._classifier,
             self._policy,

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -49,6 +49,18 @@ logger = logging.getLogger(__name__)
 AdapterFn = Callable[..., Awaitable[dict[str, object]]]
 
 
+class _RateLimitExhaustedInRetryError(Exception):
+    """Raised inside the rate-limited adapter wrapper when a retry attempt
+    would exceed the sliding-window quota.
+
+    Classified as ``APP_ERROR`` / non-retryable by the error classifier,
+    which causes the retry loop to stop immediately.
+    """
+
+    def __init__(self, tool_id: str) -> None:
+        super().__init__(f"Rate limit exhausted during retry for tool {tool_id!r}")
+
+
 # ---------------------------------------------------------------------------
 # Context models
 # ---------------------------------------------------------------------------
@@ -204,12 +216,15 @@ class RecoveryExecutor:
                 ),
             )
 
-        # --- 3. Wrap adapter with per-invocation rate-limit recording ---
-        # Each adapter call (including retries) records a rate-limit slot so
-        # the sliding window accurately reflects actual API call volume.
+        # --- 3. Wrap adapter with per-invocation rate-limit enforcement ---
+        # Each adapter call (including retries) checks AND records a
+        # rate-limit slot so that retry bursts cannot exceed the configured
+        # per-minute quota.
         if rate_limiter is not None:
 
             async def _rate_limited_adapter(args: object) -> dict[str, object]:
+                if not rate_limiter.check():
+                    raise _RateLimitExhaustedInRetryError(tool_id)
                 rate_limiter.record()
                 return await adapter(args)
 

--- a/src/kosmos/recovery/executor.py
+++ b/src/kosmos/recovery/executor.py
@@ -38,6 +38,7 @@ from kosmos.recovery.classifier import (
 from kosmos.recovery.messages import build_degradation_message
 from kosmos.recovery.retry import ToolRetryPolicy, retry_tool_call
 from kosmos.tools.models import GovAPITool, ToolResult
+from kosmos.tools.rate_limiter import RateLimiter
 
 logger = logging.getLogger(__name__)
 
@@ -117,29 +118,34 @@ class RecoveryExecutor:
     # Public interface
     # ------------------------------------------------------------------
 
-    async def execute(
+    async def execute(  # noqa: C901
         self,
         tool: GovAPITool,
         adapter: AdapterFn,
         validated_input: object,
         *,
         is_foreground: bool = True,
+        rate_limiter: RateLimiter | None = None,
     ) -> RecoveryResult:
         """Execute *adapter* with full error-recovery orchestration.
 
         Pipeline:
         1. Cache lookup → return cached data if fresh (no side-effects).
         2. Circuit breaker check → immediate degradation if OPEN.
-        3. Retry loop with exponential back-off.
-        4. On success: update circuit breaker + cache store.
-        5. On exhaustion: try stale cache fallback.
-        6. Last resort: return degradation message as a failed ToolResult.
+        3. Record rate-limit slot (only before the actual adapter call).
+        4. Retry loop with exponential back-off.
+        5. On success: update circuit breaker + cache store.
+        6. On exhaustion: try stale cache fallback.
+        7. Last resort: return degradation message as a failed ToolResult.
 
         Args:
             tool: The GovAPITool being called (used for cache TTL and messages).
             adapter: Async callable that performs the actual API call.
             validated_input: Pre-validated Pydantic model instance to pass to adapter.
             is_foreground: Whether this is a user-facing call (affects retry cap).
+            rate_limiter: Optional rate limiter; ``record()`` is called only
+                when the adapter is actually invoked (not on cache hit or
+                circuit-open short-circuit).
 
         Returns:
             A ``RecoveryResult`` that never represents an un-caught exception.
@@ -150,9 +156,12 @@ class RecoveryExecutor:
 
         # --- 1. Cache lookup (before circuit breaker to avoid wasting a
         #     HALF_OPEN probe allowance on a cache hit) ---
+        # _model_to_dict returns None when serialisation fails; in that case
+        # we skip all caching to avoid degenerate cache keys.
         input_dict = self._model_to_dict(validated_input)
-        args_hash = self._cache.compute_hash(input_dict)
-        if tool.cache_ttl_seconds > 0:
+        args_hash: str | None = None
+        if input_dict is not None and tool.cache_ttl_seconds > 0:
+            args_hash = self._cache.compute_hash(input_dict)
             cached = self._cache.get(tool_id, args_hash)
             if cached is not None:
                 elapsed = time.monotonic() - start
@@ -195,7 +204,11 @@ class RecoveryExecutor:
                 ),
             )
 
-        # --- 3. Retry loop ---
+        # --- 3. Record rate-limit slot (adapter is about to be called) ---
+        if rate_limiter is not None:
+            rate_limiter.record()
+
+        # --- 4. Retry loop ---
         result_dict, last_error, attempt_count = await retry_tool_call(
             adapter,
             validated_input,
@@ -206,12 +219,13 @@ class RecoveryExecutor:
 
         elapsed = time.monotonic() - start
 
-        # --- 4. Success path ---
+        # --- 5. Success path ---
         if result_dict is not None:
             breaker.record_success()
             # Only cache data that passes output_schema validation so that
             # invalid adapter responses are never served from the cache.
-            if tool.cache_ttl_seconds > 0:
+            # args_hash is None when input serialisation failed — skip caching.
+            if args_hash is not None and tool.cache_ttl_seconds > 0:
                 try:
                     tool.output_schema.model_validate(result_dict)
                     self._cache.put(tool_id, args_hash, result_dict, tool.cache_ttl_seconds)
@@ -219,6 +233,7 @@ class RecoveryExecutor:
                     logger.debug(
                         "Skipping cache store for tool %s: output_schema validation failed",
                         tool_id,
+                        exc_info=True,
                     )
             return RecoveryResult(
                 tool_result=ToolResult(
@@ -235,8 +250,8 @@ class RecoveryExecutor:
         if last_error is not None and last_error.is_retryable:
             breaker.record_failure()
 
-        # --- 5. Stale cache fallback (only if cache_ttl_seconds > 0) ---
-        if tool.cache_ttl_seconds > 0:
+        # --- 6. Stale cache fallback (only if cache_ttl_seconds > 0) ---
+        if args_hash is not None and tool.cache_ttl_seconds > 0:
             stale = self._get_stale_cache(tool_id, args_hash)
             if stale is not None:
                 logger.warning(
@@ -260,7 +275,7 @@ class RecoveryExecutor:
                     ),
                 )
 
-        # --- 6. Degradation message ---
+        # --- 7. Degradation message ---
         assert last_error is not None  # retry_tool_call guarantees this when result is None
         degradation = build_degradation_message(tool, last_error)
         error_type = self._error_class_to_error_type(last_error.error_class)
@@ -291,12 +306,12 @@ class RecoveryExecutor:
     # Private helpers
     # ------------------------------------------------------------------
 
-    def _model_to_dict(self, model: object) -> dict[str, object]:
+    def _model_to_dict(self, model: object) -> dict[str, object] | None:
         """Convert a Pydantic model to a plain dict for cache key computation.
 
         Uses ``mode="json"`` to ensure all values (Enums, datetimes, etc.)
-        are JSON-serialisable primitives.  Falls back to an empty dict on
-        any error to preserve the "never raises" guarantee.
+        are JSON-serialisable primitives.  Returns ``None`` on failure so the
+        caller can skip caching rather than produce a degenerate cache key.
         """
         from pydantic import BaseModel as _BaseModel  # local import to avoid circular
 
@@ -304,11 +319,11 @@ class RecoveryExecutor:
             if isinstance(model, _BaseModel):
                 return dict(model.model_dump(mode="json"))
         except Exception:
-            logger.debug("model_dump(mode='json') failed; falling back to empty dict")
-            return {}
+            logger.debug("model_dump(mode='json') failed; caching will be skipped")
+            return None
         if isinstance(model, dict):
             return model
-        return {}
+        return None
 
     def _get_stale_cache(self, tool_id: str, args_hash: str) -> dict[str, object] | None:
         """Look up a stale (possibly expired) cache entry via the public API."""

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -121,9 +121,10 @@ class ToolExecutor:
 
         # Step 4/5: Execute adapter with rate limiting + optional recovery.
         #
-        # Rate limiting is always enforced regardless of recovery mode.
-        # RecoveryExecutor may short-circuit via a cache hit or circuit-open
-        # check, but the rate limiter still governs overall call frequency.
+        # Rate-limit check runs first to reject early when over quota.
+        # ``record()`` is deferred to just before the actual adapter call so
+        # that RecoveryExecutor short-circuits (cache hit, circuit-open) do
+        # NOT consume a rate-limit slot.
         rate_limiter = self._registry.get_rate_limiter(tool_name)
         if not rate_limiter.check():
             logger.warning("Rate limit exceeded for tool: %s", tool_name)
@@ -133,10 +134,11 @@ class ToolExecutor:
                 error=f"Rate limit exceeded for tool {tool_name!r}",
                 error_type="rate_limit",
             )
-        rate_limiter.record()
 
         if self._recovery_executor is not None:
-            # Delegate to RecoveryExecutor for retry / circuit-breaker / cache.
+            # Record rate-limit slot before delegating to RecoveryExecutor
+            # which may invoke the adapter (with retries).
+            rate_limiter.record()
             recovery_result = await self._recovery_executor.execute(
                 tool,
                 adapter,
@@ -148,6 +150,7 @@ class ToolExecutor:
                 return tool_result
             result_dict = dict(tool_result.data or {})
         else:
+            rate_limiter.record()
             try:
                 result_dict = await adapter(validated_input)
             except Exception as exc:

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -136,14 +136,15 @@ class ToolExecutor:
             )
 
         if self._recovery_executor is not None:
-            # Record rate-limit slot before delegating to RecoveryExecutor
-            # which may invoke the adapter (with retries).
-            rate_limiter.record()
+            # Pass rate_limiter to RecoveryExecutor so record() is called
+            # only when the adapter is actually invoked (not on cache hit
+            # or circuit-open short-circuit).
             recovery_result = await self._recovery_executor.execute(
                 tool,
                 adapter,
                 validated_input,
                 is_foreground=True,
+                rate_limiter=rate_limiter,
             )
             tool_result = recovery_result.tool_result
             if not tool_result.success:


### PR DESCRIPTION
## Summary
- Fix 6 post-merge Copilot review comments from PR #284 (Error Recovery) and PR #285 (CLI Interface)
- 2 CRITICAL fixes: `model_dump(mode="json")` for safe serialisation, Rich markup escaping for `[cancelled]`
- 4 IMPORTANT fixes: pre-cache output validation, circuit breaker state accuracy, rate-limit slot conservation, token counter semantics clarification

## Changes
| Severity | File | Fix |
|----------|------|-----|
| CRITICAL | `recovery/executor.py` | `_model_to_dict()` → `model_dump(mode="json")` + try/except for never-raises guarantee |
| CRITICAL | `cli/repl.py` | Escape `[cancelled]` to `\[cancelled]` to prevent Rich `MarkupError` |
| IMPORTANT | `recovery/executor.py` | Validate adapter output against `output_schema` before `cache.put()` |
| IMPORTANT | `recovery/executor.py` | Use `breaker.state` instead of hardcoded `CircuitState.OPEN` |
| IMPORTANT | `tools/executor.py` | Defer `rate_limiter.record()` so cache hits / circuit-open don't consume quota |
| IMPORTANT | `cli/repl.py` | Clarify `/new` display counter reset vs engine budget preservation |

## Test plan
- [x] Full test suite passes (`uv run pytest` — all green)
- [x] Ruff lint + format checks pass
- [x] No new dependencies added