### PR TITLE
feat(geocoding): implement Kakao-backed address geocoding adapters

### DIFF
--- a/docs/adr/ADR-001-geocoding-provider.md
+++ b/docs/adr/ADR-001-geocoding-provider.md
@@ -1,0 +1,100 @@
+# ADR-001: Geocoding Provider Selection — Kakao Local API
+
+**Status**: Accepted
+**Date**: 2026-04-14
+**Epic**: #288 (KOSMOS Geocoding Adapter)
+
+---
+
+## Context
+
+KOSMOS tools (KOROAD accident search, KMA weather APIs) require precise Korean
+administrative region codes (SidoCode, GugunCode) and KMA 5 km grid coordinates
+(nx, ny).  Free-form address strings are the natural user-facing input, so a
+geocoding service is needed to bridge the two.
+
+Candidate providers evaluated:
+
+| Provider | Coverage | Auth | Rate Limit | License |
+|----------|----------|------|------------|---------|
+| Kakao Local API | Comprehensive Korean addresses | REST API key | 300k/day free | Commercial (free tier) |
+| Naver Maps API | Comprehensive Korean addresses | Client ID + Secret | 100k/day free | Commercial (free tier) |
+| OpenStreetMap Nominatim | World coverage, Korea partial | None | 1 req/s | ODbL (open) |
+| data.go.kr 도로명주소 API | Official Korean road addresses | data.go.kr key | Shared quota | Government open data |
+
+---
+
+## Decision
+
+**Use Kakao Local API** (`dapi.kakao.com/v2/local/search/address.json`) as the
+primary geocoding provider.
+
+**Key selection criteria:**
+
+1. **Korean address quality**: Kakao Maps has native Korean address parsing and
+   returns structured `region_1depth_name` / `region_2depth_name` fields that
+   map directly to SidoCode / GugunCode without additional parsing.
+
+2. **Single API key**: Kakao Local API is authenticated via a single REST API
+   key (`KOSMOS_KAKAO_API_KEY`), fitting the KOSMOS `KOSMOS_` env-var convention.
+   This is independent of the `KOSMOS_DATA_GO_KR_API_KEY` used by KOROAD/KMA.
+
+3. **Coordinate quality**: Returns `(x, y)` as longitude/latitude decimal strings
+   with sufficient precision for the KMA 5 km LCC grid conversion.
+
+4. **Road address preference**: Returns both legacy (구주소) and road address
+   (도로명주소) blocks; the road address block is preferred for region name
+   extraction as it uses up-to-date administrative names.
+
+5. **Error taxonomy**: HTTP 401 (auth expired) and HTTP 429 (rate limit) map
+   cleanly to `ToolExecutionError` subtypes; timeouts (5s) trigger the static
+   KMA table fallback.
+
+---
+
+## Consequences
+
+**Positive**:
+- `address_to_region` and `address_to_grid` resolve Korean addresses with high
+  accuracy, enabling natural-language region selection for KOROAD/KMA tools.
+- Post-2023 administrative name changes (강원특별자치도, 전북특별자치도) are handled
+  correctly by Kakao's native address normalisation.
+- Static table fallback (`kma.grid_coords.lookup_grid`) ensures weather grid
+  lookup remains functional when the Kakao API is unavailable.
+
+**Negative / Trade-offs**:
+- Adds a new dependency on a commercial API (`KOSMOS_KAKAO_API_KEY`).  This key
+  must be managed separately from `KOSMOS_DATA_GO_KR_API_KEY`.
+- Kakao's free tier (300k calls/day) is adequate for the current load model but
+  must be monitored as usage scales.
+- `is_personal_data=False` justified: address lookup returns public geographic
+  data, not user-linked PII.  The queried address string itself is transient and
+  not logged beyond DEBUG level.
+
+**Fallback strategy**:
+- On Kakao timeout, `address_to_grid` falls back to the static
+  `REGION_TO_GRID` table via `kma.grid_coords.lookup_grid()`.
+- `address_to_region` does not apply fallback (no static region-code table
+  with sufficient coverage); callers receive `sido_code=None` and must handle
+  the no-match case.
+
+---
+
+## Alternatives Rejected
+
+- **Naver Maps**: Requires two separate credentials (Client-ID + Secret header),
+  increasing secret-management complexity.
+- **Nominatim**: 1 req/s rate limit is insufficient; Korean address structure
+  quality is lower than Kakao/Naver.
+- **data.go.kr road address API**: Shares the `KOSMOS_DATA_GO_KR_API_KEY` quota
+  but returns raw jibun/road text, requiring additional parsing to extract
+  region codes.  Kakao's structured response is simpler.
+
+---
+
+## References
+
+- `docs/vision.md` § Layer 3 (Tool Adapters)
+- `src/kosmos/tools/koroad/code_tables.py` — SidoCode, GugunCode enums
+- `src/kosmos/tools/kma/grid_coords.py` — REGION_TO_GRID, latlon_to_grid
+- `specs/015-geocoding-adapter/spec.md` — full feature specification

--- a/src/kosmos/tools/geocoding/__init__.py
+++ b/src/kosmos/tools/geocoding/__init__.py
@@ -1,0 +1,54 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KOSMOS Geocoding adapter package.
+
+Provides two tools that convert Korean addresses into structured location data:
+
+  * ``address_to_region`` — resolves a free-form Korean address string to
+    province (시도) and district (구군) codes used by KOROAD and other APIs.
+  * ``address_to_grid`` — resolves a free-form Korean address string to the
+    KMA 5 km grid (nx, ny) coordinates used by weather APIs.
+
+Both tools use the Kakao Local API (``dapi.kakao.com``) for geocoding and fall
+back to the built-in KMA region lookup table when the Kakao API is unavailable.
+
+Public re-exports
+-----------------
+- :class:`AddressToRegionInput`
+- :class:`AddressToRegionOutput`
+- :class:`ADDRESS_TO_REGION_TOOL`
+- :func:`register_address_to_region`
+- :class:`AddressToGridInput`
+- :class:`AddressToGridOutput`
+- :class:`ADDRESS_TO_GRID_TOOL`
+- :func:`register_address_to_grid`
+"""
+
+from __future__ import annotations
+
+from kosmos.tools.geocoding.address_to_grid import (
+    ADDRESS_TO_GRID_TOOL,
+    AddressToGridInput,
+    AddressToGridOutput,
+)
+from kosmos.tools.geocoding.address_to_grid import (
+    register as register_address_to_grid,
+)
+from kosmos.tools.geocoding.address_to_region import (
+    ADDRESS_TO_REGION_TOOL,
+    AddressToRegionInput,
+    AddressToRegionOutput,
+)
+from kosmos.tools.geocoding.address_to_region import (
+    register as register_address_to_region,
+)
+
+__all__ = [
+    "AddressToRegionInput",
+    "AddressToRegionOutput",
+    "ADDRESS_TO_REGION_TOOL",
+    "register_address_to_region",
+    "AddressToGridInput",
+    "AddressToGridOutput",
+    "ADDRESS_TO_GRID_TOOL",
+    "register_address_to_grid",
+]

--- a/src/kosmos/tools/geocoding/address_to_grid.py
+++ b/src/kosmos/tools/geocoding/address_to_grid.py
@@ -12,10 +12,9 @@ Execution flow:
   2. Extract ``(latitude, longitude)`` from the first document's ``y``/``x`` fields.
   3. Convert (lat, lon) to (nx, ny) using the KMA Lambert Conformal Conic
      projection via :func:`~kosmos.tools.kma.grid_coords.latlon_to_grid`.
-  4. On Kakao API timeout, fall back to
-     :func:`~kosmos.tools.kma.grid_coords.lookup_grid` using the
-     ``region_1depth_name`` from the last successful response (if available),
-     or the raw address string.
+  4. On Kakao API timeout or no results, fall back to
+     :func:`~kosmos.tools.kma.grid_coords.lookup_grid` using progressively
+     shorter prefix tokens of the raw address string.
 
 If the Kakao API returns zero results and the fallback also fails, ``nx``/``ny``
 are ``None`` and ``source`` is ``"not_found"``.
@@ -107,8 +106,17 @@ async def _resolve_from_kakao(
     result = await search_address(address, client=client)
 
     if not result.documents:
-        logger.info("address_to_grid: no Kakao results for query=%r", address)
+        logger.debug("address_to_grid: no Kakao results")
         return AddressToGridOutput(resolved_address="", source="not_found")
+
+    if len(result.documents) > 1:
+        raise ToolExecutionError(
+            tool_id="address_to_grid",
+            message=(
+                f"Ambiguous address: Kakao returned {result.meta.total_count} matches. "
+                "Please provide a more specific address."
+            ),
+        )
 
     doc = result.documents[0]
 
@@ -160,9 +168,8 @@ def _fallback_local_lookup(address: str) -> AddressToGridOutput:
     for candidate in candidates:
         try:
             nx, ny = lookup_grid(candidate)
-            logger.info(
-                "address_to_grid: table fallback matched %r → nx=%d ny=%d",
-                candidate,
+            logger.debug(
+                "address_to_grid: table fallback matched → nx=%d ny=%d",
                 nx,
                 ny,
             )
@@ -175,7 +182,7 @@ def _fallback_local_lookup(address: str) -> AddressToGridOutput:
         except ValueError:
             continue
 
-    logger.warning("address_to_grid: fallback lookup failed for address=%r", address)
+    logger.debug("address_to_grid: fallback lookup found no match")
     return AddressToGridOutput(resolved_address="", source="not_found")
 
 
@@ -192,7 +199,7 @@ async def _call(
     """Adapter entry point for the address_to_grid tool.
 
     Attempts Kakao geocoding first; falls back to the static KMA table on
-    :exc:`~kosmos.tools.errors.ToolExecutionError` caused by a timeout.
+    :exc:`httpx.TimeoutException`.
 
     Args:
         params: Validated input parameters.
@@ -209,16 +216,10 @@ async def _call(
 
     try:
         output = await _resolve_from_kakao(params.address, client=client)
-    except ToolExecutionError as exc:
-        # On timeout, attempt static-table fallback; re-raise other errors.
-        if "timed out" in str(exc).lower():
-            logger.warning(
-                "address_to_grid: Kakao timed out for address=%r, using table fallback",
-                params.address,
-            )
-            output = _fallback_local_lookup(params.address)
-        else:
-            raise
+    except httpx.TimeoutException:
+        # On timeout, attempt static-table fallback.
+        logger.debug("address_to_grid: Kakao timed out, using table fallback")
+        output = _fallback_local_lookup(params.address)
 
     # If Kakao returned no results, also try static-table fallback.
     if output.source == "not_found":
@@ -226,9 +227,8 @@ async def _call(
         if fallback.source != "not_found":
             output = fallback
 
-    logger.info(
-        "address_to_grid: address=%r → nx=%s ny=%s source=%s",
-        params.address,
+    logger.debug(
+        "address_to_grid: resolved nx=%s ny=%s source=%s",
         output.nx,
         output.ny,
         output.source,
@@ -253,7 +253,7 @@ ADDRESS_TO_GRID_TOOL = GovAPITool(
         "주소 기상격자 좌표 변환 nx ny 날씨 위치 기상청 격자 "
         "address kma grid nx ny weather location geocoding"
     ),
-    requires_auth=True,
+    requires_auth=False,
     is_concurrency_safe=True,
     is_personal_data=False,
     cache_ttl_seconds=86400,
@@ -278,4 +278,4 @@ def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
 
     registry.register(ADDRESS_TO_GRID_TOOL)
     executor.register_adapter("address_to_grid", cast(AdapterFn, _call))
-    logger.info("Registered tool: address_to_grid")
+    logger.debug("Registered tool: address_to_grid")

--- a/src/kosmos/tools/geocoding/address_to_grid.py
+++ b/src/kosmos/tools/geocoding/address_to_grid.py
@@ -1,0 +1,281 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Address-to-KMA-grid geocoding adapter.
+
+Resolves a free-form Korean address string to KMA 5 km grid (nx, ny) coordinates
+used by KMA weather APIs (초단기실황, 단기예보, 초단기예보).
+
+User Story 2 (US-2): "As a KOSMOS user, I want to look up weather data for an
+address so that I can get weather conditions without manually finding grid codes."
+
+Execution flow:
+  1. Call Kakao ``search/address.json`` with the input address string.
+  2. Extract ``(latitude, longitude)`` from the first document's ``y``/``x`` fields.
+  3. Convert (lat, lon) to (nx, ny) using the KMA Lambert Conformal Conic
+     projection via :func:`~kosmos.tools.kma.grid_coords.latlon_to_grid`.
+  4. On Kakao API timeout, fall back to
+     :func:`~kosmos.tools.kma.grid_coords.lookup_grid` using the
+     ``region_1depth_name`` from the last successful response (if available),
+     or the raw address string.
+
+If the Kakao API returns zero results and the fallback also fails, ``nx``/``ny``
+are ``None`` and ``source`` is ``"not_found"``.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from kosmos.tools.errors import ToolExecutionError
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.geocoding.kakao_client import search_address
+from kosmos.tools.kma.grid_coords import latlon_to_grid, lookup_grid
+from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://dapi.kakao.com/v2/local/search/address.json"
+
+# ---------------------------------------------------------------------------
+# Input / Output models
+# ---------------------------------------------------------------------------
+
+
+class AddressToGridInput(BaseModel):
+    """Input parameters for the address_to_grid geocoding tool."""
+
+    model_config = ConfigDict(frozen=True)
+
+    address: str = Field(..., min_length=1)
+    """Free-form Korean address string to geocode (e.g. "서울특별시 서초구 반포대로 201")."""
+
+
+class AddressToGridOutput(BaseModel):
+    """Output from the address_to_grid geocoding tool."""
+
+    model_config = ConfigDict(frozen=True)
+
+    resolved_address: str
+    """Canonical address as returned by the Kakao API.  Empty string when not found."""
+
+    latitude: float | None = None
+    """WGS-84 latitude of the resolved location; ``None`` when not found."""
+
+    longitude: float | None = None
+    """WGS-84 longitude of the resolved location; ``None`` when not found."""
+
+    nx: int | None = None
+    """KMA grid X coordinate; ``None`` when the address could not be resolved."""
+
+    ny: int | None = None
+    """KMA grid Y coordinate; ``None`` when the address could not be resolved."""
+
+    source: str = "not_found"
+    """Resolution method: ``"kakao_latlon"`` (Kakao + LCC projection), ``"table_fallback"``
+    (static KMA region table), or ``"not_found"``."""
+
+
+# ---------------------------------------------------------------------------
+# Internal resolution helpers
+# ---------------------------------------------------------------------------
+
+
+async def _resolve_from_kakao(
+    address: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> AddressToGridOutput:
+    """Attempt to resolve *address* via Kakao and compute the KMA grid.
+
+    Args:
+        address: Free-form Korean address.
+        client: Optional injected ``httpx.AsyncClient`` for testing.
+
+    Returns:
+        A populated :class:`AddressToGridOutput` with ``source="kakao_latlon"``
+        on success, or a no-match output with ``source="not_found"`` when the
+        Kakao API returns no documents.
+
+    Raises:
+        ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
+        ToolExecutionError: On non-timeout Kakao API errors.
+    """
+    result = await search_address(address, client=client)
+
+    if not result.documents:
+        logger.info("address_to_grid: no Kakao results for query=%r", address)
+        return AddressToGridOutput(resolved_address="", source="not_found")
+
+    doc = result.documents[0]
+
+    try:
+        lat = float(doc.y)
+        lon = float(doc.x)
+    except (ValueError, TypeError):
+        logger.warning("address_to_grid: could not parse coordinates x=%r y=%r", doc.x, doc.y)
+        return AddressToGridOutput(resolved_address=doc.address_name, source="not_found")
+
+    nx, ny = latlon_to_grid(lat, lon)
+
+    logger.debug(
+        "address_to_grid: address=%r lat=%.5f lon=%.5f → nx=%d ny=%d",
+        address,
+        lat,
+        lon,
+        nx,
+        ny,
+    )
+
+    return AddressToGridOutput(
+        resolved_address=doc.address_name,
+        latitude=lat,
+        longitude=lon,
+        nx=nx,
+        ny=ny,
+        source="kakao_latlon",
+    )
+
+
+def _fallback_local_lookup(address: str) -> AddressToGridOutput:
+    """Fall back to the static KMA region table using the address string.
+
+    Tries successive prefix tokens of *address* against the
+    :func:`~kosmos.tools.kma.grid_coords.lookup_grid` table.
+
+    Args:
+        address: Address or region name string to try.
+
+    Returns:
+        A :class:`AddressToGridOutput` with ``source="table_fallback"`` if a match
+        was found, or ``source="not_found"`` otherwise.
+    """
+    # Try the full string first, then progressively shorter leading tokens.
+    tokens = address.strip().split()
+    candidates = [address.strip()] + [" ".join(tokens[:i]) for i in range(len(tokens), 0, -1)]
+
+    for candidate in candidates:
+        try:
+            nx, ny = lookup_grid(candidate)
+            logger.info(
+                "address_to_grid: table fallback matched %r → nx=%d ny=%d",
+                candidate,
+                nx,
+                ny,
+            )
+            return AddressToGridOutput(
+                resolved_address=candidate,
+                nx=nx,
+                ny=ny,
+                source="table_fallback",
+            )
+        except ValueError:
+            continue
+
+    logger.warning("address_to_grid: fallback lookup failed for address=%r", address)
+    return AddressToGridOutput(resolved_address="", source="not_found")
+
+
+# ---------------------------------------------------------------------------
+# Adapter callable
+# ---------------------------------------------------------------------------
+
+
+async def _call(
+    params: AddressToGridInput,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Adapter entry point for the address_to_grid tool.
+
+    Attempts Kakao geocoding first; falls back to the static KMA table on
+    :exc:`~kosmos.tools.errors.ToolExecutionError` caused by a timeout.
+
+    Args:
+        params: Validated input parameters.
+        client: Optional injected ``httpx.AsyncClient`` for testing.
+
+    Returns:
+        A plain dict matching :class:`AddressToGridOutput` field names.
+
+    Raises:
+        ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
+        ToolExecutionError: On non-timeout Kakao API errors.
+    """
+    logger.debug("address_to_grid: resolving address=%r", params.address)
+
+    try:
+        output = await _resolve_from_kakao(params.address, client=client)
+    except ToolExecutionError as exc:
+        # On timeout, attempt static-table fallback; re-raise other errors.
+        if "timed out" in str(exc).lower():
+            logger.warning(
+                "address_to_grid: Kakao timed out for address=%r, using table fallback",
+                params.address,
+            )
+            output = _fallback_local_lookup(params.address)
+        else:
+            raise
+
+    # If Kakao returned no results, also try static-table fallback.
+    if output.source == "not_found":
+        fallback = _fallback_local_lookup(params.address)
+        if fallback.source != "not_found":
+            output = fallback
+
+    logger.info(
+        "address_to_grid: address=%r → nx=%s ny=%s source=%s",
+        params.address,
+        output.nx,
+        output.ny,
+        output.source,
+    )
+    return output.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Tool definition
+# ---------------------------------------------------------------------------
+
+ADDRESS_TO_GRID_TOOL = GovAPITool(
+    id="address_to_grid",
+    name_ko="주소→기상청 격자좌표 변환 (nx/ny)",
+    provider="카카오 (Kakao) + 기상청 (KMA)",
+    category=["지오코딩", "주소변환", "기상격자"],
+    endpoint=_BASE_URL,
+    auth_type="api_key",
+    input_schema=AddressToGridInput,
+    output_schema=AddressToGridOutput,
+    search_hint=(
+        "주소 기상격자 좌표 변환 nx ny 날씨 위치 기상청 격자 "
+        "address kma grid nx ny weather location geocoding"
+    ),
+    requires_auth=True,
+    is_concurrency_safe=True,
+    is_personal_data=False,
+    cache_ttl_seconds=86400,
+    rate_limit_per_minute=30,
+    is_core=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration helper
+# ---------------------------------------------------------------------------
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register the address_to_grid tool and its adapter.
+
+    Args:
+        registry: The central :class:`~kosmos.tools.registry.ToolRegistry`.
+        executor: The :class:`~kosmos.tools.executor.ToolExecutor` to bind to.
+    """
+    from kosmos.tools.executor import AdapterFn
+
+    registry.register(ADDRESS_TO_GRID_TOOL)
+    executor.register_adapter("address_to_grid", cast(AdapterFn, _call))
+    logger.info("Registered tool: address_to_grid")

--- a/src/kosmos/tools/geocoding/address_to_grid.py
+++ b/src/kosmos/tools/geocoding/address_to_grid.py
@@ -87,7 +87,7 @@ async def _resolve_from_kakao(
     address: str,
     *,
     client: httpx.AsyncClient | None = None,
-) -> AddressToGridOutput:
+) -> AddressToGridOutput | None:
     """Attempt to resolve *address* via Kakao and compute the KMA grid.
 
     Args:
@@ -96,18 +96,16 @@ async def _resolve_from_kakao(
 
     Returns:
         A populated :class:`AddressToGridOutput` with ``source="kakao_latlon"``
-        on success, or a no-match output with ``source="not_found"`` when the
-        Kakao API returns no documents.
+        on success.  Returns ``None`` when the Kakao API returns no documents.
 
     Raises:
         ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
-        ToolExecutionError: On non-timeout Kakao API errors.
+        ToolExecutionError: On ambiguous addresses (multiple Kakao documents).
     """
     result = await search_address(address, client=client)
 
     if not result.documents:
-        logger.debug("address_to_grid: no Kakao results")
-        return AddressToGridOutput(resolved_address="", source="not_found")
+        return None
 
     if len(result.documents) > 1:
         raise ToolExecutionError(
@@ -161,9 +159,9 @@ def _fallback_local_lookup(address: str) -> AddressToGridOutput:
         A :class:`AddressToGridOutput` with ``source="table_fallback"`` if a match
         was found, or ``source="not_found"`` otherwise.
     """
-    # Try the full string first, then progressively shorter leading tokens.
+    # Try progressively shorter leading tokens (full string first).
     tokens = address.strip().split()
-    candidates = [address.strip()] + [" ".join(tokens[:i]) for i in range(len(tokens), 0, -1)]
+    candidates = [" ".join(tokens[:i]) for i in range(len(tokens), 0, -1)]
 
     for candidate in candidates:
         try:
@@ -210,22 +208,27 @@ async def _call(
 
     Raises:
         ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
-        ToolExecutionError: On non-timeout Kakao API errors.
+        ToolExecutionError: When neither Kakao nor the static table can
+            resolve the address (fail-closed), or on ambiguous addresses.
     """
-    logger.debug("address_to_grid: resolving address=%r", params.address)
+    logger.debug("address_to_grid: resolving")
+
+    output: AddressToGridOutput | None = None
 
     try:
         output = await _resolve_from_kakao(params.address, client=client)
     except httpx.TimeoutException:
-        # On timeout, attempt static-table fallback.
-        logger.debug("address_to_grid: Kakao timed out, using table fallback")
+        logger.debug("address_to_grid: Kakao timed out, trying table fallback")
+
+    # Kakao returned no results or timed out — try static-table fallback.
+    if output is None:
         output = _fallback_local_lookup(params.address)
 
-    # If Kakao returned no results, also try static-table fallback.
     if output.source == "not_found":
-        fallback = _fallback_local_lookup(params.address)
-        if fallback.source != "not_found":
-            output = fallback
+        raise ToolExecutionError(
+            tool_id="address_to_grid",
+            message="Address not found: neither Kakao API nor static table matched.",
+        )
 
     logger.debug(
         "address_to_grid: resolved nx=%s ny=%s source=%s",

--- a/src/kosmos/tools/geocoding/address_to_region.py
+++ b/src/kosmos/tools/geocoding/address_to_region.py
@@ -29,6 +29,7 @@ from typing import Any, cast
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
+from kosmos.tools.errors import ToolExecutionError
 from kosmos.tools.executor import ToolExecutor
 from kosmos.tools.geocoding.kakao_client import search_address
 from kosmos.tools.geocoding.region_mapping import region1_to_sido, region2_to_gugun
@@ -107,8 +108,17 @@ async def _resolve(
     result = await search_address(address, client=client)
 
     if not result.documents:
-        logger.info("address_to_region: no Kakao results for query=%r", address)
+        logger.debug("address_to_region: no Kakao results")
         return AddressToRegionOutput(resolved_address="")
+
+    if len(result.documents) > 1:
+        raise ToolExecutionError(
+            tool_id="address_to_region",
+            message=(
+                f"Ambiguous address: Kakao returned {result.meta.total_count} matches. "
+                "Please provide a more specific address."
+            ),
+        )
 
     doc = result.documents[0]
 
@@ -164,9 +174,8 @@ async def _call(
 
     output = await _resolve(params.address, client=client)
 
-    logger.info(
-        "address_to_region: address=%r → sido_code=%s gugun_code=%s",
-        params.address,
+    logger.debug(
+        "address_to_region: resolved sido_code=%s gugun_code=%s",
         output.sido_code,
         output.gugun_code,
     )
@@ -190,7 +199,7 @@ ADDRESS_TO_REGION_TOOL = GovAPITool(
         "주소 지역코드 변환 시도코드 구군코드 카카오 지오코딩 "
         "address region code geocoding sido gugun kakao location"
     ),
-    requires_auth=True,
+    requires_auth=False,
     is_concurrency_safe=True,
     is_personal_data=False,
     cache_ttl_seconds=86400,
@@ -215,4 +224,4 @@ def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
 
     registry.register(ADDRESS_TO_REGION_TOOL)
     executor.register_adapter("address_to_region", cast(AdapterFn, _call))
-    logger.info("Registered tool: address_to_region")
+    logger.debug("Registered tool: address_to_region")

--- a/src/kosmos/tools/geocoding/address_to_region.py
+++ b/src/kosmos/tools/geocoding/address_to_region.py
@@ -1,0 +1,218 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Address-to-region geocoding adapter.
+
+Resolves a free-form Korean address string to KOROAD province (시도) and
+district (구군) integer codes via the Kakao Local API.
+
+User Story 1 (US-1): "As a KOSMOS user, I want to find accident hotspots near
+an address so that I can assess road-safety risk without manually looking up
+region codes."
+
+Execution flow:
+  1. Call Kakao ``search/address.json`` with the input address string.
+  2. Extract ``region_1depth_name`` and ``region_2depth_name`` from the first
+     document.
+  3. Map both names to :class:`~kosmos.tools.koroad.code_tables.SidoCode` and
+     :class:`~kosmos.tools.koroad.code_tables.GugunCode` via
+     :mod:`~kosmos.tools.geocoding.region_mapping`.
+  4. Return the codes together with the canonical address string and coordinates.
+
+If the Kakao API returns zero results, ``sido_code`` and ``gugun_code`` are
+``None`` and ``resolved_address`` is an empty string.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, cast
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.geocoding.kakao_client import search_address
+from kosmos.tools.geocoding.region_mapping import region1_to_sido, region2_to_gugun
+from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://dapi.kakao.com/v2/local/search/address.json"
+
+# ---------------------------------------------------------------------------
+# Input / Output models
+# ---------------------------------------------------------------------------
+
+
+class AddressToRegionInput(BaseModel):
+    """Input parameters for the address_to_region geocoding tool."""
+
+    model_config = ConfigDict(frozen=True)
+
+    address: str = Field(..., min_length=1)
+    """Free-form Korean address string to geocode (e.g. "서울특별시 강남구 테헤란로 152")."""
+
+
+class AddressToRegionOutput(BaseModel):
+    """Output from the address_to_region geocoding tool."""
+
+    model_config = ConfigDict(frozen=True)
+
+    resolved_address: str
+    """Canonical address string as returned by the Kakao API.  Empty string when no match."""
+
+    latitude: float | None = None
+    """WGS-84 latitude of the resolved location; ``None`` when no match."""
+
+    longitude: float | None = None
+    """WGS-84 longitude of the resolved location; ``None`` when no match."""
+
+    region_1depth: str = ""
+    """Province/city name (시도) as returned by Kakao (e.g. "서울특별시")."""
+
+    region_2depth: str = ""
+    """District name (구군) as returned by Kakao (e.g. "강남구")."""
+
+    sido_code: int | None = None
+    """KOROAD SidoCode integer for the resolved province; ``None`` when no match or unmapped."""
+
+    gugun_code: int | None = None
+    """KOROAD GugunCode integer for the resolved district; ``None`` when unmapped."""
+
+
+# ---------------------------------------------------------------------------
+# Internal resolution helper
+# ---------------------------------------------------------------------------
+
+
+async def _resolve(
+    address: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> AddressToRegionOutput:
+    """Geocode *address* and map it to KOROAD region codes.
+
+    Args:
+        address: Free-form Korean address to geocode.
+        client: Optional injected ``httpx.AsyncClient`` for testing.
+
+    Returns:
+        A populated :class:`AddressToRegionOutput`.  All code fields are
+        ``None`` when the Kakao API returns no documents.
+
+    Raises:
+        ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
+        ToolExecutionError: On Kakao API HTTP errors.
+    """
+    result = await search_address(address, client=client)
+
+    if not result.documents:
+        logger.info("address_to_region: no Kakao results for query=%r", address)
+        return AddressToRegionOutput(resolved_address="")
+
+    doc = result.documents[0]
+
+    # Prefer road_address for region depth names; fall back to legacy address block.
+    addr_block = doc.road_address or doc.address
+    region1 = addr_block.region_1depth_name if addr_block else ""
+    region2 = addr_block.region_2depth_name if addr_block else ""
+
+    sido = region1_to_sido(region1) if region1 else None
+    gugun = region2_to_gugun(region2) if region2 else None
+
+    try:
+        lat = float(doc.y) if doc.y else None
+        lon = float(doc.x) if doc.x else None
+    except (ValueError, TypeError):
+        lat = lon = None
+
+    return AddressToRegionOutput(
+        resolved_address=doc.address_name,
+        latitude=lat,
+        longitude=lon,
+        region_1depth=region1,
+        region_2depth=region2,
+        sido_code=int(sido) if sido is not None else None,
+        gugun_code=int(gugun) if gugun is not None else None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Adapter callable
+# ---------------------------------------------------------------------------
+
+
+async def _call(
+    params: AddressToRegionInput,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> dict[str, Any]:
+    """Adapter entry point for the address_to_region tool.
+
+    Args:
+        params: Validated input parameters.
+        client: Optional injected ``httpx.AsyncClient`` for testing.
+
+    Returns:
+        A plain dict matching :class:`AddressToRegionOutput` field names.
+
+    Raises:
+        ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
+        ToolExecutionError: On Kakao API HTTP errors.
+    """
+    logger.debug("address_to_region: resolving address=%r", params.address)
+
+    output = await _resolve(params.address, client=client)
+
+    logger.info(
+        "address_to_region: address=%r → sido_code=%s gugun_code=%s",
+        params.address,
+        output.sido_code,
+        output.gugun_code,
+    )
+    return output.model_dump()
+
+
+# ---------------------------------------------------------------------------
+# Tool definition
+# ---------------------------------------------------------------------------
+
+ADDRESS_TO_REGION_TOOL = GovAPITool(
+    id="address_to_region",
+    name_ko="주소→지역코드 변환 (시도/구군)",
+    provider="카카오 (Kakao)",
+    category=["지오코딩", "주소변환", "지역코드"],
+    endpoint=_BASE_URL,
+    auth_type="api_key",
+    input_schema=AddressToRegionInput,
+    output_schema=AddressToRegionOutput,
+    search_hint=(
+        "주소 지역코드 변환 시도코드 구군코드 카카오 지오코딩 "
+        "address region code geocoding sido gugun kakao location"
+    ),
+    requires_auth=True,
+    is_concurrency_safe=True,
+    is_personal_data=False,
+    cache_ttl_seconds=86400,
+    rate_limit_per_minute=30,
+    is_core=False,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registration helper
+# ---------------------------------------------------------------------------
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register the address_to_region tool and its adapter.
+
+    Args:
+        registry: The central :class:`~kosmos.tools.registry.ToolRegistry`.
+        executor: The :class:`~kosmos.tools.executor.ToolExecutor` to bind to.
+    """
+    from kosmos.tools.executor import AdapterFn
+
+    registry.register(ADDRESS_TO_REGION_TOOL)
+    executor.register_adapter("address_to_region", cast(AdapterFn, _call))
+    logger.info("Registered tool: address_to_region")

--- a/src/kosmos/tools/geocoding/address_to_region.py
+++ b/src/kosmos/tools/geocoding/address_to_region.py
@@ -108,8 +108,10 @@ async def _resolve(
     result = await search_address(address, client=client)
 
     if not result.documents:
-        logger.debug("address_to_region: no Kakao results")
-        return AddressToRegionOutput(resolved_address="")
+        raise ToolExecutionError(
+            tool_id="address_to_region",
+            message="Address not found: Kakao returned no results.",
+        )
 
     if len(result.documents) > 1:
         raise ToolExecutionError(

--- a/src/kosmos/tools/geocoding/kakao_client.py
+++ b/src/kosmos/tools/geocoding/kakao_client.py
@@ -11,8 +11,8 @@ Key source: ``KOSMOS_KAKAO_API_KEY`` environment variable.
 Error mapping:
   - HTTP 401  → :exc:`~kosmos.tools.errors.ToolExecutionError` (auth_expired)
   - HTTP 429  → :exc:`~kosmos.tools.errors.ToolExecutionError` (rate_limit)
-  - timeout   → :exc:`~kosmos.tools.errors.ToolExecutionError` (timeout)
-  - other 4xx/5xx → :exc:`~kosmos.tools.errors.ToolExecutionError`
+  - timeout   → :exc:`httpx.TimeoutException` (propagated for recovery classifier)
+  - other 4xx/5xx → :exc:`httpx.HTTPStatusError` (propagated for recovery classifier)
 """
 
 from __future__ import annotations
@@ -196,7 +196,7 @@ async def search_address(
         "Authorization": f"KakaoAK {api_key}",
         "Accept": "application/json",
     }
-    request_params: dict[str, str | int] = {"query": query, "size": 1}
+    request_params: dict[str, str | int] = {"query": query, "size": 2}
 
     logger.debug("Kakao address search: query=%r", query)
 
@@ -235,24 +235,8 @@ async def search_address(
 
     except (ToolExecutionError, ConfigurationError):
         raise
-    except httpx.TimeoutException as exc:
-        raise ToolExecutionError(
-            tool_id="kakao_geocoding",
-            message=f"Kakao API request timed out after {_DEFAULT_TIMEOUT}s: {exc}",
-            cause=exc,
-        ) from exc
-    except httpx.HTTPStatusError as exc:
-        raise ToolExecutionError(
-            tool_id="kakao_geocoding",
-            message=f"Kakao API HTTP error: {exc.response.status_code}",
-            cause=exc,
-        ) from exc
-    except httpx.RequestError as exc:
-        raise ToolExecutionError(
-            tool_id="kakao_geocoding",
-            message=f"Network error reaching Kakao API: {exc}",
-            cause=exc,
-        ) from exc
+    # Let httpx exceptions (TimeoutException, HTTPStatusError, RequestError)
+    # propagate directly so the recovery classifier can recognise them.
     finally:
         if own_client and client is not None:
             await client.aclose()

--- a/src/kosmos/tools/geocoding/kakao_client.py
+++ b/src/kosmos/tools/geocoding/kakao_client.py
@@ -8,11 +8,11 @@ coordinate and administrative region data.
 Authentication: REST API key via ``Authorization: KakaoAK {key}`` header.
 Key source: ``KOSMOS_KAKAO_API_KEY`` environment variable.
 
-Error mapping:
-  - HTTP 401  → :exc:`~kosmos.tools.errors.ToolExecutionError` (auth_expired)
-  - HTTP 429  → :exc:`~kosmos.tools.errors.ToolExecutionError` (rate_limit)
-  - timeout   → :exc:`httpx.TimeoutException` (propagated for recovery classifier)
-  - other 4xx/5xx → :exc:`httpx.HTTPStatusError` (propagated for recovery classifier)
+Error mapping (all propagated directly for recovery classifier):
+  - HTTP 401  → :exc:`httpx.HTTPStatusError` (auth_expired)
+  - HTTP 429  → :exc:`httpx.HTTPStatusError` (rate_limit)
+  - timeout   → :exc:`httpx.TimeoutException`
+  - other 4xx/5xx → :exc:`httpx.HTTPStatusError`
 """
 
 from __future__ import annotations
@@ -23,7 +23,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel, ConfigDict, Field
 
-from kosmos.tools.errors import ConfigurationError, ToolExecutionError, _require_env
+from kosmos.tools.errors import ConfigurationError, _require_env
 
 logger = logging.getLogger(__name__)
 
@@ -187,8 +187,12 @@ async def search_address(
 
     Raises:
         ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
-        ToolExecutionError: On HTTP 401 (auth expired), 429 (rate limit),
-            timeout, or other HTTP errors.
+        ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
+        httpx.TimeoutException: On request timeout.
+        httpx.HTTPStatusError: On HTTP 4xx/5xx responses (including 401
+            auth-expired and 429 rate-limit).  Propagated directly so
+            the recovery classifier can recognise and route them.
+        httpx.RequestError: On connection-level failures.
     """
     api_key = _require_env("KOSMOS_KAKAO_API_KEY")
 
@@ -208,32 +212,21 @@ async def search_address(
         assert client is not None
         response = await client.get(_BASE_URL, headers=headers, params=request_params)
 
-        if response.status_code == 401:
-            raise ToolExecutionError(
-                tool_id="kakao_geocoding",
-                message=(
-                    "Kakao API authentication failed (HTTP 401). Check KOSMOS_KAKAO_API_KEY value."
-                ),
-            )
-        if response.status_code == 429:
-            raise ToolExecutionError(
-                tool_id="kakao_geocoding",
-                message="Kakao API rate limit exceeded (HTTP 429). Try again later.",
-            )
-
+        # Let httpx.HTTPStatusError propagate for ALL status codes (including
+        # 401 auth-expired, 429 rate-limit) so the recovery classifier can
+        # recognise them directly without unwrapping ToolExecutionError.
         response.raise_for_status()
 
         payload: dict[str, Any] = response.json()
         result = KakaoSearchResult(**payload)
 
         logger.debug(
-            "Kakao address search returned %d document(s) for query=%r",
+            "Kakao address search returned %d document(s)",
             result.meta.total_count,
-            query,
         )
         return result
 
-    except (ToolExecutionError, ConfigurationError):
+    except ConfigurationError:
         raise
     # Let httpx exceptions (TimeoutException, HTTPStatusError, RequestError)
     # propagate directly so the recovery classifier can recognise them.

--- a/src/kosmos/tools/geocoding/kakao_client.py
+++ b/src/kosmos/tools/geocoding/kakao_client.py
@@ -1,0 +1,258 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Kakao Local API HTTP client for address geocoding.
+
+Wraps the ``GET https://dapi.kakao.com/v2/local/search/address.json``
+endpoint used to convert free-form Korean address strings into structured
+coordinate and administrative region data.
+
+Authentication: REST API key via ``Authorization: KakaoAK {key}`` header.
+Key source: ``KOSMOS_KAKAO_API_KEY`` environment variable.
+
+Error mapping:
+  - HTTP 401  → :exc:`~kosmos.tools.errors.ToolExecutionError` (auth_expired)
+  - HTTP 429  → :exc:`~kosmos.tools.errors.ToolExecutionError` (rate_limit)
+  - timeout   → :exc:`~kosmos.tools.errors.ToolExecutionError` (timeout)
+  - other 4xx/5xx → :exc:`~kosmos.tools.errors.ToolExecutionError`
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field
+
+from kosmos.tools.errors import ConfigurationError, ToolExecutionError, _require_env
+
+logger = logging.getLogger(__name__)
+
+_BASE_URL = "https://dapi.kakao.com/v2/local/search/address.json"
+_DEFAULT_TIMEOUT = 5.0  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Pydantic v2 response models
+# ---------------------------------------------------------------------------
+
+
+class KakaoRoadAddressResult(BaseModel):
+    """Road address (도로명주소) portion of a Kakao address document."""
+
+    model_config = ConfigDict(frozen=True)
+
+    address_name: str
+    """Full road address string."""
+
+    region_1depth_name: str
+    """Province (시도) name, e.g. "서울특별시"."""
+
+    region_2depth_name: str
+    """District (구군) name, e.g. "강남구"."""
+
+    region_3depth_name: str = ""
+    """Sub-district (읍면동) name."""
+
+    road_name: str = ""
+    """Road name."""
+
+    underground_yn: str = "N"
+    """Whether underground (Y/N)."""
+
+    main_building_no: str = ""
+    """Main building number."""
+
+    sub_building_no: str = ""
+    """Sub building number."""
+
+    building_name: str = ""
+    """Building name."""
+
+    zone_no: str = ""
+    """Postal zone code."""
+
+    x: str = ""
+    """Longitude as string."""
+
+    y: str = ""
+    """Latitude as string."""
+
+
+class KakaoAddressDocument(BaseModel):
+    """A single address document returned by the Kakao search/address endpoint."""
+
+    model_config = ConfigDict(frozen=True)
+
+    address_name: str
+    """Full resolved address string."""
+
+    address_type: str = ""
+    """Type of address: REGION, ROAD_ADDR, REGION_ADDR, etc."""
+
+    x: str
+    """Longitude (경도) as string."""
+
+    y: str
+    """Latitude (위도) as string."""
+
+    address: KakaoAddressResult | None = None
+    """Legacy address result block (구주소)."""
+
+    road_address: KakaoRoadAddressResult | None = None
+    """Road address block (도로명주소); preferred when available."""
+
+
+class KakaoAddressResult(BaseModel):
+    """Legacy address (구주소) portion of a Kakao address document."""
+
+    model_config = ConfigDict(frozen=True)
+
+    address_name: str
+    """Full legacy address string."""
+
+    region_1depth_name: str
+    """Province (시도) name."""
+
+    region_2depth_name: str
+    """District (구군) name."""
+
+    region_3depth_name: str = ""
+    """Sub-district (읍면동) name."""
+
+    mountain_yn: str = "N"
+    """Whether mountain address (Y/N)."""
+
+    main_address_no: str = ""
+    """Main address number."""
+
+    sub_address_no: str = ""
+    """Sub address number."""
+
+    x: str = ""
+    """Longitude as string."""
+
+    y: str = ""
+    """Latitude as string."""
+
+
+# Re-attach forward reference now that KakaoAddressResult is defined
+KakaoAddressDocument.model_rebuild()
+
+
+class KakaoSearchMeta(BaseModel):
+    """Metadata returned alongside Kakao address search results."""
+
+    model_config = ConfigDict(frozen=True)
+
+    total_count: int = Field(default=0, ge=0)
+    """Total number of documents matching the query."""
+
+    pageable_count: int = Field(default=0, ge=0)
+    """Number of results the API will paginate through."""
+
+    is_end: bool = True
+    """Whether this is the last page of results."""
+
+
+class KakaoSearchResult(BaseModel):
+    """Top-level response envelope from the Kakao address search API."""
+
+    model_config = ConfigDict(frozen=True)
+
+    meta: KakaoSearchMeta
+    """Pagination metadata."""
+
+    documents: list[KakaoAddressDocument]
+    """Matched address documents (empty list when no match)."""
+
+
+# ---------------------------------------------------------------------------
+# HTTP client
+# ---------------------------------------------------------------------------
+
+
+async def search_address(
+    query: str,
+    *,
+    client: httpx.AsyncClient | None = None,
+) -> KakaoSearchResult:
+    """Search Kakao Local API for a Korean address string.
+
+    Args:
+        query: Free-form Korean address to geocode (e.g. "서울특별시 강남구 테헤란로").
+        client: Optional injected ``httpx.AsyncClient`` for testing.
+
+    Returns:
+        A :class:`KakaoSearchResult` with matched documents (may be empty).
+
+    Raises:
+        ConfigurationError: If ``KOSMOS_KAKAO_API_KEY`` is not set.
+        ToolExecutionError: On HTTP 401 (auth expired), 429 (rate limit),
+            timeout, or other HTTP errors.
+    """
+    api_key = _require_env("KOSMOS_KAKAO_API_KEY")
+
+    headers = {
+        "Authorization": f"KakaoAK {api_key}",
+        "Accept": "application/json",
+    }
+    request_params: dict[str, str | int] = {"query": query, "size": 1}
+
+    logger.debug("Kakao address search: query=%r", query)
+
+    own_client = client is None
+    if own_client:
+        client = httpx.AsyncClient(timeout=_DEFAULT_TIMEOUT)
+
+    try:
+        assert client is not None
+        response = await client.get(_BASE_URL, headers=headers, params=request_params)
+
+        if response.status_code == 401:
+            raise ToolExecutionError(
+                tool_id="kakao_geocoding",
+                message=(
+                    "Kakao API authentication failed (HTTP 401). Check KOSMOS_KAKAO_API_KEY value."
+                ),
+            )
+        if response.status_code == 429:
+            raise ToolExecutionError(
+                tool_id="kakao_geocoding",
+                message="Kakao API rate limit exceeded (HTTP 429). Try again later.",
+            )
+
+        response.raise_for_status()
+
+        payload: dict[str, Any] = response.json()
+        result = KakaoSearchResult(**payload)
+
+        logger.debug(
+            "Kakao address search returned %d document(s) for query=%r",
+            result.meta.total_count,
+            query,
+        )
+        return result
+
+    except (ToolExecutionError, ConfigurationError):
+        raise
+    except httpx.TimeoutException as exc:
+        raise ToolExecutionError(
+            tool_id="kakao_geocoding",
+            message=f"Kakao API request timed out after {_DEFAULT_TIMEOUT}s: {exc}",
+            cause=exc,
+        ) from exc
+    except httpx.HTTPStatusError as exc:
+        raise ToolExecutionError(
+            tool_id="kakao_geocoding",
+            message=f"Kakao API HTTP error: {exc.response.status_code}",
+            cause=exc,
+        ) from exc
+    except httpx.RequestError as exc:
+        raise ToolExecutionError(
+            tool_id="kakao_geocoding",
+            message=f"Network error reaching Kakao API: {exc}",
+            cause=exc,
+        ) from exc
+    finally:
+        if own_client and client is not None:
+            await client.aclose()

--- a/src/kosmos/tools/geocoding/region_mapping.py
+++ b/src/kosmos/tools/geocoding/region_mapping.py
@@ -1,0 +1,193 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Korean administrative region name → KOROAD SidoCode / GugunCode mapping.
+
+Converts the ``region_1depth_name`` and ``region_2depth_name`` strings
+returned by the Kakao Local API into the integer codes expected by the
+KOROAD accident search API.
+
+Coverage:
+  - All 17 sido (시도) values defined in :class:`~kosmos.tools.koroad.code_tables.SidoCode`,
+    including post-2023 special autonomy designations:
+    강원특별자치도 (code 51) and 전북특별자치도 (code 52).
+  - Shortened forms: "서울" → SEOUL, "경기" → GYEONGGI, etc.
+  - Official long forms: "서울특별시" → SEOUL, "경기도" → GYEONGGI.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from kosmos.tools.koroad.code_tables import GugunCode, SidoCode
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Region-1 depth (시도) lookup table
+# ---------------------------------------------------------------------------
+
+# Maps all known Korean province/city name forms to SidoCode.
+# Handles: short forms, official long forms, post-2023 autonomy names.
+_REGION1_TO_SIDO: dict[str, SidoCode] = {
+    # --- Seoul ---
+    "서울": SidoCode.SEOUL,
+    "서울시": SidoCode.SEOUL,
+    "서울특별시": SidoCode.SEOUL,
+    # --- Busan ---
+    "부산": SidoCode.BUSAN,
+    "부산시": SidoCode.BUSAN,
+    "부산광역시": SidoCode.BUSAN,
+    # --- Daegu ---
+    "대구": SidoCode.DAEGU,
+    "대구시": SidoCode.DAEGU,
+    "대구광역시": SidoCode.DAEGU,
+    # --- Incheon ---
+    "인천": SidoCode.INCHEON,
+    "인천시": SidoCode.INCHEON,
+    "인천광역시": SidoCode.INCHEON,
+    # --- Gwangju ---
+    "광주": SidoCode.GWANGJU,
+    "광주시": SidoCode.GWANGJU,
+    "광주광역시": SidoCode.GWANGJU,
+    # --- Daejeon ---
+    "대전": SidoCode.DAEJEON,
+    "대전시": SidoCode.DAEJEON,
+    "대전광역시": SidoCode.DAEJEON,
+    # --- Ulsan ---
+    "울산": SidoCode.ULSAN,
+    "울산시": SidoCode.ULSAN,
+    "울산광역시": SidoCode.ULSAN,
+    # --- Sejong ---
+    "세종": SidoCode.SEJONG,
+    "세종시": SidoCode.SEJONG,
+    "세종특별자치시": SidoCode.SEJONG,
+    # --- Gyeonggi ---
+    "경기": SidoCode.GYEONGGI,
+    "경기도": SidoCode.GYEONGGI,
+    # --- Gangwon (post-2023: 강원특별자치도, code 51) ---
+    "강원": SidoCode.GANGWON,
+    "강원도": SidoCode.GANGWON,
+    "강원특별자치도": SidoCode.GANGWON,
+    # Legacy composite name intentionally maps to new code for 2023+ datasets
+    "강원도(강원특별자치도)": SidoCode.GANGWON,
+    # --- Chungbuk ---
+    "충북": SidoCode.CHUNGBUK,
+    "충청북도": SidoCode.CHUNGBUK,
+    # --- Chungnam ---
+    "충남": SidoCode.CHUNGNAM,
+    "충청남도": SidoCode.CHUNGNAM,
+    # --- Jeonbuk (post-2023: 전북특별자치도, code 52) ---
+    "전북": SidoCode.JEONBUK,
+    "전북도": SidoCode.JEONBUK,
+    "전라북도": SidoCode.JEONBUK,
+    "전북특별자치도": SidoCode.JEONBUK,
+    # Legacy composite name intentionally maps to new code for 2023+ datasets
+    "전라북도(전북특별자치도)": SidoCode.JEONBUK,
+    # --- Jeonnam ---
+    "전남": SidoCode.JEONNAM,
+    "전라남도": SidoCode.JEONNAM,
+    # --- Gyeongbuk ---
+    "경북": SidoCode.GYEONGBUK,
+    "경상북도": SidoCode.GYEONGBUK,
+    # --- Gyeongnam ---
+    "경남": SidoCode.GYEONGNAM,
+    "경상남도": SidoCode.GYEONGNAM,
+    # --- Jeju ---
+    "제주": SidoCode.JEJU,
+    "제주도": SidoCode.JEJU,
+    "제주특별자치도": SidoCode.JEJU,
+}
+
+# ---------------------------------------------------------------------------
+# Region-2 depth (구군) lookup table
+# ---------------------------------------------------------------------------
+
+# Maps district name strings to GugunCode members.
+# Key: Kakao API region_2depth_name value (usually the official Korean name).
+# Value: GugunCode member.  Returns None for unrecognized districts;
+#        callers should use GugunCode.SEOUL_JONGNO (0) or similar safe fallback.
+_REGION2_TO_GUGUN: dict[str, GugunCode] = {
+    # --- Seoul (시도코드 11) ---
+    "종로구": GugunCode.SEOUL_JONGNO,
+    "중구": GugunCode.SEOUL_JUNGGU,
+    "용산구": GugunCode.SEOUL_YONGSAN,
+    "성동구": GugunCode.SEOUL_SEONGDONG,
+    "광진구": GugunCode.SEOUL_GWANGJIN,
+    "동대문구": GugunCode.SEOUL_DONGDAEMUN,
+    "중랑구": GugunCode.SEOUL_JUNGRANG,
+    "성북구": GugunCode.SEOUL_SEONGBUK,
+    "강북구": GugunCode.SEOUL_GANGBUK,
+    "도봉구": GugunCode.SEOUL_DOBONG,
+    "노원구": GugunCode.SEOUL_NOWON,
+    "은평구": GugunCode.SEOUL_EUNPYEONG,
+    "서대문구": GugunCode.SEOUL_SEODAEMUN,
+    "마포구": GugunCode.SEOUL_MAPO,
+    "양천구": GugunCode.SEOUL_YANGCHEON,
+    "강서구": GugunCode.SEOUL_GANGSEO,
+    "구로구": GugunCode.SEOUL_GURO,
+    "금천구": GugunCode.SEOUL_GEUMCHEON,
+    "영등포구": GugunCode.SEOUL_YEONGDEUNGPO,
+    "동작구": GugunCode.SEOUL_DONGJAK,
+    "관악구": GugunCode.SEOUL_GWANAK,
+    "서초구": GugunCode.SEOUL_SEOCHO,
+    "강남구": GugunCode.SEOUL_GANGNAM,
+    "송파구": GugunCode.SEOUL_SONGPA,
+    "강동구": GugunCode.SEOUL_GANGDONG,
+    # --- Busan (시도코드 26) ---
+    "해운대구": GugunCode.BUSAN_HAEUNDAE,
+    "부산진구": GugunCode.BUSAN_BUSANJIN,
+    "동래구": GugunCode.BUSAN_DONGNAE,
+    "남구": GugunCode.BUSAN_NAM,
+    "북구": GugunCode.BUSAN_BUK,
+    "사상구": GugunCode.BUSAN_SASANG,
+    "사하구": GugunCode.BUSAN_SAHA,
+    "연제구": GugunCode.BUSAN_YEONJE,
+    "영도구": GugunCode.BUSAN_YEONGDO,
+    "수영구": GugunCode.BUSAN_SUYEONG,
+    "금정구": GugunCode.BUSAN_GEUMJEONG,
+    "기장군": GugunCode.BUSAN_GIJANG,
+}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def region1_to_sido(region1: str) -> SidoCode | None:
+    """Map a Kakao ``region_1depth_name`` string to a :class:`SidoCode`.
+
+    Handles shortened forms ("서울"), official long forms ("서울특별시"),
+    and post-2023 special autonomy names ("강원특별자치도", "전북특별자치도").
+
+    Args:
+        region1: Province/city name as returned by the Kakao Local API.
+            Leading/trailing whitespace is stripped before lookup.
+
+    Returns:
+        The matching :class:`SidoCode`, or ``None`` if no match is found.
+    """
+    normalized = region1.strip()
+    result = _REGION1_TO_SIDO.get(normalized)
+    if result is None:
+        logger.warning("region1_to_sido: no match for %r", normalized)
+    return result
+
+
+def region2_to_gugun(region2: str) -> GugunCode | None:
+    """Map a Kakao ``region_2depth_name`` string to a :class:`GugunCode`.
+
+    Args:
+        region2: District name as returned by the Kakao Local API.
+            Leading/trailing whitespace is stripped before lookup.
+
+    Returns:
+        The matching :class:`GugunCode`, or ``None`` if no match is found.
+        Returns ``None`` for districts not yet in the lookup table —
+        callers should use a sido-appropriate default (e.g. the first
+        district code for that sido) as a fallback.
+    """
+    normalized = region2.strip()
+    result = _REGION2_TO_GUGUN.get(normalized)
+    if result is None:
+        logger.debug("region2_to_gugun: no exact match for %r, returning None", normalized)
+    return result

--- a/src/kosmos/tools/geocoding/region_mapping.py
+++ b/src/kosmos/tools/geocoding/region_mapping.py
@@ -104,7 +104,7 @@ _REGION1_TO_SIDO: dict[str, SidoCode] = {
 # Maps district name strings to GugunCode members.
 # Key: Kakao API region_2depth_name value (usually the official Korean name).
 # Value: GugunCode member.  Returns None for unrecognized districts;
-#        callers should use GugunCode.SEOUL_JONGNO (0) or similar safe fallback.
+#        callers should use GugunCode.SEOUL_JONGNO or a similarly safe fallback.
 _REGION2_TO_GUGUN: dict[str, GugunCode] = {
     # --- Seoul (시도코드 11) ---
     "종로구": GugunCode.SEOUL_JONGNO,

--- a/src/kosmos/tools/geocoding/region_mapping.py
+++ b/src/kosmos/tools/geocoding/region_mapping.py
@@ -169,7 +169,7 @@ def region1_to_sido(region1: str) -> SidoCode | None:
     normalized = region1.strip()
     result = _REGION1_TO_SIDO.get(normalized)
     if result is None:
-        logger.warning("region1_to_sido: no match for %r", normalized)
+        logger.debug("region1_to_sido: no match for %r", normalized)
     return result
 
 
@@ -182,9 +182,8 @@ def region2_to_gugun(region2: str) -> GugunCode | None:
 
     Returns:
         The matching :class:`GugunCode`, or ``None`` if no match is found.
-        Returns ``None`` for districts not yet in the lookup table —
-        callers should use a sido-appropriate default (e.g. the first
-        district code for that sido) as a fallback.
+        Callers must handle the ``None`` case explicitly (e.g. raise
+        an error) rather than guessing a default code.
     """
     normalized = region2.strip()
     result = _REGION2_TO_GUGUN.get(normalized)

--- a/src/kosmos/tools/kma/grid_coords.py
+++ b/src/kosmos/tools/kma/grid_coords.py
@@ -1,5 +1,5 @@
 # SPDX-License-Identifier: Apache-2.0
-"""KMA (Korea Meteorological Administration) grid coordinate lookup tables.
+"""KMA (Korea Meteorological Administration) grid coordinate lookup tables and conversions.
 
 Maps Korean region names (Korean or Romanized) to KMA 5 km grid (nx, ny) points
 used by the ultra-short-term observation API (getUltraSrtNcst).
@@ -9,6 +9,8 @@ Reference: KMA VilageFcstInfoService_2.0 API technical guide.
 """
 
 from __future__ import annotations
+
+import math
 
 # REGION_TO_GRID: maps region name strings to (nx, ny) KMA grid tuples.
 # Keys include both Korean and common Romanized names for broad matching.
@@ -131,3 +133,59 @@ def lookup_grid(region: str) -> tuple[int, int]:
         raise ValueError(
             f"Unknown region {region!r}. Known regions ({len(known)} total): {known[:10]}..."
         ) from None
+
+
+def latlon_to_grid(lat: float, lon: float) -> tuple[int, int]:
+    """Convert WGS-84 (latitude, longitude) to KMA 5 km Lambert Conformal Conic grid (nx, ny).
+
+    Uses the official KMA VilageFcstInfoService_2.0 projection parameters:
+      - Earth radius Re = 6371.00877 km
+      - Grid resolution = 5.0 km
+      - Standard latitudes slat1 = 30.0°, slat2 = 60.0°
+      - Reference longitude olon = 126.0°, reference latitude olat = 38.0°
+      - Grid origin xo = 43, yo = 136 (in grid units from the projection origin)
+
+    Args:
+        lat: Latitude in decimal degrees (WGS-84).
+        lon: Longitude in decimal degrees (WGS-84).
+
+    Returns:
+        A ``(nx, ny)`` tuple of integer KMA grid coordinates.
+    """
+    # KMA Lambert Conformal Conic projection constants (official KMA parameters)
+    earth_radius_km = 6371.00877  # Earth radius [km]
+    grid_km = 5.0  # Grid resolution [km]
+    slat1_deg = 30.0  # Standard latitude 1 [degrees]
+    slat2_deg = 60.0  # Standard latitude 2 [degrees]
+    olon_deg = 126.0  # Reference (true) longitude [degrees]
+    olat_deg = 38.0  # Reference latitude [degrees]
+    xo = 43.0  # Grid x-origin offset
+    yo = 136.0  # Grid y-origin offset
+
+    degrad = math.pi / 180.0
+
+    re = earth_radius_km / grid_km
+    slat1 = slat1_deg * degrad
+    slat2 = slat2_deg * degrad
+    olon = olon_deg * degrad
+    olat = olat_deg * degrad
+
+    sn = math.tan(math.pi * 0.25 + slat2 * 0.5) / math.tan(math.pi * 0.25 + slat1 * 0.5)
+    sn = math.log(math.cos(slat1) / math.cos(slat2)) / math.log(sn)
+    sf = math.tan(math.pi * 0.25 + slat1 * 0.5)
+    sf = (sf**sn) * math.cos(slat1) / sn
+    ro = math.tan(math.pi * 0.25 + olat * 0.5)
+    ro = re * sf / (ro**sn)
+
+    ra = math.tan(math.pi * 0.25 + lat * degrad * 0.5)
+    ra = re * sf / (ra**sn)
+    theta = lon * degrad - olon
+    if theta > math.pi:
+        theta -= 2.0 * math.pi
+    if theta < -math.pi:
+        theta += 2.0 * math.pi
+    theta *= sn
+
+    nx = int(ra * math.sin(theta) + xo + 1.5)
+    ny = int(ro - ra * math.cos(theta) + yo + 1.5)
+    return nx, ny

--- a/src/kosmos/tools/register_all.py
+++ b/src/kosmos/tools/register_all.py
@@ -26,6 +26,8 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> None:
       5. kma_ultra_short_term_forecast — KMA ultra-short-term forecast (초단기예보)
       6. kma_pre_warning — KMA weather pre-warning list (기상예비특보목록)
       7. road_risk_score — composite road risk score (fans out to all three)
+      8. address_to_region — Kakao geocoding → KOROAD region codes (시도/구군)
+      9. address_to_grid — Kakao geocoding → KMA grid coordinates (nx/ny)
 
     Args:
         registry: The central ToolRegistry to add tools to.
@@ -36,6 +38,8 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> None:
             function is called a second time on the same registry).
     """
     from kosmos.tools.composite.road_risk_score import register as reg_risk
+    from kosmos.tools.geocoding.address_to_grid import register as reg_addr_grid
+    from kosmos.tools.geocoding.address_to_region import register as reg_addr_region
     from kosmos.tools.kma.kma_current_observation import register as reg_kma_obs
     from kosmos.tools.kma.kma_pre_warning import register as reg_kma_pre_warning
     from kosmos.tools.kma.kma_short_term_forecast import register as reg_kma_stf
@@ -50,5 +54,7 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> None:
     reg_kma_ustf(registry, executor)
     reg_kma_pre_warning(registry, executor)
     reg_risk(registry, executor)
+    reg_addr_region(registry, executor)
+    reg_addr_grid(registry, executor)
 
     logger.info("All %d tools registered successfully", len(registry))

--- a/tests/tools/geocoding/__init__.py
+++ b/tests/tools/geocoding/__init__.py
@@ -1,0 +1,1 @@
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/tools/geocoding/fixtures/address_to_grid_haeundae.json
+++ b/tests/tools/geocoding/fixtures/address_to_grid_haeundae.json
@@ -1,0 +1,27 @@
+{
+  "meta": {
+    "total_count": 1,
+    "pageable_count": 1,
+    "is_end": true
+  },
+  "documents": [
+    {
+      "address_name": "부산광역시 해운대구 중동 1415",
+      "address_type": "REGION_ADDR",
+      "x": "129.158780",
+      "y": "35.163030",
+      "address": {
+        "address_name": "부산광역시 해운대구 중동 1415",
+        "region_1depth_name": "부산광역시",
+        "region_2depth_name": "해운대구",
+        "region_3depth_name": "중동",
+        "mountain_yn": "N",
+        "main_address_no": "1415",
+        "sub_address_no": "",
+        "x": "129.158780",
+        "y": "35.163030"
+      },
+      "road_address": null
+    }
+  ]
+}

--- a/tests/tools/geocoding/fixtures/address_to_grid_seocho.json
+++ b/tests/tools/geocoding/fixtures/address_to_grid_seocho.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "total_count": 1,
+    "pageable_count": 1,
+    "is_end": true
+  },
+  "documents": [
+    {
+      "address_name": "서울특별시 서초구 반포대로 201",
+      "address_type": "ROAD_ADDR",
+      "x": "127.008941",
+      "y": "37.503888",
+      "address": {
+        "address_name": "서울특별시 서초구 반포동 19-3",
+        "region_1depth_name": "서울특별시",
+        "region_2depth_name": "서초구",
+        "region_3depth_name": "반포동",
+        "mountain_yn": "N",
+        "main_address_no": "19",
+        "sub_address_no": "3",
+        "x": "127.008941",
+        "y": "37.503888"
+      },
+      "road_address": {
+        "address_name": "서울특별시 서초구 반포대로 201",
+        "region_1depth_name": "서울특별시",
+        "region_2depth_name": "서초구",
+        "region_3depth_name": "반포동",
+        "road_name": "반포대로",
+        "underground_yn": "N",
+        "main_building_no": "201",
+        "sub_building_no": "",
+        "building_name": "국립중앙도서관",
+        "zone_no": "06579",
+        "x": "127.008941",
+        "y": "37.503888"
+      }
+    }
+  ]
+}

--- a/tests/tools/geocoding/fixtures/address_to_region_busan.json
+++ b/tests/tools/geocoding/fixtures/address_to_region_busan.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "total_count": 1,
+    "pageable_count": 1,
+    "is_end": true
+  },
+  "documents": [
+    {
+      "address_name": "부산광역시 해운대구 해운대해변로 264",
+      "address_type": "ROAD_ADDR",
+      "x": "129.162591",
+      "y": "35.158887",
+      "address": {
+        "address_name": "부산광역시 해운대구 우동 1408",
+        "region_1depth_name": "부산광역시",
+        "region_2depth_name": "해운대구",
+        "region_3depth_name": "우동",
+        "mountain_yn": "N",
+        "main_address_no": "1408",
+        "sub_address_no": "",
+        "x": "129.162591",
+        "y": "35.158887"
+      },
+      "road_address": {
+        "address_name": "부산광역시 해운대구 해운대해변로 264",
+        "region_1depth_name": "부산광역시",
+        "region_2depth_name": "해운대구",
+        "region_3depth_name": "우동",
+        "road_name": "해운대해변로",
+        "underground_yn": "N",
+        "main_building_no": "264",
+        "sub_building_no": "",
+        "building_name": "해운대 그랜드 호텔",
+        "zone_no": "48099",
+        "x": "129.162591",
+        "y": "35.158887"
+      }
+    }
+  ]
+}

--- a/tests/tools/geocoding/fixtures/address_to_region_gangnam.json
+++ b/tests/tools/geocoding/fixtures/address_to_region_gangnam.json
@@ -1,0 +1,40 @@
+{
+  "meta": {
+    "total_count": 1,
+    "pageable_count": 1,
+    "is_end": true
+  },
+  "documents": [
+    {
+      "address_name": "서울특별시 강남구 테헤란로 152",
+      "address_type": "ROAD_ADDR",
+      "x": "127.036167",
+      "y": "37.500167",
+      "address": {
+        "address_name": "서울특별시 강남구 역삼동 737",
+        "region_1depth_name": "서울특별시",
+        "region_2depth_name": "강남구",
+        "region_3depth_name": "역삼동",
+        "mountain_yn": "N",
+        "main_address_no": "737",
+        "sub_address_no": "",
+        "x": "127.036167",
+        "y": "37.500167"
+      },
+      "road_address": {
+        "address_name": "서울특별시 강남구 테헤란로 152",
+        "region_1depth_name": "서울특별시",
+        "region_2depth_name": "강남구",
+        "region_3depth_name": "역삼동",
+        "road_name": "테헤란로",
+        "underground_yn": "N",
+        "main_building_no": "152",
+        "sub_building_no": "",
+        "building_name": "강남파이낸스센터",
+        "zone_no": "06236",
+        "x": "127.036167",
+        "y": "37.500167"
+      }
+    }
+  ]
+}

--- a/tests/tools/geocoding/fixtures/address_to_region_nonsense.json
+++ b/tests/tools/geocoding/fixtures/address_to_region_nonsense.json
@@ -1,0 +1,8 @@
+{
+  "meta": {
+    "total_count": 0,
+    "pageable_count": 0,
+    "is_end": true
+  },
+  "documents": []
+}

--- a/tests/tools/geocoding/test_address_to_grid.py
+++ b/tests/tools/geocoding/test_address_to_grid.py
@@ -1,0 +1,228 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for kosmos.tools.geocoding.address_to_grid."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from kosmos.tools.errors import ConfigurationError
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.geocoding.address_to_grid import (
+    ADDRESS_TO_GRID_TOOL,
+    AddressToGridInput,
+    _call,
+    _fallback_local_lookup,
+    _resolve_from_kakao,
+    register,
+)
+from kosmos.tools.registry import ToolRegistry
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((_FIXTURE_DIR / name).read_text())
+
+
+def _make_mock_client(fixture_data: dict) -> httpx.AsyncClient:
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = fixture_data
+    mock_response.raise_for_status = MagicMock()
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# TestAddressToGridInput
+# ---------------------------------------------------------------------------
+
+
+class TestAddressToGridInput:
+    def test_valid_address(self):
+        inp = AddressToGridInput(address="서울특별시 서초구 반포대로 201")
+        assert inp.address == "서울특별시 서초구 반포대로 201"
+
+    def test_empty_address_raises(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AddressToGridInput(address="")
+
+
+# ---------------------------------------------------------------------------
+# TestResolveFromKakao
+# ---------------------------------------------------------------------------
+
+
+class TestResolveFromKakao:
+    @pytest.mark.asyncio
+    async def test_seocho_resolves_grid(self, monkeypatch):
+        """Seocho address resolves to a valid KMA grid with source=kakao_latlon."""
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_grid_seocho.json")
+        mock_client = _make_mock_client(fixture)
+
+        output = await _resolve_from_kakao("서울특별시 서초구 반포대로 201", client=mock_client)
+
+        assert output.source == "kakao_latlon"
+        assert output.nx is not None
+        assert output.ny is not None
+        assert output.latitude is not None
+        assert output.longitude is not None
+        # Seocho should map to grid near (61, 124)
+        assert isinstance(output.nx, int)
+        assert isinstance(output.ny, int)
+
+    @pytest.mark.asyncio
+    async def test_haeundae_resolves_grid(self, monkeypatch):
+        """Haeundae address resolves to a valid KMA grid with source=kakao_latlon."""
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_grid_haeundae.json")
+        mock_client = _make_mock_client(fixture)
+
+        output = await _resolve_from_kakao("부산광역시 해운대구 중동", client=mock_client)
+
+        assert output.source == "kakao_latlon"
+        assert output.nx is not None and output.nx > 0
+        assert output.ny is not None and output.ny > 0
+
+    @pytest.mark.asyncio
+    async def test_no_results_returns_not_found(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_region_nonsense.json")
+        mock_client = _make_mock_client(fixture)
+
+        output = await _resolve_from_kakao("nonsense xyz", client=mock_client)
+
+        assert output.source == "not_found"
+        assert output.nx is None
+        assert output.ny is None
+
+
+# ---------------------------------------------------------------------------
+# TestFallbackLocalLookup
+# ---------------------------------------------------------------------------
+
+
+class TestFallbackLocalLookup:
+    def test_seoul_fallback(self):
+        """'서울' appears in the static table."""
+        output = _fallback_local_lookup("서울")
+        assert output.source == "table_fallback"
+        assert output.nx == 61
+        assert output.ny == 126
+
+    def test_partial_match_by_first_token(self):
+        """'서울특별시 강남구 ...' — first token '서울특별시' should match."""
+        output = _fallback_local_lookup("서울특별시 강남구 테헤란로 152")
+        assert output.source == "table_fallback"
+        assert output.nx is not None
+
+    def test_unknown_returns_not_found(self):
+        output = _fallback_local_lookup("알수없는지역 알수없는구")
+        assert output.source == "not_found"
+        assert output.nx is None
+        assert output.ny is None
+
+
+# ---------------------------------------------------------------------------
+# TestCall
+# ---------------------------------------------------------------------------
+
+
+class TestCall:
+    @pytest.mark.asyncio
+    async def test_kakao_success_returns_dict(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_grid_seocho.json")
+        mock_client = _make_mock_client(fixture)
+
+        params = AddressToGridInput(address="서울특별시 서초구 반포대로 201")
+        result = await _call(params, client=mock_client)
+
+        assert isinstance(result, dict)
+        assert result["source"] == "kakao_latlon"
+        assert result["nx"] is not None
+        assert result["ny"] is not None
+
+    @pytest.mark.asyncio
+    async def test_kakao_timeout_falls_back_to_table(self, monkeypatch):
+        """On Kakao timeout, falls back to static table lookup."""
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.TimeoutException("timed out")
+
+        params = AddressToGridInput(address="서울 강남구")
+        result = await _call(params, client=mock_client)
+
+        # Should use table fallback for "서울" prefix
+        assert result["source"] == "table_fallback"
+        assert result["nx"] is not None
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("KOSMOS_KAKAO_API_KEY", raising=False)
+        params = AddressToGridInput(address="서울특별시 강남구")
+        with pytest.raises(ConfigurationError):
+            await _call(params)
+
+    @pytest.mark.asyncio
+    async def test_no_results_tries_fallback(self, monkeypatch):
+        """When Kakao returns no results, fallback table is consulted."""
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_region_nonsense.json")
+        mock_client = _make_mock_client(fixture)
+
+        params = AddressToGridInput(address="서울")
+        result = await _call(params, client=mock_client)
+
+        # Static table has "서울", so fallback should succeed
+        assert result["nx"] is not None
+        assert result["ny"] is not None
+
+
+# ---------------------------------------------------------------------------
+# TestToolDefinition
+# ---------------------------------------------------------------------------
+
+
+class TestToolDefinition:
+    def test_tool_id(self):
+        assert ADDRESS_TO_GRID_TOOL.id == "address_to_grid"
+
+    def test_requires_auth_true(self):
+        assert ADDRESS_TO_GRID_TOOL.requires_auth is True
+
+    def test_is_personal_data_false(self):
+        assert ADDRESS_TO_GRID_TOOL.is_personal_data is False
+
+    def test_is_concurrency_safe_true(self):
+        assert ADDRESS_TO_GRID_TOOL.is_concurrency_safe is True
+
+    def test_is_core_false(self):
+        assert ADDRESS_TO_GRID_TOOL.is_core is False
+
+    def test_cache_ttl_positive(self):
+        assert ADDRESS_TO_GRID_TOOL.cache_ttl_seconds > 0
+
+
+# ---------------------------------------------------------------------------
+# TestRegister
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_adds_to_registry_and_executor(self):
+        registry = ToolRegistry()
+        executor = ToolExecutor(registry)
+        register(registry, executor)
+        assert "address_to_grid" in registry
+        assert "address_to_grid" in executor._adapters

--- a/tests/tools/geocoding/test_address_to_grid.py
+++ b/tests/tools/geocoding/test_address_to_grid.py
@@ -198,8 +198,8 @@ class TestToolDefinition:
     def test_tool_id(self):
         assert ADDRESS_TO_GRID_TOOL.id == "address_to_grid"
 
-    def test_requires_auth_true(self):
-        assert ADDRESS_TO_GRID_TOOL.requires_auth is True
+    def test_requires_auth_false(self):
+        assert ADDRESS_TO_GRID_TOOL.requires_auth is False
 
     def test_is_personal_data_false(self):
         assert ADDRESS_TO_GRID_TOOL.is_personal_data is False

--- a/tests/tools/geocoding/test_address_to_grid.py
+++ b/tests/tools/geocoding/test_address_to_grid.py
@@ -95,16 +95,14 @@ class TestResolveFromKakao:
         assert output.ny is not None and output.ny > 0
 
     @pytest.mark.asyncio
-    async def test_no_results_returns_not_found(self, monkeypatch):
+    async def test_no_results_returns_none(self, monkeypatch):
         monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
         fixture = _load_fixture("address_to_region_nonsense.json")
         mock_client = _make_mock_client(fixture)
 
         output = await _resolve_from_kakao("nonsense xyz", client=mock_client)
 
-        assert output.source == "not_found"
-        assert output.nx is None
-        assert output.ny is None
+        assert output is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/geocoding/test_address_to_region.py
+++ b/tests/tools/geocoding/test_address_to_region.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for kosmos.tools.geocoding.address_to_region."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from kosmos.tools.errors import ConfigurationError
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.geocoding.address_to_region import (
+    ADDRESS_TO_REGION_TOOL,
+    AddressToRegionInput,
+    AddressToRegionOutput,
+    _call,
+    _resolve,
+    register,
+)
+from kosmos.tools.registry import ToolRegistry
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((_FIXTURE_DIR / name).read_text())
+
+
+def _make_mock_client(fixture_data: dict) -> httpx.AsyncClient:
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = 200
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = fixture_data
+    mock_response.raise_for_status = MagicMock()
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# TestAddressToRegionInput
+# ---------------------------------------------------------------------------
+
+
+class TestAddressToRegionInput:
+    def test_valid_address(self):
+        inp = AddressToRegionInput(address="서울특별시 강남구 테헤란로 152")
+        assert inp.address == "서울특별시 강남구 테헤란로 152"
+
+    def test_empty_address_raises(self):
+        from pydantic import ValidationError
+
+        with pytest.raises(ValidationError):
+            AddressToRegionInput(address="")
+
+
+# ---------------------------------------------------------------------------
+# TestResolve
+# ---------------------------------------------------------------------------
+
+
+class TestResolve:
+    @pytest.mark.asyncio
+    async def test_gangnam_resolves_correctly(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_region_gangnam.json")
+        mock_client = _make_mock_client(fixture)
+
+        output = await _resolve("서울특별시 강남구 테헤란로 152", client=mock_client)
+
+        assert isinstance(output, AddressToRegionOutput)
+        assert output.region_1depth == "서울특별시"
+        assert output.region_2depth == "강남구"
+        assert output.sido_code == 11  # SidoCode.SEOUL
+        assert output.gugun_code == 680  # GugunCode.SEOUL_GANGNAM
+        assert output.latitude is not None
+        assert output.longitude is not None
+
+    @pytest.mark.asyncio
+    async def test_busan_haeundae_resolves_correctly(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_region_busan.json")
+        mock_client = _make_mock_client(fixture)
+
+        output = await _resolve("부산광역시 해운대구 해운대해변로 264", client=mock_client)
+
+        assert output.sido_code == 26  # SidoCode.BUSAN
+        assert output.gugun_code == 350  # GugunCode.BUSAN_HAEUNDAE
+        assert output.region_1depth == "부산광역시"
+        assert output.region_2depth == "해운대구"
+
+    @pytest.mark.asyncio
+    async def test_no_results_returns_empty_output(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_region_nonsense.json")
+        mock_client = _make_mock_client(fixture)
+
+        output = await _resolve("nonsense xyz 12345", client=mock_client)
+
+        assert output.resolved_address == ""
+        assert output.sido_code is None
+        assert output.gugun_code is None
+        assert output.latitude is None
+        assert output.longitude is None
+
+
+# ---------------------------------------------------------------------------
+# TestCall
+# ---------------------------------------------------------------------------
+
+
+class TestCall:
+    @pytest.mark.asyncio
+    async def test_returns_dict(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        fixture = _load_fixture("address_to_region_gangnam.json")
+        mock_client = _make_mock_client(fixture)
+
+        params = AddressToRegionInput(address="서울특별시 강남구 테헤란로 152")
+        result = await _call(params, client=mock_client)
+
+        assert isinstance(result, dict)
+        assert result["sido_code"] == 11
+        assert result["gugun_code"] == 680
+        assert result["region_1depth"] == "서울특별시"
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("KOSMOS_KAKAO_API_KEY", raising=False)
+        params = AddressToRegionInput(address="서울특별시 강남구")
+        with pytest.raises(ConfigurationError):
+            await _call(params)
+
+
+# ---------------------------------------------------------------------------
+# TestToolDefinition
+# ---------------------------------------------------------------------------
+
+
+class TestToolDefinition:
+    def test_tool_id(self):
+        assert ADDRESS_TO_REGION_TOOL.id == "address_to_region"
+
+    def test_requires_auth_true(self):
+        assert ADDRESS_TO_REGION_TOOL.requires_auth is True
+
+    def test_is_personal_data_false(self):
+        assert ADDRESS_TO_REGION_TOOL.is_personal_data is False
+
+    def test_is_concurrency_safe_true(self):
+        assert ADDRESS_TO_REGION_TOOL.is_concurrency_safe is True
+
+    def test_is_core_false(self):
+        assert ADDRESS_TO_REGION_TOOL.is_core is False
+
+    def test_cache_ttl_is_positive(self):
+        assert ADDRESS_TO_REGION_TOOL.cache_ttl_seconds > 0
+
+
+# ---------------------------------------------------------------------------
+# TestRegister
+# ---------------------------------------------------------------------------
+
+
+class TestRegister:
+    def test_register_adds_to_registry_and_executor(self):
+        registry = ToolRegistry()
+        executor = ToolExecutor(registry)
+        register(registry, executor)
+        assert "address_to_region" in registry
+        assert "address_to_region" in executor._adapters

--- a/tests/tools/geocoding/test_address_to_region.py
+++ b/tests/tools/geocoding/test_address_to_region.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from kosmos.tools.errors import ConfigurationError
+from kosmos.tools.errors import ConfigurationError, ToolExecutionError
 from kosmos.tools.executor import ToolExecutor
 from kosmos.tools.geocoding.address_to_region import (
     ADDRESS_TO_REGION_TOOL,
@@ -93,18 +93,14 @@ class TestResolve:
         assert output.region_2depth == "해운대구"
 
     @pytest.mark.asyncio
-    async def test_no_results_returns_empty_output(self, monkeypatch):
+    async def test_no_results_raises_tool_execution_error(self, monkeypatch):
         monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
         fixture = _load_fixture("address_to_region_nonsense.json")
         mock_client = _make_mock_client(fixture)
 
-        output = await _resolve("nonsense xyz 12345", client=mock_client)
-
-        assert output.resolved_address == ""
-        assert output.sido_code is None
-        assert output.gugun_code is None
-        assert output.latitude is None
-        assert output.longitude is None
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await _resolve("nonsense xyz 12345", client=mock_client)
+        assert "not found" in str(exc_info.value).lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/geocoding/test_address_to_region.py
+++ b/tests/tools/geocoding/test_address_to_region.py
@@ -144,8 +144,8 @@ class TestToolDefinition:
     def test_tool_id(self):
         assert ADDRESS_TO_REGION_TOOL.id == "address_to_region"
 
-    def test_requires_auth_true(self):
-        assert ADDRESS_TO_REGION_TOOL.requires_auth is True
+    def test_requires_auth_false(self):
+        assert ADDRESS_TO_REGION_TOOL.requires_auth is False
 
     def test_is_personal_data_false(self):
         assert ADDRESS_TO_REGION_TOOL.is_personal_data is False

--- a/tests/tools/geocoding/test_grid_conversion.py
+++ b/tests/tools/geocoding/test_grid_conversion.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for latlon_to_grid() in kosmos.tools.kma.grid_coords."""
+
+from __future__ import annotations
+
+from kosmos.tools.kma.grid_coords import latlon_to_grid
+
+
+class TestLatLonToGrid:
+    """Validate KMA Lambert Conformal Conic conversion against known reference points."""
+
+    def test_seoul_city_hall(self):
+        """Seoul City Hall (37.5665, 126.9780) → expected KMA grid ~(60, 127)."""
+        nx, ny = latlon_to_grid(37.5665, 126.9780)
+        # Allow ±2 grid cells for floating-point variation
+        assert abs(nx - 60) <= 2, f"nx={nx} expected ~60"
+        assert abs(ny - 127) <= 2, f"ny={ny} expected ~127"
+
+    def test_busan_haeundae(self):
+        """Busan Haeundae beach (35.1588, 129.1603) → expected KMA grid ~(99, 76)."""
+        nx, ny = latlon_to_grid(35.1588, 129.1603)
+        assert abs(nx - 99) <= 2, f"nx={nx} expected ~99"
+        assert abs(ny - 76) <= 2, f"ny={ny} expected ~76"
+
+    def test_seocho_coords(self):
+        """Seocho (37.5039, 127.0089) → nx near 61, ny near 124."""
+        nx, ny = latlon_to_grid(37.5039, 127.0089)
+        assert abs(nx - 61) <= 2, f"nx={nx} expected ~61"
+        assert abs(ny - 124) <= 2, f"ny={ny} expected ~124"
+
+    def test_gangnam_coords(self):
+        """Gangnam (37.5002, 127.0362) → nx near 61, ny near 125."""
+        nx, ny = latlon_to_grid(37.5002, 127.0362)
+        assert abs(nx - 61) <= 2, f"nx={nx} expected ~61"
+        assert abs(ny - 125) <= 2, f"ny={ny} expected ~125"
+
+    def test_returns_tuple_of_ints(self):
+        nx, ny = latlon_to_grid(37.5665, 126.9780)
+        assert isinstance(nx, int)
+        assert isinstance(ny, int)
+
+    def test_jeju_island(self):
+        """Jeju Island center (33.4890, 126.4983) → expected KMA grid ~(52, 38)."""
+        nx, ny = latlon_to_grid(33.4890, 126.4983)
+        assert abs(nx - 52) <= 3, f"nx={nx} expected ~52"
+        assert abs(ny - 38) <= 3, f"ny={ny} expected ~38"

--- a/tests/tools/geocoding/test_kakao_client.py
+++ b/tests/tools/geocoding/test_kakao_client.py
@@ -163,11 +163,10 @@ class TestSearchAddress:
         assert "429" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_timeout_raises_tool_execution_error(self, monkeypatch):
+    async def test_timeout_propagates_as_httpx_exception(self, monkeypatch):
         monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
         mock_client = AsyncMock(spec=httpx.AsyncClient)
         mock_client.get.side_effect = httpx.TimeoutException("timed out")
 
-        with pytest.raises(ToolExecutionError) as exc_info:
+        with pytest.raises(httpx.TimeoutException):
             await search_address("서울 강남구", client=mock_client)
-        assert "timed out" in str(exc_info.value).lower()

--- a/tests/tools/geocoding/test_kakao_client.py
+++ b/tests/tools/geocoding/test_kakao_client.py
@@ -10,7 +10,7 @@ from unittest.mock import AsyncMock, MagicMock
 import httpx
 import pytest
 
-from kosmos.tools.errors import ConfigurationError, ToolExecutionError
+from kosmos.tools.errors import ConfigurationError
 from kosmos.tools.geocoding.kakao_client import (
     KakaoAddressDocument,
     KakaoSearchMeta,
@@ -135,32 +135,34 @@ class TestSearchAddress:
             await search_address("서울 강남구")
 
     @pytest.mark.asyncio
-    async def test_http_401_raises_tool_execution_error(self, monkeypatch):
+    async def test_http_401_propagates_as_http_status_error(self, monkeypatch):
         monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "bad-key")
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 401
         mock_response.headers = {"content-type": "application/json"}
-        mock_response.raise_for_status = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "401 Unauthorized", request=MagicMock(), response=mock_response
+        )
         mock_client = AsyncMock(spec=httpx.AsyncClient)
         mock_client.get.return_value = mock_response
 
-        with pytest.raises(ToolExecutionError) as exc_info:
+        with pytest.raises(httpx.HTTPStatusError):
             await search_address("서울 강남구", client=mock_client)
-        assert "401" in str(exc_info.value)
 
     @pytest.mark.asyncio
-    async def test_http_429_raises_tool_execution_error(self, monkeypatch):
+    async def test_http_429_propagates_as_http_status_error(self, monkeypatch):
         monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
         mock_response = MagicMock(spec=httpx.Response)
         mock_response.status_code = 429
         mock_response.headers = {"content-type": "application/json"}
-        mock_response.raise_for_status = MagicMock()
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "429 Too Many Requests", request=MagicMock(), response=mock_response
+        )
         mock_client = AsyncMock(spec=httpx.AsyncClient)
         mock_client.get.return_value = mock_response
 
-        with pytest.raises(ToolExecutionError) as exc_info:
+        with pytest.raises(httpx.HTTPStatusError):
             await search_address("서울 강남구", client=mock_client)
-        assert "429" in str(exc_info.value)
 
     @pytest.mark.asyncio
     async def test_timeout_propagates_as_httpx_exception(self, monkeypatch):

--- a/tests/tools/geocoding/test_kakao_client.py
+++ b/tests/tools/geocoding/test_kakao_client.py
@@ -1,0 +1,173 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for kosmos.tools.geocoding.kakao_client."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from kosmos.tools.errors import ConfigurationError, ToolExecutionError
+from kosmos.tools.geocoding.kakao_client import (
+    KakaoAddressDocument,
+    KakaoSearchMeta,
+    KakaoSearchResult,
+    search_address,
+)
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures"
+
+
+def _load_fixture(name: str) -> dict:
+    return json.loads((_FIXTURE_DIR / name).read_text())
+
+
+def _make_mock_client(fixture_data: dict, *, status_code: int = 200) -> httpx.AsyncClient:
+    mock_response = MagicMock(spec=httpx.Response)
+    mock_response.status_code = status_code
+    mock_response.headers = {"content-type": "application/json"}
+    mock_response.json.return_value = fixture_data
+    if status_code >= 400:
+        mock_response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            message=f"HTTP {status_code}",
+            request=MagicMock(),
+            response=mock_response,
+        )
+    else:
+        mock_response.raise_for_status = MagicMock()
+    mock_client = AsyncMock(spec=httpx.AsyncClient)
+    mock_client.get.return_value = mock_response
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# TestKakaoSearchMeta
+# ---------------------------------------------------------------------------
+
+
+class TestKakaoSearchMeta:
+    def test_default_values(self):
+        meta = KakaoSearchMeta()
+        assert meta.total_count == 0
+        assert meta.pageable_count == 0
+        assert meta.is_end is True
+
+    def test_populated(self):
+        meta = KakaoSearchMeta(total_count=3, pageable_count=3, is_end=False)
+        assert meta.total_count == 3
+        assert meta.is_end is False
+
+
+# ---------------------------------------------------------------------------
+# TestKakaoSearchResult
+# ---------------------------------------------------------------------------
+
+
+class TestKakaoSearchResult:
+    def test_empty_documents(self):
+        result = KakaoSearchResult(meta=KakaoSearchMeta(), documents=[])
+        assert result.documents == []
+        assert result.meta.total_count == 0
+
+    def test_gangnam_fixture(self):
+        data = _load_fixture("address_to_region_gangnam.json")
+        result = KakaoSearchResult(**data)
+        assert result.meta.total_count == 1
+        assert len(result.documents) == 1
+        doc = result.documents[0]
+        assert isinstance(doc, KakaoAddressDocument)
+        assert doc.road_address is not None
+        assert doc.road_address.region_1depth_name == "서울특별시"
+        assert doc.road_address.region_2depth_name == "강남구"
+
+    def test_busan_fixture(self):
+        data = _load_fixture("address_to_region_busan.json")
+        result = KakaoSearchResult(**data)
+        assert result.meta.total_count == 1
+        doc = result.documents[0]
+        assert doc.road_address is not None
+        assert doc.road_address.region_1depth_name == "부산광역시"
+        assert doc.road_address.region_2depth_name == "해운대구"
+
+    def test_no_results_fixture(self):
+        data = _load_fixture("address_to_region_nonsense.json")
+        result = KakaoSearchResult(**data)
+        assert result.meta.total_count == 0
+        assert result.documents == []
+
+
+# ---------------------------------------------------------------------------
+# TestSearchAddress
+# ---------------------------------------------------------------------------
+
+
+class TestSearchAddress:
+    @pytest.mark.asyncio
+    async def test_happy_path_gangnam(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key-123")
+        fixture = _load_fixture("address_to_region_gangnam.json")
+        mock_client = _make_mock_client(fixture)
+
+        result = await search_address("서울특별시 강남구 테헤란로 152", client=mock_client)
+
+        assert result.meta.total_count == 1
+        assert len(result.documents) == 1
+        doc = result.documents[0]
+        assert doc.road_address is not None
+        assert doc.road_address.region_1depth_name == "서울특별시"
+
+    @pytest.mark.asyncio
+    async def test_no_results(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key-123")
+        fixture = _load_fixture("address_to_region_nonsense.json")
+        mock_client = _make_mock_client(fixture)
+
+        result = await search_address("nonsense xyz 12345", client=mock_client)
+        assert result.documents == []
+
+    @pytest.mark.asyncio
+    async def test_missing_api_key_raises_config_error(self, monkeypatch):
+        monkeypatch.delenv("KOSMOS_KAKAO_API_KEY", raising=False)
+        with pytest.raises(ConfigurationError):
+            await search_address("서울 강남구")
+
+    @pytest.mark.asyncio
+    async def test_http_401_raises_tool_execution_error(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "bad-key")
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 401
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = mock_response
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await search_address("서울 강남구", client=mock_client)
+        assert "401" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_http_429_raises_tool_execution_error(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        mock_response = MagicMock(spec=httpx.Response)
+        mock_response.status_code = 429
+        mock_response.headers = {"content-type": "application/json"}
+        mock_response.raise_for_status = MagicMock()
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.return_value = mock_response
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await search_address("서울 강남구", client=mock_client)
+        assert "429" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_timeout_raises_tool_execution_error(self, monkeypatch):
+        monkeypatch.setenv("KOSMOS_KAKAO_API_KEY", "test-key")
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.get.side_effect = httpx.TimeoutException("timed out")
+
+        with pytest.raises(ToolExecutionError) as exc_info:
+            await search_address("서울 강남구", client=mock_client)
+        assert "timed out" in str(exc_info.value).lower()

--- a/tests/tools/geocoding/test_region_mapping.py
+++ b/tests/tools/geocoding/test_region_mapping.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for kosmos.tools.geocoding.region_mapping."""
+
+from __future__ import annotations
+
+from kosmos.tools.geocoding.region_mapping import region1_to_sido, region2_to_gugun
+from kosmos.tools.koroad.code_tables import GugunCode, SidoCode
+
+
+class TestRegion1ToSido:
+    """region1_to_sido() covers all 17 sido including post-2023 autonomy names."""
+
+    # --- Basic metro cities ---
+    def test_seoul_short(self):
+        assert region1_to_sido("서울") == SidoCode.SEOUL
+
+    def test_seoul_official(self):
+        assert region1_to_sido("서울특별시") == SidoCode.SEOUL
+
+    def test_busan_short(self):
+        assert region1_to_sido("부산") == SidoCode.BUSAN
+
+    def test_busan_official(self):
+        assert region1_to_sido("부산광역시") == SidoCode.BUSAN
+
+    def test_daegu(self):
+        assert region1_to_sido("대구광역시") == SidoCode.DAEGU
+
+    def test_incheon(self):
+        assert region1_to_sido("인천광역시") == SidoCode.INCHEON
+
+    def test_gwangju(self):
+        assert region1_to_sido("광주광역시") == SidoCode.GWANGJU
+
+    def test_daejeon(self):
+        assert region1_to_sido("대전광역시") == SidoCode.DAEJEON
+
+    def test_ulsan(self):
+        assert region1_to_sido("울산광역시") == SidoCode.ULSAN
+
+    def test_sejong_short(self):
+        assert region1_to_sido("세종") == SidoCode.SEJONG
+
+    def test_sejong_official(self):
+        assert region1_to_sido("세종특별자치시") == SidoCode.SEJONG
+
+    def test_gyeonggi_short(self):
+        assert region1_to_sido("경기") == SidoCode.GYEONGGI
+
+    def test_gyeonggi_official(self):
+        assert region1_to_sido("경기도") == SidoCode.GYEONGGI
+
+    # --- Post-2023 special autonomy names ---
+    def test_gangwon_legacy_name(self):
+        """Old name 강원도 maps to new GANGWON code (51) for 2023+ compatibility."""
+        assert region1_to_sido("강원도") == SidoCode.GANGWON
+
+    def test_gangwon_new_name(self):
+        assert region1_to_sido("강원특별자치도") == SidoCode.GANGWON
+
+    def test_gangwon_short(self):
+        assert region1_to_sido("강원") == SidoCode.GANGWON
+
+    def test_jeonbuk_legacy_name(self):
+        """Old name 전라북도 maps to new JEONBUK code (52) for 2023+ compatibility."""
+        assert region1_to_sido("전라북도") == SidoCode.JEONBUK
+
+    def test_jeonbuk_new_name(self):
+        assert region1_to_sido("전북특별자치도") == SidoCode.JEONBUK
+
+    def test_jeonbuk_short(self):
+        assert region1_to_sido("전북") == SidoCode.JEONBUK
+
+    # --- Other provinces ---
+    def test_chungbuk(self):
+        assert region1_to_sido("충청북도") == SidoCode.CHUNGBUK
+
+    def test_chungnam(self):
+        assert region1_to_sido("충청남도") == SidoCode.CHUNGNAM
+
+    def test_jeonnam(self):
+        assert region1_to_sido("전라남도") == SidoCode.JEONNAM
+
+    def test_gyeongbuk(self):
+        assert region1_to_sido("경상북도") == SidoCode.GYEONGBUK
+
+    def test_gyeongnam(self):
+        assert region1_to_sido("경상남도") == SidoCode.GYEONGNAM
+
+    def test_jeju_short(self):
+        assert region1_to_sido("제주") == SidoCode.JEJU
+
+    def test_jeju_official(self):
+        assert region1_to_sido("제주특별자치도") == SidoCode.JEJU
+
+    # --- Whitespace handling ---
+    def test_strips_whitespace(self):
+        assert region1_to_sido("  서울특별시  ") == SidoCode.SEOUL
+
+    # --- Unknown name ---
+    def test_unknown_returns_none(self):
+        assert region1_to_sido("알수없는도시") is None
+
+    def test_empty_string_returns_none(self):
+        assert region1_to_sido("") is None
+
+    # --- Enum codes ---
+    def test_gangwon_code_is_51(self):
+        sido = region1_to_sido("강원특별자치도")
+        assert sido is not None
+        assert int(sido) == 51
+
+    def test_jeonbuk_code_is_52(self):
+        sido = region1_to_sido("전북특별자치도")
+        assert sido is not None
+        assert int(sido) == 52
+
+
+class TestRegion2ToGugun:
+    """region2_to_gugun() maps Seoul and Busan district names correctly."""
+
+    def test_gangnam(self):
+        assert region2_to_gugun("강남구") == GugunCode.SEOUL_GANGNAM
+
+    def test_seocho(self):
+        assert region2_to_gugun("서초구") == GugunCode.SEOUL_SEOCHO
+
+    def test_jongno(self):
+        assert region2_to_gugun("종로구") == GugunCode.SEOUL_JONGNO
+
+    def test_haeundae(self):
+        assert region2_to_gugun("해운대구") == GugunCode.BUSAN_HAEUNDAE
+
+    def test_strips_whitespace(self):
+        assert region2_to_gugun("  강남구  ") == GugunCode.SEOUL_GANGNAM
+
+    def test_unknown_returns_none(self):
+        assert region2_to_gugun("알수없는구") is None
+
+    def test_empty_returns_none(self):
+        assert region2_to_gugun("") is None

--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -16,7 +16,7 @@ class TestToolRegistration:
         registry = ToolRegistry()
         executor = ToolExecutor(registry)
         register_all_tools(registry, executor)
-        assert len(registry) == 7
+        assert len(registry) == 9
 
     def test_tool_ids_present(self) -> None:
         """Each expected tool_id is in the registry."""
@@ -28,6 +28,8 @@ class TestToolRegistration:
             "kma_weather_alert_status",
             "kma_current_observation",
             "road_risk_score",
+            "address_to_region",
+            "address_to_grid",
         }
         for tool_id in expected:
             assert tool_id in registry, f"{tool_id} not found in registry"
@@ -42,6 +44,8 @@ class TestToolRegistration:
             "kma_weather_alert_status",
             "kma_current_observation",
             "road_risk_score",
+            "address_to_region",
+            "address_to_grid",
         }
         for tool_id in expected:
             assert tool_id in executor._adapters, f"No adapter for {tool_id}"


### PR DESCRIPTION
## Summary

- Add two geocoding tools (`address_to_region`, `address_to_grid`) backed by the Kakao Local API
- Implement Kakao HTTP client with Pydantic v2 models, auth via `KOSMOS_KAKAO_API_KEY`
- Add Korean region name → KOROAD SidoCode/GugunCode mapping (all 17 시도, post-2023 autonomy names)
- Add Lambert Conformal Conic `latlon_to_grid()` to KMA grid_coords module
- Register both tools in `register_all.py` (7 → 9 tools total)
- Create ADR-001 documenting Kakao provider selection rationale

Closes #288

## Test plan

- [x] 89 new geocoding tests pass with recorded fixtures (no live API calls)
- [x] Full test suite (1360 tests) passes with zero regressions
- [x] `ruff check` and `ruff format --check` clean
- [ ] CI pipeline passes all checks
- [ ] Copilot Review Gate passes