### PR TITLE
fix(env): load repo-root .env for tool adapters + CLI entry

### DIFF
--- a/src/kosmos/_dotenv.py
+++ b/src/kosmos/_dotenv.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Repo-root ``.env`` loader used by both the CLI entry point and the test suite.
+
+Tool adapters (``tools/errors.py``, ``permissions/credentials.py``, ``cli/themes.py``)
+read env vars directly via ``os.environ.get()`` rather than through
+``pydantic-settings``. Without this loader, a developer who configured
+``KOSMOS_*`` keys via ``.env`` would see tool adapters report "not set"
+because ``pydantic-settings`` materialises values into its own settings
+object — never into ``os.environ``. Shell-exported variables always win,
+so production deployments that inject secrets via GitHub Actions / systemd
+/ Docker env are unaffected.
+
+Stdlib-only parser — no new runtime dependency (see ``AGENTS.md``).
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+
+def load_repo_dotenv(repo_root: Path | None = None) -> None:
+    """Populate ``os.environ`` from ``<repo_root>/.env`` if present.
+
+    Pre-existing ``os.environ`` entries win — never overwrites a variable
+    that the shell (or CI secret injection) already exported. Silently
+    no-ops when ``.env`` is absent.
+    """
+    root = repo_root if repo_root is not None else _default_repo_root()
+    env_path = root / ".env"
+    if not env_path.is_file():
+        return
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip().strip('"').strip("'")
+        if key and key not in os.environ:
+            os.environ[key] = value
+
+
+def _default_repo_root() -> Path:
+    """Resolve the repo root assuming this file lives at ``src/kosmos/_dotenv.py``."""
+    return Path(__file__).resolve().parent.parent.parent

--- a/src/kosmos/cli/app.py
+++ b/src/kosmos/cli/app.py
@@ -12,6 +12,7 @@ import typer
 from rich.console import Console
 from rich.markup import escape
 
+from kosmos._dotenv import load_repo_dotenv
 from kosmos.cli.config import CLIConfig
 from kosmos.cli.renderer import EventRenderer
 from kosmos.cli.repl import REPLLoop
@@ -242,4 +243,5 @@ def _run_repl(resume_session_id: str | None = None) -> None:
 
 def main() -> None:
     """Public entry point called by ``[project.scripts]`` and ``__main__.py``."""
+    load_repo_dotenv()
     _app()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,20 @@
 # SPDX-License-Identifier: Apache-2.0
-"""Root test configuration — live marker skip logic.
+"""Root test configuration — live marker skip logic and .env loading.
 
 Ensures ``@pytest.mark.live`` tests are skipped by default and only run
-when explicitly selected via ``pytest -m live``.
+when explicitly selected via ``pytest -m live``. Also loads ``.env`` from
+the repository root into ``os.environ`` so tool adapters that read env
+vars via ``os.environ.get()`` (e.g. Kakao, data.go.kr) see the same
+configuration the CLI entry point sees.
 """
 
 from __future__ import annotations
 
 import pytest
+
+from kosmos._dotenv import load_repo_dotenv
+
+load_repo_dotenv()
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:


### PR DESCRIPTION
## Summary

- Tool adapters (`tools/errors.py`, `permissions/credentials.py`, `cli/themes.py`) read env vars directly via `os.environ.get()`. `pydantic-settings` (used only by `LLMClientConfig` and `CLIConfig`) materialises values into its own settings object — **never into `os.environ`** — so `.env`-configured `KOSMOS_*` keys were invisible to tool adapters.
- Adds a stdlib-only `load_repo_dotenv()` (new `src/kosmos/_dotenv.py`) wired into both the CLI entry point (`cli/app.py:main`) and the pytest root conftest (`tests/conftest.py`). Pre-existing `os.environ` entries always win, so shell-exported secrets and CI-injected GitHub Actions secrets are never overwritten.
- No new runtime dependency (per `AGENTS.md`).

## Evidence

- Live suite was reproducing 8× `KOSMOS_KAKAO_API_KEY is not set` ERROR despite a populated `.env` on `spec/019-phase1-hardening`.
- After this fix: `uv run pytest -m live -v` → **33 passed / 0 failed / 0 xfailed** (434.91s, 2026-04-15).
- Mocked regression: `uv run pytest -m "not live"` → **1471 passed** (8.58s).

## Test plan

- [x] `uv run pytest -m "not live"` — 1471 passed, no regressions
- [x] `uv run pytest -m live -v` — 33/33 passed (Phase 1 SC-1 target met)
- [x] `uv run ruff check src/kosmos/_dotenv.py src/kosmos/cli/app.py tests/conftest.py` — clean
- [x] `uv run mypy src/kosmos/_dotenv.py src/kosmos/cli/app.py` — clean
- [ ] CI green (Copilot review gate + checks)

## Notes

- This fix was discovered while investigating Spec 020 (Epic #428, Tool-Error Self-Correct). Live re-run after this patch showed the Phase 1 tool-call-shape failures were actually env-loading failures in disguise; Spec 020's circuit breaker / structured payload scope will be re-evaluated for Phase 2 demotion in a follow-up.