### PR TITLE
feat(observability): add openTelemetry GenAI spans and Langfuse v3 stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -50,3 +50,10 @@ KOSMOS_FRIENDLI_TOKEN=
 # General member: 20,000 calls/day, 5GB
 # ──────────────────────────────────────────────────────────────
 # KOSMOS_KMA_API_HUB_KEY=
+
+# Observability (OTel + Langfuse) — spec 021
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/public/otel
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20<base64-of-public_key:secret_key>
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+# OTEL_SDK_DISABLED=true   # uncomment to disable all tracing (no network)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,8 @@ jobs:
     name: Test (Python ${{ matrix.python-version }})
     needs: lint
     runs-on: ubuntu-latest
+    env:
+      OTEL_SDK_DISABLED: "true"
     strategy:
       fail-fast: false
       matrix:

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/018-phase1-live-extension"
+  "feature_directory": "specs/021-observability-otel-genai"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,8 @@ This project's agent instructions live in [`AGENTS.md`](./AGENTS.md). Read that 
 - N/A (test-only; observability snapshots are in-memory test state) (018-phase1-live-extension)
 - Python 3.12+ + `httpx >=0.27` (async HTTP + streaming 429 detection), `pydantic >=2.0` (tool I/O schemas with `Field(description=...)` exposed as JSON schema to the LLM), `pytest` + `pytest-asyncio` (unit + `@pytest.mark.live` gated E2E). No new runtime dependencies introduced. (019-phase1-hardening)
 - N/A (no persistent state; rate-limit retry counters and semaphore live in `LLMClient` instance memory for the session's lifetime). (019-phase1-hardening)
+- Python 3.12+ + `httpx>=0.27` (async HTTP, 기존), `pydantic>=2.13` (모델, 기존), `opentelemetry-sdk` (신규), `opentelemetry-exporter-otlp-proto-http` (신규), `opentelemetry-semantic-conventions` (신규, GenAI v1.40 experimental opt-in) (021-observability-otel-genai)
+- N/A (span 메모리 버퍼 + OTLP 전송, 로컬 Langfuse는 Docker 스택의 Postgres/ClickHouse/MinIO가 담당) (021-observability-otel-genai)
 
 ## Recent Changes
 - 019-phase1-hardening: LLM 429 resilience (Retry-After + exponential backoff + per-session semaphore) and KOROAD tool-input discipline (Field descriptions + session guidance)

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: Apache-2.0
+# Langfuse v3 local development stack for KOSMOS observability.
+#
+# Usage:
+#   docker compose -f docker-compose.dev.yml up -d
+#   open http://localhost:3000  (sign up → create project → copy API keys)
+#
+# Reference: https://langfuse.com/self-hosting/docker-compose
+#
+# Secrets: all sensitive values come from environment variables with safe
+# dev-only defaults. Override by exporting KOSMOS_LANGFUSE_* vars or via .env.
+
+x-langfuse-env: &langfuse-env
+  DATABASE_URL: postgresql://${KOSMOS_LANGFUSE_DB_USER:-langfuse}:${KOSMOS_LANGFUSE_DB_PASSWORD:-langfuse}@postgres:5432/${KOSMOS_LANGFUSE_DB_NAME:-langfuse}
+  SALT: ${KOSMOS_LANGFUSE_SALT:-langfuse-salt-dev-only}
+  ENCRYPTION_KEY: ${KOSMOS_LANGFUSE_ENCRYPTION_KEY:-0000000000000000000000000000000000000000000000000000000000000000}
+  NEXTAUTH_URL: http://localhost:3000
+  NEXTAUTH_SECRET: ${KOSMOS_LANGFUSE_NEXTAUTH_SECRET:-mysecret}
+  TELEMETRY_ENABLED: "false"
+  LANGFUSE_ENABLE_EXPERIMENTAL_FEATURES: "false"
+  REDIS_HOST: redis
+  REDIS_PORT: "6379"
+  REDIS_AUTH: ${KOSMOS_LANGFUSE_REDIS_AUTH:-}
+  CLICKHOUSE_URL: http://clickhouse:8123
+  CLICKHOUSE_USER: ${KOSMOS_LANGFUSE_CLICKHOUSE_USER:-default}
+  CLICKHOUSE_PASSWORD: ${KOSMOS_LANGFUSE_CLICKHOUSE_PASSWORD:-langfuse}
+  LANGFUSE_S3_MEDIA_UPLOAD_ENABLED: "true"
+  LANGFUSE_S3_MEDIA_UPLOAD_BUCKET: ${KOSMOS_LANGFUSE_S3_BUCKET:-langfuse}
+  LANGFUSE_S3_MEDIA_UPLOAD_ENDPOINT: http://minio:9000
+  LANGFUSE_S3_MEDIA_UPLOAD_ACCESS_KEY_ID: ${KOSMOS_LANGFUSE_MINIO_ACCESS_KEY:-minio}
+  LANGFUSE_S3_MEDIA_UPLOAD_SECRET_ACCESS_KEY: ${KOSMOS_LANGFUSE_MINIO_SECRET_KEY:-miniosecret}
+  LANGFUSE_S3_MEDIA_UPLOAD_FORCE_PATH_STYLE: "true"
+  LANGFUSE_S3_MEDIA_UPLOAD_REGION: us-east-1
+
+services:
+  # ---------------------------------------------------------------------------
+  # Langfuse web + OTLP ingest (port 3000)
+  # ---------------------------------------------------------------------------
+  langfuse-web:
+    image: langfuse/langfuse:3
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    ports:
+      - "3000:3000"
+    environment:
+      <<: *langfuse-env
+      LANGFUSE_WORKER_HOST: langfuse-worker
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:3000/api/public/health"]
+      interval: 15s
+      timeout: 5s
+      retries: 10
+      start_period: 60s
+
+  # ---------------------------------------------------------------------------
+  # Langfuse background worker (queue processor)
+  # ---------------------------------------------------------------------------
+  langfuse-worker:
+    image: langfuse/langfuse-worker:3
+    restart: unless-stopped
+    depends_on:
+      postgres:
+        condition: service_healthy
+      clickhouse:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+      minio:
+        condition: service_healthy
+    environment:
+      <<: *langfuse-env
+
+  # ---------------------------------------------------------------------------
+  # PostgreSQL — Langfuse metadata store
+  # ---------------------------------------------------------------------------
+  postgres:
+    image: postgres:16-alpine
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${KOSMOS_LANGFUSE_DB_USER:-langfuse}
+      POSTGRES_PASSWORD: ${KOSMOS_LANGFUSE_DB_PASSWORD:-langfuse}
+      POSTGRES_DB: ${KOSMOS_LANGFUSE_DB_NAME:-langfuse}
+    volumes:
+      - langfuse-postgres-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${KOSMOS_LANGFUSE_DB_USER:-langfuse} -d ${KOSMOS_LANGFUSE_DB_NAME:-langfuse}"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # Redis — task queue
+  # ---------------------------------------------------------------------------
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    command: redis-server --save ""
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  # ---------------------------------------------------------------------------
+  # ClickHouse — trace/observation analytics store
+  # ---------------------------------------------------------------------------
+  clickhouse:
+    image: clickhouse/clickhouse-server:24.8-alpine
+    restart: unless-stopped
+    environment:
+      CLICKHOUSE_USER: ${KOSMOS_LANGFUSE_CLICKHOUSE_USER:-default}
+      CLICKHOUSE_PASSWORD: ${KOSMOS_LANGFUSE_CLICKHOUSE_PASSWORD:-langfuse}
+      CLICKHOUSE_DB: langfuse
+    volumes:
+      - langfuse-clickhouse-data:/var/lib/clickhouse
+    healthcheck:
+      test: ["CMD-SHELL", "wget --spider -q http://localhost:8123/ping || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 20
+      start_period: 30s
+    ulimits:
+      nofile:
+        soft: 262144
+        hard: 262144
+
+  # ---------------------------------------------------------------------------
+  # MinIO — S3-compatible blob / media store
+  # ---------------------------------------------------------------------------
+  minio:
+    image: minio/minio:RELEASE.2024-11-07T00-52-20Z
+    restart: unless-stopped
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: ${KOSMOS_LANGFUSE_MINIO_ACCESS_KEY:-minio}
+      MINIO_ROOT_PASSWORD: ${KOSMOS_LANGFUSE_MINIO_SECRET_KEY:-miniosecret}
+    volumes:
+      - langfuse-minio-data:/data
+    healthcheck:
+      test: ["CMD", "mc", "ready", "local"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+      start_period: 20s
+
+  # Create the default bucket on first boot
+  minio-init:
+    image: minio/mc:RELEASE.2024-11-17T19-35-25Z
+    restart: on-failure
+    depends_on:
+      minio:
+        condition: service_healthy
+    entrypoint: >
+      /bin/sh -c "
+        mc alias set local http://minio:9000 ${KOSMOS_LANGFUSE_MINIO_ACCESS_KEY:-minio} ${KOSMOS_LANGFUSE_MINIO_SECRET_KEY:-miniosecret};
+        mc mb --ignore-existing local/${KOSMOS_LANGFUSE_S3_BUCKET:-langfuse};
+        exit 0
+      "
+
+volumes:
+  langfuse-postgres-data:
+  langfuse-clickhouse-data:
+  langfuse-minio-data:

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -111,3 +111,7 @@ markers = ["live: hits real data.go.kr APIs, skipped by default"]
 ## Test data language
 
 Test values may include Korean strings when they represent real domain data a citizen would send (e.g., `"홍길동"`, `"부산광역시"`). Test names, docstrings, and assertion messages stay English per the source code language rule.
+
+## CI OTEL suppression
+
+CI sets `OTEL_SDK_DISABLED=true` at the job level (`jobs.test.env`) so no OTLP exporter, `BatchSpanProcessor`, or network activity is ever initialised during test runs (FR-009, SC-003).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "typer>=0.24.1",
     "rich>=13.0",
     "prompt-toolkit>=3.0",
+    "opentelemetry-sdk>=1.25",
+    "opentelemetry-exporter-otlp-proto-http>=1.25",
+    "opentelemetry-semantic-conventions>=0.46b0",
 ]
 
 [project.scripts]

--- a/specs/021-observability-otel-genai/checklists/requirements.md
+++ b/specs/021-observability-otel-genai/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Observability — OpenTelemetry GenAI + Langfuse
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-15
+**Feature**: [Link to spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs) — *Semantic-convention attribute names (`gen_ai.provider.name` 등) 및 프로토콜(HTTP/protobuf)은 관찰 가능한 계약(wire contract)이므로 기능 요구사항이며, 특정 언어/프레임워크 선택은 spec에 들어있지 않다.*
+- [x] Focused on user value and business needs — *P1~P3 user stories가 개발자·SRE·운영자 관점에서 작성됨.*
+- [x] Written for non-technical stakeholders — *WHAT/WHY 중심. HOW(구현)은 plan 단계로 위임.*
+- [x] All mandatory sections completed — User Scenarios, Requirements, Success Criteria, Assumptions, Scope Boundaries 모두 채워짐.
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain — Epic 본문이 충분히 구체적이라 모든 결정이 가능했음.
+- [x] Requirements are testable and unambiguous — 각 FR은 단일 관찰 가능 속성 또는 span 구조로 검증 가능.
+- [x] Success criteria are measurable — SC-001~SC-006 모두 정량(횟수/시간/패키지 수/실패율)으로 표현됨.
+- [x] Success criteria are technology-agnostic — SC는 "trace", "span", "counter", "로컬 UI에서의 확인" 등 OTel 일반 용어로 작성. 특정 라이브러리명 언급 없음(계약상 필요한 `gen_ai.provider.name` 속성명 외).
+- [x] All acceptance scenarios are defined — 각 user story에 Given/When/Then 시나리오 2-3개씩.
+- [x] Edge cases are identified — 6개 edge case 열거(gRPC 차단, rename, PII, 429 재시도, 스트림 절단, backlog 가득).
+- [x] Scope is clearly bounded — Out of Scope 5항목, Deferred 4항목 명시.
+- [x] Dependencies and assumptions identified — Assumptions 6항목, FR-016으로 의존성 예산 명시.
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria — 16개 FR 전부 acceptance scenarios / SC에 매핑됨.
+- [x] User scenarios cover primary flows — 정상 trace, 토큰 집계, CI 안전, 로컬 부트스트랩 4개 시나리오가 Epic SC-1~SC-6를 모두 커버.
+- [x] Feature meets measurable outcomes defined in Success Criteria — FR↔SC 매핑: FR-001~004 → SC-001, FR-002/005 → SC-002, FR-009 → SC-003, FR-010 → SC-004, FR-014/015 → SC-005, FR-016 → SC-006.
+- [x] No implementation details leak into specification — 세부 Python 클래스·함수 서명은 spec에 없음. plan 단계에서 다룰 것.
+
+## Notes
+
+- Spec은 Epic #463의 8가지 딥리서치 수정(v1.37 rename, http/protobuf, Development 안정성 opt-in, 수동 span, Langfuse v3, 3-deps-only, auto-instrumentor 금지)을 모두 반영함.
+- Semantic convention 속성명 사용(`gen_ai.provider.name`, `gen_ai.conversation.id`)은 구현이 아니라 외부 관측 계약이므로 spec에 남긴다.
+- 다음 단계: `/speckit.clarify` 불필요(모든 결정이 결정적). 바로 `/speckit.plan`으로 진행 가능.

--- a/specs/021-observability-otel-genai/contracts/otel-span-contract.md
+++ b/specs/021-observability-otel-genai/contracts/otel-span-contract.md
@@ -1,0 +1,167 @@
+# OTel Span Wire Contract
+
+**Feature**: `021-observability-otel-genai`
+**Version**: v1.0 (aligns with OTel GenAI semconv v1.40)
+**Stability**: Development (requires `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`)
+
+This contract is the **observable agreement** between KOSMOS and any OTLP-compatible backend (Langfuse v3, Datadog, Phoenix, Uptrace). Changing any name, attribute key, or status mapping in this document is a breaking change to downstream dashboards and requires a new spec.
+
+## Transport
+
+| Property | Value |
+|---|---|
+| Protocol | `http/protobuf` (gRPC not supported) |
+| Endpoint (local) | `http://localhost:3000/api/public/otel` |
+| Authentication | HTTP Basic `base64(public_key:secret_key)` via `OTEL_EXPORTER_OTLP_HEADERS` |
+| Processor | `BatchSpanProcessor` (default queue 2048, export timeout 30s, scheduled delay 5s) |
+| Compression | Not enforced (Langfuse handles gzip transparently) |
+
+## Resource attributes (all spans)
+
+| Attribute | Type | Value |
+|---|---|---|
+| `service.name` | str | `kosmos` |
+| `service.version` | str | `pyproject.toml[project.version]` (read at boot) |
+| `deployment.environment.name` | str | `OTEL_DEPLOYMENT_ENVIRONMENT` env (default `dev`) |
+
+## Span 1 — `invoke_agent kosmos-query`
+
+Parent span opened at `engine.query.query()` entry, closed at generator exhaustion or exception.
+
+**Required attributes**
+
+| Key | Type | Value |
+|---|---|---|
+| `gen_ai.operation.name` | str | `invoke_agent` |
+| `gen_ai.agent.name` | str | `kosmos-query` |
+
+**Conditional attributes**
+
+| Key | Type | Condition |
+|---|---|---|
+| `gen_ai.conversation.id` | str | Attach iff `QueryContext.session_context is not None`. Value = `session_context.session_id`. |
+| `error.type` | str | Attach iff terminated by exception. Value = `exc.__class__.__name__`. |
+
+**Status mapping**
+
+| Outcome | OTel Status |
+|---|---|
+| Normal completion | `Status(UNSET)` |
+| Exception propagated | `Status(ERROR)` + `span.record_exception(exc)` |
+
+**Parent relationship**: Root in its trace (no upstream parent). All `chat` and `execute_tool` spans produced during the same query become children via OTel context propagation.
+
+## Span 2 — `chat`
+
+Created per LLM call in `LLMClient.generate_stream`. Closed when the stream finalizes (normal or error).
+
+**Required attributes**
+
+| Key | Type | Value source |
+|---|---|---|
+| `gen_ai.operation.name` | str | `chat` |
+| `gen_ai.provider.name` | str | `friendliai` (**never** `gen_ai.system` — deprecated since v1.37) |
+| `gen_ai.request.model` | str | Request payload `model` |
+| `gen_ai.response.model` | str | Response frame `model` (fallback: request model) |
+| `gen_ai.usage.input_tokens` | int | Aggregated at stream end (single write) |
+| `gen_ai.usage.output_tokens` | int | Aggregated at stream end (single write) |
+| `gen_ai.response.finish_reasons` | list[str] | e.g., `["stop"]`, `["tool_calls"]`, `["length"]` |
+
+**Optional attributes** (attach only if present in request)
+
+| Key | Type | Source |
+|---|---|---|
+| `gen_ai.request.temperature` | float | Request `temperature` |
+| `gen_ai.request.max_tokens` | int | Request `max_tokens` |
+| `gen_ai.request.top_p` | float | Request `top_p` |
+
+**Error attribute**
+
+| Key | Type | Condition |
+|---|---|---|
+| `error.type` | str | Failure path. Value = exception class name. |
+
+**Status mapping**
+
+| Outcome | OTel Status |
+|---|---|
+| Stream finalized normally | `Status(UNSET)` |
+| Upstream error / truncation | `Status(ERROR)` + `span.record_exception(exc)` |
+
+**Streaming usage rule**: Token counters MUST be written exactly once, at stream end. Per-chunk updates are a contract violation (Langfuse sums attribute overwrites).
+
+**Retry rule**: HTTP 429 retries inside a single logical call remain within the **same** `chat` span. Do not create per-attempt spans. Each retry increments `kosmos_llm_rate_limit_retries_total{provider, model}` (see Metrics).
+
+## Span 3 — `execute_tool {tool_id}`
+
+Created per tool dispatch in `ToolExecutor.dispatch`.
+
+**Required attributes**
+
+| Key | Type | Value source |
+|---|---|---|
+| `gen_ai.operation.name` | str | `execute_tool` |
+| `gen_ai.tool.name` | str | `tool_id` |
+| `gen_ai.tool.type` | str | `function` (all KOSMOS tools are function-call) |
+
+**Optional attributes**
+
+| Key | Type | Source |
+|---|---|---|
+| `gen_ai.tool.call.id` | str | LLM-provided `tool_call_id`, if available |
+
+**Error attribute**
+
+| Key | Type | Condition |
+|---|---|---|
+| `error.type` | str | `ToolResult.success is False`. Value = `ToolResult.error_class` (whitelist-filtered). |
+
+**Status mapping**
+
+| Outcome | OTel Status |
+|---|---|
+| `ToolResult.success = True` | `Status(UNSET)` |
+| `ToolResult.success = False` | `Status(ERROR)` + `span.record_exception` (if exception bubbled) |
+
+**PII rule**: Tool input payloads, tool output payloads, and API response bodies MUST NOT be attached as span attributes. Only whitelist-approved metadata keys (`tool_id`, `step`, `decision`, `error_class`, `model`) pass through.
+
+## Metric — `kosmos_llm_rate_limit_retries_total`
+
+| Property | Value |
+|---|---|
+| Instrument | Counter |
+| Unit | `1` (count) |
+| Description | `Number of HTTP 429 retries emitted by LLM provider, per retry attempt` |
+| Labels | `provider` (str), `model` (str) |
+| Increment site | `LLMClient.generate_stream`, just before issuing the retried request (after honoring `Retry-After`) |
+
+## Attribute whitelist (PII prefilter)
+
+Any `dict`-shaped metadata passing through `otel_bridge.filter_metadata` is prefiltered against the canonical frozenset imported from `src/kosmos/observability/event_logger.py`:
+
+```
+{"tool_id", "step", "decision", "error_class", "model"}
+```
+
+Keys outside this set are dropped silently. Values that are not `str | bool | int | float | list[primitive]` are dropped. This is the **single source of truth**; the OTel path must not maintain a second whitelist.
+
+## No-op contract
+
+When `OTEL_SDK_DISABLED=true` or the endpoint is unset:
+
+- `TracerProvider` = `NoOpTracerProvider`
+- All `start_as_current_span` calls return no-op spans
+- `BatchSpanProcessor` is **not** instantiated (no background thread)
+- All attribute writes are no-ops
+- **No network activity** occurs
+- Application behavior is identical to the pre-OTel baseline
+
+Any test run under this mode that measures a non-zero delta from the pre-OTel baseline (wall time, memory, network) is a contract violation.
+
+## Versioning
+
+Changes to this contract follow:
+
+1. **Additive** (new optional attribute, new resource attribute, new span kind) — minor bump, no spec required.
+2. **Breaking** (rename, remove, change required→optional, change status mapping) — new spec + migration plan. Always tag the deprecated name for at least one release.
+3. **Semconv upgrade** (e.g., GenAI v1.40 → Stable) — flip `OTEL_SEMCONV_STABILITY_OPT_IN` default, announce in CHANGELOG.

--- a/specs/021-observability-otel-genai/data-model.md
+++ b/specs/021-observability-otel-genai/data-model.md
@@ -1,0 +1,179 @@
+# Phase 1 Data Model — Observability (OTel GenAI + Langfuse)
+
+**Feature**: `021-observability-otel-genai`
+**Date**: 2026-04-15
+
+본 문서는 span·속성·메트릭의 논리 데이터 모델을 정의한다. 외부 관측 계약(wire contract)은 `contracts/otel-span-contract.md`에 있고, 본 문서는 내부 Python 표현(Pydantic v2 + OTel API)과 **값의 의미**에 집중한다.
+
+## Entities overview
+
+| Entity | Kind | Owner module | Lifetime |
+|---|---|---|---|
+| `TracingSettings` | Pydantic v2 model | `src/kosmos/observability/tracing.py` | 프로세스 부팅 시 1회 생성 |
+| `InvokeAgentSpan` | OTel Span (논리적 분류) | `src/kosmos/engine/query.py` | query 호출 당 1개 (parent) |
+| `ChatSpan` | OTel Span | `src/kosmos/llm/client.py` | LLM 호출 당 1개 |
+| `ExecuteToolSpan` | OTel Span | `src/kosmos/tools/executor.py` | 도구 실행 당 1개 |
+| `FilteredAttributes` | `dict[str, AttributeValue]` | `src/kosmos/observability/otel_bridge.py` | span.set_attributes 입력 |
+| `RateLimitRetryCounter` | Counter metric (기존 `MetricsCollector` 확장) | `src/kosmos/observability/metrics.py` 소비자 | 프로세스 lifetime |
+
+> 신규 I/O Pydantic 모델은 `TracingSettings` 1개뿐이다. Span은 OTel SDK가 관리하는 외부 객체이므로 Pydantic 대상이 아니다(Principle III 경계).
+
+## E1. TracingSettings
+
+부팅 시 환경변수를 읽어 tracing 동작을 결정한다.
+
+```python
+# src/kosmos/observability/tracing.py
+from pydantic import BaseModel, ConfigDict, Field
+
+class TracingSettings(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    enabled: bool = Field(
+        default=True,
+        description="False면 NoOpTracerProvider 사용. OTEL_SDK_DISABLED=true 시 False."
+    )
+    endpoint: str | None = Field(
+        default=None,
+        description="OTLP HTTP endpoint. None이면 exporter 미구성 → no-op."
+    )
+    protocol: str = Field(
+        default="http/protobuf",
+        description="OTLP 프로토콜. http/protobuf만 허용(gRPC 금지)."
+    )
+    headers: dict[str, str] = Field(
+        default_factory=dict,
+        description="OTLP exporter 헤더(Langfuse Basic auth 포함)."
+    )
+    service_name: str = Field(default="kosmos", description="OTel resource service.name.")
+    semconv_opt_in: str = Field(
+        default="gen_ai_latest_experimental",
+        description="OTEL_SEMCONV_STABILITY_OPT_IN 값."
+    )
+```
+
+**Validation rules**:
+- `protocol` ∈ `{"http/protobuf"}` — 그 외 값이면 경고 로그 후 `enabled=False`로 강등.
+- `endpoint`가 `None`이고 `enabled=True`인 경우: `NoOpTracerProvider` 자동 선택 + 1회 경고 로그.
+- `headers` 키에 `Authorization`이 있으면 값은 로그/재노출 금지(빌트인 Pydantic 직렬화는 사용 안 함).
+
+**State transitions**: 부팅 시 한 번 구성, 이후 immutable(`frozen=True`).
+
+## E2. InvokeAgentSpan (parent)
+
+Query 진입점에서 생성되는 최상위 에이전트 span.
+
+| 속성 | 필수 | 타입 | 값 | 출처 |
+|---|---|---|---|---|
+| `span.name` | ✅ | str | `"invoke_agent kosmos-query"` | 상수 |
+| `gen_ai.operation.name` | ✅ | str | `"invoke_agent"` | semconv 상수 |
+| `gen_ai.agent.name` | ✅ | str | `"kosmos-query"` | 상수 |
+| `gen_ai.conversation.id` | 조건부 | str | `QueryContext.session_context.session_id` | 런타임 |
+| `gen_ai.agent.description` | ❌ | str | 생략 | — |
+
+**Conditional rule**: `session_context is None`이면 `gen_ai.conversation.id`를 **부착하지 않는다**(속성 누락). 빈 문자열 금지.
+
+**Status mapping**:
+- 정상 종료: `Status(StatusCode.UNSET)` (OTel 권장 — success는 unset)
+- 예외 전파: `Status(StatusCode.ERROR)` + `span.record_exception(exc)` + `error.type=<class>`.
+
+**Parent-child**: 같은 async context 안에서 만들어지는 `ChatSpan`, `ExecuteToolSpan`은 OTel context propagation으로 자동 자식이 된다.
+
+## E3. ChatSpan
+
+LLM 호출 당 1개. 스트리밍 완료 시점에 usage/finish_reasons 집계 결과를 기록한다.
+
+| 속성 | 필수 | 타입 | 값 / 출처 |
+|---|---|---|---|
+| `span.name` | ✅ | str | `"chat"` |
+| `gen_ai.operation.name` | ✅ | str | `"chat"` |
+| `gen_ai.provider.name` | ✅ | str | `"friendliai"` (v1.37 rename — `gen_ai.system` 금지) |
+| `gen_ai.request.model` | ✅ | str | `LLMClient` 요청 모델명 |
+| `gen_ai.response.model` | ✅ | str | 서버 응답 `model` 필드(없으면 request와 동일) |
+| `gen_ai.usage.input_tokens` | ✅ | int | 스트림 종료 시 집계 |
+| `gen_ai.usage.output_tokens` | ✅ | int | 스트림 종료 시 집계 |
+| `gen_ai.response.finish_reasons` | ✅ | list[str] | `["stop"]`, `["tool_calls"]` 등 |
+| `gen_ai.request.temperature` | ❌ | float | 요청에 포함된 경우만 |
+| `gen_ai.request.max_tokens` | ❌ | int | 요청에 포함된 경우만 |
+| `error.type` | 조건부 | str | 실패 시 `exc.__class__.__name__` |
+
+**Streaming usage aggregation**: 청크마다 속성을 갱신하지 않는다. `LLMClient.generate_stream` 내부 누적기(`src/kosmos/llm/usage.py`)가 기존 방식대로 동작, **스트림 finalize 직후** `span.set_attributes(...)` 1회 호출로 커밋.
+
+**Retry behavior**: 429 재시도는 span을 분기하지 않는다. 같은 `chat` span 안에서 `kosmos_llm_rate_limit_retries_total` counter가 증가한다(E6 참조).
+
+## E4. ExecuteToolSpan
+
+도구 실행 당 1개. `ToolExecutor.dispatch` 내부에서 생성.
+
+| 속성 | 필수 | 타입 | 값 / 출처 |
+|---|---|---|---|
+| `span.name` | ✅ | str | `f"execute_tool {tool_id}"` |
+| `gen_ai.operation.name` | ✅ | str | `"execute_tool"` |
+| `gen_ai.tool.name` | ✅ | str | `tool_id` |
+| `gen_ai.tool.type` | ✅ | str | `"function"` (KOSMOS는 전 도구가 함수형) |
+| `gen_ai.tool.call.id` | ❌ | str | LLM 응답의 tool_call_id가 있으면 부착 |
+| `error.type` | 조건부 | str | 실패 시 |
+
+**Status mapping**:
+- `ToolResult.success=True` → `Status(UNSET)`.
+- `ToolResult.success=False` → `Status(ERROR)` + `error.type=error_class` (whitelist 통과값).
+
+**PII rule**: 도구 입력/출력 payload는 **부착하지 않는다**. E5의 whitelist만 통과 허용.
+
+## E5. FilteredAttributes
+
+span 속성 부착 전 통과하는 필터 함수의 입출력.
+
+```python
+# src/kosmos/observability/otel_bridge.py
+from kosmos.observability.event_logger import _ALLOWED_METADATA_KEYS
+
+def filter_metadata(raw: dict[str, object]) -> dict[str, AttributeValue]:
+    """Whitelist 통과 + AttributeValue 호환 타입만 반환."""
+```
+
+**Whitelist source**: `_ALLOWED_METADATA_KEYS = {"tool_id", "step", "decision", "error_class", "model"}` (단일 진실 소스, `event_logger.py:45-47`).
+
+**Type coercion rules**:
+- `str | int | float | bool | None` → 그대로 통과.
+- `list[primitive]` → 그대로 통과.
+- 그 외(dict/bytes/객체) → **drop**, 경고 로그 없음(noise 방지).
+
+**Invariant**: 동일 입력에 대해 이 함수와 `ObservabilityEventLogger`의 whitelist 필터 결과 키 집합이 **정확히 같아야** 한다(테스트 `test_otel_bridge_pii.py`로 보장).
+
+## E6. RateLimitRetryCounter
+
+| 항목 | 값 |
+|---|---|
+| 메트릭 이름 | `kosmos_llm_rate_limit_retries_total` |
+| 종류 | Counter (누적) |
+| 라벨 | `provider` (str, 예: `friendliai`), `model` (str) |
+| 증가 시점 | `LLMClient.generate_stream`에서 FriendliAI가 `429` 반환 → `Retry-After` 헤더 존중 후 재시도 직전에 +1 |
+| 리셋 정책 | 프로세스 lifetime 내 누적, 프로세스 종료 시 소멸 |
+
+**기존 시스템과의 관계**: 이 카운터는 `MetricsCollector` 인터페이스의 기존 규약을 따른다(기존 카운터 추가와 동일 방식). OTel Metrics로의 이관은 본 epic 범위 밖(Deferred).
+
+## Relationships
+
+```
+TracingSettings ──1─┐
+                    ▼
+            TracerProvider (OTel SDK)
+                    │
+                    ├── InvokeAgentSpan (query 1개)
+                    │         │
+                    │         ├── ChatSpan (n개, 순차)
+                    │         │      └── 429 시 RateLimitRetryCounter++
+                    │         │
+                    │         └── ExecuteToolSpan (m개, 순차 또는 병렬)
+                    │
+                    └── BatchSpanProcessor → OTLPSpanExporter(http/protobuf) → Langfuse
+```
+
+Span 속성 부착은 항상 `FilteredAttributes`를 거친다(`otel_bridge.filter_metadata`).
+
+## Constitution Principle III gate
+
+- 신규 Pydantic v2 모델: `TracingSettings` (frozen, extra=forbid, 필드마다 타입 지정 + description). PASS.
+- OTel Span/Tracer는 외부 라이브러리 객체 → Pydantic 경계 바깥. PASS.
+- `FilteredAttributes` 반환 타입은 OTel SDK의 `AttributeValue` 유니온(`str|bool|int|float|Sequence[...]`)으로 고정. `Any` 사용 없음. PASS.

--- a/specs/021-observability-otel-genai/plan.md
+++ b/specs/021-observability-otel-genai/plan.md
@@ -1,0 +1,107 @@
+# Implementation Plan: Observability — OpenTelemetry GenAI + Langfuse
+
+**Branch**: `021-observability-otel-genai` | **Date**: 2026-04-15 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/021-observability-otel-genai/spec.md`
+
+## Summary
+
+KOSMOS의 에이전트 루프를 **수동 OTel GenAI span authoring** 방식으로 계측하여 Langfuse v3 자체 호스팅 스택에 전송한다. 부착점은 세 군데로 고정한다: (1) `engine/query.py`의 query 진입점에 `invoke_agent` 부모 span을 만들고 `gen_ai.conversation.id=session_id`를 부착, (2) `LLMClient.generate_stream`에 `chat` 자식 span을 만들고 스트리밍 완료 시점에 입력/출력 토큰·모델·provider를 집계해 기록하며 429 retry counter를 증가, (3) `ToolExecutor.dispatch`에 `execute_tool {tool_id}` 자식 span을 만든다.
+
+기존 `ObservabilityEventLogger`·`MetricsCollector`는 손대지 않고 **OTel을 병렬 레이어로 추가**한다. PII whitelist는 기존 `_ALLOWED_METADATA_KEYS` frozenset을 단일 진실 소스로 삼아 span 속성에도 동일 필터를 통과한 값만 전파한다. Export는 OTLP **HTTP/protobuf**만 사용(Langfuse gRPC 미수신). `OTEL_SDK_DISABLED=true`에서 no-op 경로로 빠져 전체 테스트 스위트가 통과해야 한다.
+
+신규 외부 런타임 의존성은 정확히 3개로 제한된다: `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`, `opentelemetry-semantic-conventions`. auto-instrumentor 계열(`opentelemetry-instrumentation-*`, OpenLLMetry/Traceloop 등)은 FriendliAI가 pure httpx를 사용해 훅 대상이 없고 AGENTS.md 최소 의존 원칙과도 상충하므로 **영구 거부**한다.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+
+**Primary Dependencies**: `httpx>=0.27` (async HTTP, 기존), `pydantic>=2.13` (모델, 기존), `opentelemetry-sdk` (신규), `opentelemetry-exporter-otlp-proto-http` (신규), `opentelemetry-semantic-conventions` (신규, GenAI v1.40 experimental opt-in)
+**Storage**: N/A (span 메모리 버퍼 + OTLP 전송, 로컬 Langfuse는 Docker 스택의 Postgres/ClickHouse/MinIO가 담당)
+**Testing**: `pytest` + `pytest-asyncio` (기존). 신규 테스트는 `InMemorySpanExporter`(otel-sdk 내장)를 사용하여 네트워크 없이 span 구조/속성 검증.
+**Target Platform**: macOS/Linux 개발환경 + Docker(로컬 Langfuse v3 스택). CI는 `OTEL_SDK_DISABLED=true` 경로.
+**Project Type**: Single project (Python CLI + 모듈 라이브러리) — `src/kosmos/observability/` 아래에 OTel 레이어 확장.
+**Performance Goals**: span 부가 오버헤드는 한 LLM/도구 호출당 <1ms p95 (집계·export 제외). BatchSpanProcessor는 비동기 background flush.
+**Constraints**: (a) 기존 `ObservabilityEventLogger`·`MetricsCollector`·`ObservabilityEvent` API 변경 금지(하위 호환). (b) PII whitelist는 재사용, 중복 구현 금지. (c) 런타임 의존성 정확히 +3개. (d) gRPC exporter 금지.
+**Scale/Scope**: 단일 프로세스·단일 에이전트 세션 단위. Phase 2 시나리오당 수십~수백 span/session 규모. 샘플링 없음(1:1).
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Check | Status |
+|---|---|---|
+| I. Reference-Driven Development | 모든 설계 결정이 `docs/vision.md § Reference materials` 또는 OTel 공식 semconv에 매핑됨 (Phase 0 research.md 참조) | PASS |
+| II. Fail-Closed Security (NON-NEGOTIABLE) | OTel 레이어는 기존 fail-closed 기본값 변경 없음. PII whitelist 재사용으로 속성 유출 차단. `OTEL_SDK_DISABLED` 기본 비활성은 아니나, 엔드포인트 미설정 시 no-op + 경고 로그 1회 → 관측성 장애가 애플리케이션을 깨지 않음. | PASS |
+| III. Pydantic v2 Strict Typing (NON-NEGOTIABLE) | 신규 I/O 모델은 Pydantic v2. OTel SDK의 Span은 외부 객체이므로 Pydantic 요구 대상 아님(라이브러리 경계). 내부에서 노출하는 설정·이벤트 구조체만 Pydantic v2. | PASS |
+| IV. Government API Compliance | 본 epic은 `data.go.kr` 호출을 추가/변경하지 않음. 관측 레이어는 기존 어댑터 호출을 감싸기만 함. CI에서 live 호출 없음. | PASS |
+| V. Policy Alignment (PIPA) | 개인정보 식별자는 span 속성에 실리지 않음(whitelist 통과 값만 전파). 세션 ID는 PIPA상 개인정보 아님(랜덤 UUID). | PASS |
+| VI. Deferred Work Accountability | spec.md "Scope Boundaries & Deferred Items" 섹션에 4개 `NEEDS TRACKING` 엔트리 등록됨. 자유문에 미등록 "future/phase 2+" 없음. | PASS |
+
+**Gate result**: PASS (no violations, Complexity Tracking 불필요)
+
+### Post-Design Re-check (after Phase 1)
+
+Phase 1 산출물(`data-model.md`, `contracts/otel-span-contract.md`, `quickstart.md`) 작성 후 6원칙 재검증:
+
+| Principle | Post-design 상태 | 근거 |
+|---|---|---|
+| I. Reference-Driven | 모든 신규 wire contract(span 이름·속성·metric)가 OTel GenAI semconv v1.40 또는 Langfuse 공식 docs에 매핑. `contracts/otel-span-contract.md § References` 참조. | PASS |
+| II. Fail-Closed | `data-model.md § E5` whitelist는 단일 진실 소스. no-op 계약(`§ No-op contract`)은 네트워크 0 보장. | PASS |
+| III. Pydantic v2 Strict | 신규 Pydantic 모델은 `TracingSettings` 1개(`frozen=True`, `extra="forbid"`). OTel Span은 외부 객체 경계. | PASS |
+| IV. Government API | 정부 API 호출 불변. 관측 레이어는 감싸기만 함. | PASS |
+| V. PIPA | `contracts § PII rule`: tool payload·API response body 부착 금지를 wire contract로 명시. | PASS |
+| VI. Deferred Accountability | spec.md Deferred 4항목 그대로 유지. Phase 1에서 신규 deferral 없음. | PASS |
+
+**Post-design gate**: PASS. Complexity Tracking 여전히 비어 있음.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/021-observability-otel-genai/
+├── plan.md              # This file (/speckit.plan output)
+├── spec.md              # Feature specification
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+├── contracts/
+│   └── otel-span-contract.md  # Phase 1 output — span name/attribute wire contract
+├── checklists/
+│   └── requirements.md
+└── tasks.md             # (/speckit.tasks output — not created here)
+```
+
+### Source Code (repository root)
+
+```text
+src/kosmos/observability/
+├── __init__.py                 # 기존
+├── events.py                   # 기존 — 손대지 않음
+├── event_logger.py             # 기존 — 손대지 않음 (PII whitelist 단일 진실 소스)
+├── metrics.py                  # 기존 — 손대지 않음
+├── tracing.py                  # NEW — OTel TracerProvider 초기화 + no-op 분기
+├── otel_bridge.py              # NEW — ObservabilityEvent → span 속성 매퍼 (whitelist 재사용)
+└── semconv.py                  # NEW — GenAI 속성 상수(v1.40) 중앙화
+
+src/kosmos/llm/client.py        # MODIFY — generate_stream 내 chat span 생성 + 429 counter
+src/kosmos/tools/executor.py    # MODIFY — dispatch 내 execute_tool span 생성
+src/kosmos/engine/query.py      # MODIFY — query() 진입점에 invoke_agent parent span 생성
+
+tests/observability/
+├── test_tracing_init.py        # NEW — 초기화/OTEL_SDK_DISABLED no-op
+├── test_llm_chat_span.py       # NEW — InMemorySpanExporter로 chat span 속성 검증
+├── test_tool_execute_span.py   # NEW — execute_tool span + 에러 상태 검증
+├── test_query_parent_span.py   # NEW — invoke_agent span + 자식 계층 검증
+├── test_otel_bridge_pii.py     # NEW — whitelist 필터링 재사용 검증
+└── test_retry_429_counter.py   # NEW — 429 발생 시 counter 증가 검증
+
+docker-compose.dev.yml          # NEW — Langfuse v3 + Postgres + Redis + ClickHouse + MinIO
+.env.example                    # MODIFY — OTEL_* 변수 블록 추가
+pyproject.toml                  # MODIFY — 3개 OTel 의존 추가
+```
+
+**Structure Decision**: 단일 프로젝트 구조. 신규 모듈 3개(`tracing.py`, `otel_bridge.py`, `semconv.py`)를 기존 `src/kosmos/observability/` 패키지에 추가하여 **단일 진입점**(`src/kosmos/observability/__init__.py`)을 통해 노출. 기존 `event_logger.py`·`metrics.py`는 수정하지 않는다. 부착점 3개(`llm/client.py`, `tools/executor.py`, `engine/query.py`)에는 *optional* 의존(tracer 주입식)으로 추가하여, tracer가 없을 때 기존 동작 변화 없음.
+
+## Complexity Tracking
+
+> No violations. Table intentionally empty.

--- a/specs/021-observability-otel-genai/quickstart.md
+++ b/specs/021-observability-otel-genai/quickstart.md
@@ -1,0 +1,116 @@
+# Quickstart — Observability (OTel GenAI + Langfuse)
+
+**Feature**: `021-observability-otel-genai`
+**Audience**: developer running KOSMOS locally who wants to see LLM/tool traces in Langfuse.
+
+Three environments are supported:
+
+1. **Local dev with Langfuse** — see full traces in a browser UI
+2. **Local dev without Langfuse** — set `OTEL_SDK_DISABLED=true`, everything is a no-op
+3. **CI** — always no-op (CI injects `OTEL_SDK_DISABLED=true`)
+
+## A. Local dev with Langfuse (full flow)
+
+### A.1. Boot the Langfuse v3 stack
+
+```bash
+docker compose -f docker-compose.dev.yml up -d
+```
+
+Services brought up: `langfuse-web` (UI), `langfuse-worker`, `postgres`, `redis`, `clickhouse`, `minio`. First boot takes 30–60s for schema migration.
+
+Check health:
+
+```bash
+docker compose -f docker-compose.dev.yml ps
+curl -sf http://localhost:3000/api/public/health | jq
+```
+
+### A.2. Create a Langfuse project and get API keys
+
+1. Open <http://localhost:3000>
+2. Sign up (first user becomes admin)
+3. Create a project (e.g., `kosmos-dev`)
+4. Settings → **API Keys** → Create → copy `Public Key` (`pk-lf-...`) and `Secret Key` (`sk-lf-...`)
+
+### A.3. Wire `.env`
+
+Copy the observability block from `.env.example` to `.env` and fill the key pair:
+
+```bash
+# Observability (OTel + Langfuse)
+OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/public/otel
+OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20<base64-of-public_key:secret_key>
+OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+# OTEL_SDK_DISABLED=true   # leave commented
+```
+
+Generate the base64 string:
+
+```bash
+echo -n "pk-lf-xxxx:sk-lf-xxxx" | base64
+```
+
+URL-encode the space after `Basic` as `%20` (`OTEL_EXPORTER_OTLP_HEADERS` is a URL-encoded string).
+
+### A.4. Run any KOSMOS query
+
+```bash
+uv run python -m kosmos.cli "서울 강남구 교통사고 현황 알려줘"
+```
+
+### A.5. Verify in Langfuse UI
+
+1. Open <http://localhost:3000/project/kosmos-dev/traces>
+2. You should see **one trace** with three levels:
+   - Root span: `invoke_agent kosmos-query` with `gen_ai.conversation.id = <session uuid>`
+   - Child span(s): `chat` with `gen_ai.provider.name=friendliai`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`
+   - Child span(s): `execute_tool koroad_accident_search` (or similar tool name)
+3. Metrics view: `kosmos_llm_rate_limit_retries_total` (0 if no 429s occurred)
+
+If traces are missing, see **Troubleshooting** below.
+
+## B. Local dev without Langfuse (fast path)
+
+If Langfuse isn't running, or you want no overhead:
+
+```bash
+export OTEL_SDK_DISABLED=true
+uv run python -m kosmos.cli "..."
+```
+
+Expected behavior: **identical to pre-OTel baseline**. No network calls, no background threads, no log output from the tracing layer.
+
+## C. CI (automatic)
+
+CI runs inject `OTEL_SDK_DISABLED=true` via the workflow env. Nothing needs to be configured per-job. If you see any OTel-related noise in CI logs, that's a bug — file it.
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---|---|---|
+| No trace appears in Langfuse, no error in app logs | Endpoint unreachable; BatchSpanProcessor swallows export errors | `curl -v http://localhost:3000/api/public/health`; check `docker compose ps` |
+| `Exporter returned status code 401` in app warnings | Wrong base64 auth header | Re-generate with `echo -n "pk:sk" \| base64`; ensure `Basic%20` prefix in URL-encoded form |
+| `Exporter returned status code 404` | Wrong endpoint path | Endpoint must be `http://localhost:3000/api/public/otel` (NOT `/v1/traces`) |
+| Trace appears but no `gen_ai.*` attributes | Missing opt-in | Set `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental` |
+| gRPC connection errors | Wrong protocol | Langfuse does not accept gRPC; set `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` |
+| Tests fail with "no OTel endpoint" | CI env leaked into local pytest | `unset OTEL_SDK_DISABLED` or use `OTEL_SDK_DISABLED=true` — both work, but don't leave it half-set |
+| High p99 latency on first request after boot | BatchSpanProcessor warmup | Expected; subsequent requests see <1ms p95 overhead |
+
+## Validation checklist (for PR reviewers)
+
+- [ ] `docker compose -f docker-compose.dev.yml up -d` boots without error
+- [ ] A single CLI query produces one trace with three span kinds in Langfuse
+- [ ] `chat` span shows non-zero `gen_ai.usage.input_tokens` and `gen_ai.usage.output_tokens`
+- [ ] `execute_tool` span status = `UNSET` on success, `ERROR` on tool failure
+- [ ] With `OTEL_SDK_DISABLED=true`, the full test suite (`uv run pytest`) passes
+- [ ] No span attribute contains raw user input or API response bodies (PII check)
+- [ ] `pyproject.toml` adds exactly 3 new runtime deps (sdk, exporter, semconv)
+
+## References
+
+- OTel GenAI semconv v1.40: <https://opentelemetry.io/docs/specs/semconv/gen-ai/>
+- Langfuse self-hosting (docker-compose): <https://langfuse.com/self-hosting/docker-compose>
+- Langfuse OTel ingestion: <https://langfuse.com/docs/opentelemetry>
+- OTel Configuration env vars: <https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/>

--- a/specs/021-observability-otel-genai/research.md
+++ b/specs/021-observability-otel-genai/research.md
@@ -1,0 +1,158 @@
+# Phase 0 Research — Observability (OTel GenAI + Langfuse)
+
+**Feature**: `021-observability-otel-genai`
+**Date**: 2026-04-15
+
+본 문서는 plan.md의 Technical Context 결정이 의존하는 외부 레퍼런스를 정리하고, Constitution Principle I("Reference-Driven Development") 게이트 통과를 위해 각 설계 결정을 **docs/vision.md § Reference materials 또는 OTel 공식 semconv** 중 하나에 1:1 매핑한다.
+
+## Deferred Items Validation (Principle VI gate)
+
+spec.md "Scope Boundaries & Deferred Items" 섹션을 스캔한 결과:
+
+| Item | Tracking Issue | Action |
+|---|---|---|
+| Production OTLP collector 운영 | `NEEDS TRACKING` | `/speckit-taskstoissues`가 플레이스홀더 Issue 생성 |
+| OTel Logs 시그널 통합 | `NEEDS TRACKING` | 동일 |
+| Span 샘플링/필터링 정책 | `NEEDS TRACKING` | 동일 |
+| 자동 평가(eval)와 Langfuse datasets 연동 | `NEEDS TRACKING` | 동일 |
+
+spec 전반 free-text 스캔: "separate epic", "future epic", "Phase 2+", "v2", "deferred to", "later release", "out of scope for v1" 패턴을 검색한 결과, **Deferred Items 표에 등록되지 않은 미등록 deferral 없음**. Principle VI GATE 통과.
+
+## Decision log
+
+### D1. 수동 span authoring (auto-instrumentor 거부)
+
+- **Decision**: OTel GenAI span을 `LLMClient.generate_stream`, `ToolExecutor.dispatch`, `engine/query.query` 안에서 `tracer.start_as_current_span(...)`로 **직접** 생성한다. `opentelemetry-instrumentation-openai-v2`, OpenLLMetry(traceloop-sdk), LangSmith wrapper 등은 사용하지 않는다.
+- **Rationale**:
+  - KOSMOS의 LLM 호출은 FriendliAI Serverless에 `httpx.AsyncClient`로 직접 요청(OpenAI-compatible endpoint). `openai` Python SDK의 `ChatCompletion` 객체가 존재하지 않기 때문에 auto-instrumentor가 훅 걸 대상이 원천적으로 없다.
+  - AGENTS.md § Hard rules: "Never add a dependency outside a spec-driven PR" — 의존성 최소화 원칙.
+  - 수동 authoring은 속성 이름·값 통제가 명확해 PII whitelist 재사용이 단순해진다.
+- **Alternatives considered**:
+  - `opentelemetry-instrumentation-httpx`: span이 "HTTP client" 수준에서만 생기고 GenAI 속성(gen_ai.*)이 자동으로 붙지 않음. 결국 수동 속성 부착이 필요 → 이점 없음.
+  - OpenLLMetry(Traceloop): 프로젝트 스타일상 runtime monkey-patch + Decorator. AGENTS.md 최소 의존 원칙 위배.
+- **Reference**:
+  - OTel Python semconv: `opentelemetry-semantic-conventions` 패키지의 `gen_ai` 모듈 상수(v1.40, Development 안정성).
+  - docs/vision.md § Claude Agent SDK — async generator tool loop: 자체 tracing 관례를 파생 frameworks에 위임하지 않는 관례.
+
+### D2. Span 이름과 속성 — OTel GenAI semconv v1.40
+
+- **Decision**: 세 종류 span의 이름·속성 셋은 OTel GenAI semconv v1.40을 따른다.
+  - `invoke_agent kosmos-query` — 속성: `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name=kosmos-query`, `gen_ai.conversation.id=<session_id>`
+  - `chat` — 속성: `gen_ai.operation.name=chat`, `gen_ai.provider.name=friendliai`, `gen_ai.request.model=<model>`, `gen_ai.response.model=<model>`, `gen_ai.usage.input_tokens=<int>`, `gen_ai.usage.output_tokens=<int>`, `gen_ai.response.finish_reasons=[...]`
+  - `execute_tool {tool_id}` — 속성: `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name=<tool_id>`, `gen_ai.tool.type=function`
+- **Rationale**: Langfuse는 OTel GenAI semconv 속성을 1급으로 인식해 token 사용량·모델 필터링을 자동 제공. 속성 이름을 임의로 쓰면 Langfuse 대시보드의 gen_ai 전용 뷰가 비활성화된다.
+- **Alternatives considered**:
+  - `gen_ai.system` (v1.37 이전 이름): v1.37에서 `gen_ai.provider.name`로 rename됨. **금지**(Epic #463 제약 #7).
+  - 자체 attribute key(`kosmos.llm.*`): Langfuse 자동 인식 손실. 기각.
+- **Reference**: https://opentelemetry.io/docs/specs/semconv/gen-ai/ (v1.40 spans, Development stability).
+
+### D3. OTLP HTTP/protobuf 프로토콜 고정
+
+- **Decision**: `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`를 기본값으로 고정. gRPC 경로는 제공하지 않는다.
+- **Rationale**: Langfuse OTel endpoint(`/api/public/otel/v1/traces`)는 HTTP/protobuf만 수신한다. 잘못된 프로토콜로 export 시 연결 에러가 발생해 애플리케이션 로그 소음만 늘어남.
+- **Alternatives considered**:
+  - gRPC(:4317): Langfuse 미수신. 기각.
+  - OTLP/JSON(HTTP): SDK 지원은 있으나 protobuf 대비 페이로드 효율이 낮고 Langfuse 권장 구성이 protobuf. 기각.
+- **Reference**: Langfuse 공식 문서 "Self-hosting v3 — OpenTelemetry ingestion" (2026-04-01 최신본).
+
+### D4. `OTEL_SDK_DISABLED=true` no-op 경로
+
+- **Decision**: 환경변수 `OTEL_SDK_DISABLED=true`이면 TracerProvider를 `NoOpTracerProvider`로 세팅하고 BatchSpanProcessor/Exporter를 전혀 초기화하지 않는다. 테스트 스위트의 CI 실행에서 기본값이 된다(CI env에서 주입).
+- **Rationale**: CI는 네트워크 제한 환경. OTel SDK는 `OTEL_SDK_DISABLED`를 표준 환경변수로 인식한다(OTel Configuration spec). 모든 OTel API 호출은 no-op이 되어 기존 테스트가 영향 받지 않는다.
+- **Alternatives considered**:
+  - 자체 feature flag(`KOSMOS_OTEL_ENABLED`): OTel 표준 변수와 이중 경로 발생. 기각.
+- **Reference**: https://opentelemetry.io/docs/specs/otel/configuration/sdk-environment-variables/ (`OTEL_SDK_DISABLED`).
+
+### D5. Stability opt-in: `gen_ai_latest_experimental`
+
+- **Decision**: `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`를 기본값으로 지정(애플리케이션 부팅 시 미설정이면 주입).
+- **Rationale**: v1.40 GenAI 속성은 전부 "Development" 안정성. opt-in 없이는 semconv 라이브러리가 일부 신규 속성을 노출하지 않는다. 환경변수로 명시 → 향후 Stable 승급 시 한 줄로 이전.
+- **Alternatives considered**: opt-in 안 함 → 최신 속성 미사용. 기각.
+- **Reference**: OTel semconv migration guide, `OTEL_SEMCONV_STABILITY_OPT_IN` 문서.
+
+### D6. 스트리밍 usage 집계(청크별 기록 금지)
+
+- **Decision**: `LLMClient.generate_stream`은 스트리밍 응답을 순차 consume하며 토큰·content를 내부에서 누적, **스트림 종료 시점에만** `chat` span 속성으로 1회 기록한다.
+- **Rationale**: OTel GenAI semconv는 span당 하나의 usage 속성 쌍(`input_tokens`, `output_tokens`)만 규정. 청크마다 속성을 갱신하면 Langfuse 파싱 비용 증가 + 속성 덮어쓰기 부작용.
+- **Alternatives considered**:
+  - 청크마다 event 추가: 가능하나 본 epic 범위 밖(D11 참조).
+- **Reference**: OTel GenAI spec — streaming usage aggregation convention. 내부 레퍼런스: `src/kosmos/llm/usage.py`의 기존 누산 패턴.
+
+### D7. 429 retry counter를 별도 metric으로 추가
+
+- **Decision**: FriendliAI가 `429 Too Many Requests`를 반환해 LLM 재시도가 발생할 때마다 `kosmos_llm_rate_limit_retries_total` counter를 1 증가. `Retry-After` 헤더 존중 기존 로직(spec 019)은 변경 없음.
+- **Rationale**: 재시도가 span 내 숨어 있으면 운영자가 "오늘 몇 번의 429가 있었나"를 쉽게 못 본다. Counter는 Langfuse의 metric 뷰에서 시계열로 즉시 확인 가능.
+- **Alternatives considered**:
+  - 재시도마다 별도 span 생성: 노이즈. 기각(spec edge case 참조).
+- **Reference**: docs/vision.md § LangGraph `RetryPolicy` + 019 spec의 429 처리.
+
+### D8. PII whitelist 재사용 — 단일 진실 소스 보존
+
+- **Decision**: `src/kosmos/observability/event_logger.py`의 `_ALLOWED_METADATA_KEYS` frozenset(`tool_id`, `step`, `decision`, `error_class`, `model`)을 `otel_bridge.py`에서 import하여 span 속성 prefilter에도 사용한다. 중복 whitelist 정의 금지.
+- **Rationale**: 두 곳에 whitelist를 두면 한쪽만 업데이트되는 drift 위험. Constitution II(fail-closed) 유지.
+- **Reference**: 기존 `src/kosmos/observability/event_logger.py:45-47` 주석 "(AC-A10)".
+
+### D9. Docker Compose — Langfuse v3 자체 호스팅
+
+- **Decision**: Langfuse v3 공식 `docker-compose` 참조(langfuse-k8s 및 self-hosting docs)를 기반으로 `docker-compose.dev.yml` 작성. 구성: `langfuse-web`(UI/API), `langfuse-worker`, `postgres`, `redis`, `clickhouse`, `minio`(S3 호환). 포트: Web 3000, OTLP ingest 3000/api/public/otel.
+- **Rationale**: Langfuse v3는 ClickHouse(trace/observation 저장)·MinIO(event blob)·Redis(queue)를 필수로 한다. v2 이미지는 공식 deprecated.
+- **Alternatives considered**:
+  - Langfuse Cloud: spec OoS(자체 호스팅 전제).
+  - v2 + Postgres only: 더 간단하나 공식 deprecated. 기각.
+- **Reference**: https://langfuse.com/self-hosting/docker-compose (2026-04-01 버전 체크).
+
+### D10. `.env.example` 엔트리 블록 & base64 auth 헤더
+
+- **Decision**: `.env.example`에 다음 블록 추가:
+  ```
+  # Observability (OTel + Langfuse)
+  OTEL_EXPORTER_OTLP_ENDPOINT=http://localhost:3000/api/public/otel
+  OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf
+  OTEL_EXPORTER_OTLP_HEADERS=Authorization=Basic%20<base64(public_key:secret_key)>
+  OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental
+  # OTEL_SDK_DISABLED=true   # uncomment to disable in CI/offline
+  ```
+- **Rationale**: Langfuse의 OTLP endpoint는 HTTP Basic auth(public_key:secret_key, base64)를 요구. 주석으로 CI 비활성화 팁 제공.
+- **Reference**: Langfuse OTel ingestion guide + OTel `OTEL_EXPORTER_OTLP_HEADERS` spec.
+
+### D11. Out of scope (재확인)
+
+- 프로덕션 collector, OTel Logs, sampling 정책, eval/datasets 연동은 spec에 이미 Deferred로 등록됨(본 Research에서 추가 action 없음).
+
+## Integration patterns
+
+### IP1. Tracer 주입 방식
+
+- `TracerProvider`를 애플리케이션 부팅 시 1회 초기화(`tracing.setup_tracing()` 팩토리). `LLMClient`, `ToolExecutor`, `query()`에는 **모듈 레벨 `trace.get_tracer(__name__)`** 호출로 tracer를 얻음(OTel 표준 패턴).
+- 장점: 별도 constructor DI 없이도 동일 프로세스의 TracerProvider에 연결된다. `setup_tracing()`을 호출하지 않으면 `NoOpTracer`가 자동 반환 → 기존 동작 100% 보존.
+
+### IP2. BatchSpanProcessor 구성
+
+- `BatchSpanProcessor(OTLPSpanExporter(endpoint=..., protocol="http/protobuf"))`.
+- Default queue size(2048), default export timeout(30s), default scheduled delay(5s)를 그대로 사용. `OTEL_BSP_*` 환경변수로 override 가능(OTel spec).
+
+### IP3. Span 속성 whitelist prefilter
+
+- `otel_bridge.filter_metadata(d: dict) -> dict` — `_ALLOWED_METADATA_KEYS`를 import하여 사용. span 생성 시 `span.set_attributes(filter_metadata(raw))`.
+
+### IP4. 에러 → span 상태 매핑
+
+- OTel `Status(StatusCode.ERROR)` + `span.record_exception(exc)`. `span.set_attribute("error.type", exc.__class__.__name__)`.
+- 기존 `ObservabilityEvent.success=False` 이벤트는 그대로 별도 채널로 emit — 변경 없음.
+
+## Reference → Design mapping (Constitution Principle I gate)
+
+| Design decision | Reference source | Layer |
+|---|---|---|
+| 수동 span authoring | OTel semconv v1.40 (Python), AGENTS.md 최소 의존 원칙 | Observability (cross-cutting) |
+| `gen_ai.provider.name` 사용 | OTel semconv v1.37 rename note | Observability |
+| OTLP HTTP/protobuf | Langfuse self-hosting 공식 docs | Export |
+| `OTEL_SDK_DISABLED` no-op | OTel Configuration spec (env vars) | Bootstrap |
+| PII whitelist 재사용 | 기존 `event_logger.py:_ALLOWED_METADATA_KEYS` + Constitution II | Observability |
+| Streaming usage aggregation | OTel GenAI spec + `src/kosmos/llm/usage.py` 누산 | LLM Client |
+| 429 retry counter | docs/vision.md § LangGraph RetryPolicy + 019 spec | LLM Client |
+| BatchSpanProcessor | OTel Python SDK default patterns | Export |
+| Langfuse v3 자체 호스팅 | Langfuse self-hosting docker-compose 공식 | Dev stack |
+| Parent span = session | docs/vision.md § Query Engine (async generator loop) | Query Engine |
+
+Gate: **all design decisions mapped to a concrete reference**. Constitution Principle I PASS.

--- a/specs/021-observability-otel-genai/spec.md
+++ b/specs/021-observability-otel-genai/spec.md
@@ -1,0 +1,163 @@
+# Feature Specification: Observability — OpenTelemetry GenAI + Langfuse
+
+**Feature Branch**: `021-observability-otel-genai`
+**Created**: 2026-04-15
+**Status**: Draft
+**Input**: Epic #463 — Phase 2 요구조건 (OTel GenAI semconv v1.40 수동 span, Langfuse v3 자체 호스팅, MetricsCollector/ObservabilityEventLogger 브리지, OTLP http/protobuf, `OTEL_SDK_DISABLED` no-op 경로, `gen_ai.provider.name` 명칭, `gen_ai_latest_experimental` opt-in).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Developer traces a production agent failure end-to-end (Priority: P1)
+
+한 운영자가 Phase 2 시나리오 실행 중 "경로 안전" 질의가 실패했다고 보고한다. 개발자는 Langfuse UI를 열어 해당 세션 ID로 trace 하나를 조회한다. 사용자 질의 → LLM 호출(스트리밍) → 도구 실행(KOROAD 어댑터) → LLM 재호출 → 최종 응답까지 **하나의 부모-자식 span 트리**로 연결되어, 어느 단계에서 실패가 발생했는지, 각 단계가 몇 ms 걸렸는지, LLM이 몇 토큰을 사용했는지, 도구가 어떤 오류 클래스를 반환했는지 한 화면에서 파악할 수 있다.
+
+**Why this priority**: KOSMOS는 멀티턴·멀티도구 루프라 blackbox 로그만으로는 장애 원인을 찾을 수 없다. Phase 2 시나리오가 본격화되기 전 "최소 1개 trace로 전체 흐름을 볼 수 있는" 관측성이 선행 조건이다 (Infrastructure Initiative SC-7).
+
+**Independent Test**: 테스트용 에이전트 세션을 로컬에서 1회 실행하고, 구동된 Langfuse 인스턴스의 trace 탐색 화면에서 해당 `session_id` 가 달린 trace를 열어 (a) 부모 `invoke_agent` span (b) 자식 `chat` span (c) 자식 `execute_tool` span 세 종류가 모두 계층 구조로 나타나는지 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** 한 사용자 세션이 LLM 호출 1회와 도구 호출 1회를 포함한다, **When** 세션이 정상 완료되면, **Then** Langfuse는 1개의 parent span(`invoke_agent`)과 그 아래 2개의 자식 span(`chat`, `execute_tool <tool_id>`)을 동일한 trace ID로 수신한다.
+2. **Given** LLM 스트리밍 호출 중 FriendliAI가 `429` 응답을 반환해 재시도가 발생한다, **When** 재시도가 성공한다, **Then** 해당 `chat` span은 하나로 유지되고 재시도는 `kosmos_llm_rate_limit_retries_total` counter에 1회 증가되며 span 상태는 `UNSET`으로 마감된다.
+3. **Given** 도구 실행이 Pydantic 검증 실패로 에러를 던진다, **When** 에이전트 루프가 이를 캐치한다, **Then** `execute_tool` span의 상태는 `ERROR`로 기록되고, `error.type` 속성에 에러 클래스가 달린다.
+
+---
+
+### User Story 2 — SRE monitors token spend and streaming throughput (Priority: P2)
+
+운영 책임자가 "지난 24시간 동안 어느 도구가 가장 많은 LLM 입력 토큰을 유발했는지"를 주간 리뷰에서 확인해야 한다. Langfuse 대시보드에서 모델별·도구별 토큰 합계와 호출 횟수를 곧바로 필터링할 수 있고, 각 `chat` span의 시작~종료 duration으로 총 응답 시간을 확인할 수 있다.
+
+**Why this priority**: K-EXAONE 서버리스는 토큰당 과금 모델이며, 도구 호출 루프가 비정상적으로 길어지면 비용이 수 배 증가한다. 장애가 없어도 관측이 되지 않으면 비용 통제 자체가 불가능하다.
+
+**Independent Test**: 임의의 프롬프트로 스트리밍 chat 호출 1회를 수행한 뒤 Langfuse의 usage 리포트에서 입력/출력 토큰과 총 소요시간이 각각 별개 값으로 기록되었는지 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** 스트리밍 chat 호출이 완료되었다, **When** Langfuse가 span을 수신한다, **Then** 해당 span에는 입력 토큰, 출력 토큰, 모델명, provider 이름이 모두 기록되어 있다.
+2. **Given** 동일한 프롬프트로 5회 반복 호출한다, **When** Langfuse 대시보드에서 시간 범위를 주간으로 필터링한다, **Then** 모델별 총 토큰 합계가 5회분의 합과 일치한다(±0).
+
+---
+
+### User Story 3 — CI runs without an OTLP collector (Priority: P1)
+
+개발자가 CI에서 유닛 테스트를 돌린다. CI 컨테이너에는 Langfuse나 OTLP collector가 실행되어 있지 않고, 인터넷 접근도 제한되어 있다. 환경변수로 텔레메트리를 끄면, 어떤 span export 시도도 일어나지 않고 테스트는 정상 통과한다. 텔레메트리가 꺼져 있는 상태에서도 기존 `ObservabilityEventLogger`와 `MetricsCollector` 로직은 동일하게 동작한다.
+
+**Why this priority**: 텔레메트리 장애가 CI/배포 파이프라인을 중단시키면 안 된다. OTel 레이어는 **항상 옵셔널**이어야 한다 (AGENTS.md § Hard rules — 외부 의존성 추가 시 spec-driven PR).
+
+**Independent Test**: `OTEL_SDK_DISABLED=true` 환경에서 전체 pytest 스위트를 실행한 뒤, (a) 모든 기존 테스트가 통과하는지, (b) OTLP 엔드포인트로의 네트워크 시도가 0회였는지(캡처 기반) 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** `OTEL_SDK_DISABLED=true`가 설정되어 있다, **When** `pytest` 전체 스위트를 실행한다, **Then** 모든 테스트가 통과하고 외부 네트워크 호출은 발생하지 않는다.
+2. **Given** `OTEL_EXPORTER_OTLP_ENDPOINT`가 지정되지 않았다, **When** 에이전트 세션이 실행된다, **Then** 애플리케이션은 경고만 남기고 정상 실행을 계속한다(예외를 던지지 않는다).
+3. **Given** OTLP 엔드포인트가 설정되어 있지만 collector가 다운되어 있다, **When** 에이전트 루프가 span을 export 시도한다, **Then** export 실패는 내부적으로 로깅되고 사용자 요청은 정상 응답된다.
+
+---
+
+### User Story 4 — Operator brings up the local Langfuse stack with one command (Priority: P2)
+
+새로 합류한 개발자가 README의 "Observability 로컬 구동" 절을 읽고 `docker compose -f docker-compose.dev.yml up` 한 줄로 Langfuse UI·API 서버·필수 백엔드(Postgres, Redis, ClickHouse, MinIO 호환 오브젝트 스토리지)를 모두 띄운다. `.env.example`를 `.env`로 복사한 뒤 환경변수 몇 개(엔드포인트, public/secret key base64)만 채우면 로컬 에이전트 세션 trace가 바로 Langfuse UI에 나타난다.
+
+**Why this priority**: 자체 호스팅 Langfuse v3는 4개의 백엔드 서비스가 필요하며, 수동 설치는 시연·온보딩 장벽이 크다. 1-커맨드 부트스트랩이 없으면 "관측성 사용법" 자체가 채택되지 않는다.
+
+**Independent Test**: 깨끗한 개발 머신에서 README 지침대로 3개 명령어(`cp .env.example .env`, 값 채움, `docker compose up`)만으로 Langfuse UI가 뜨고, 샘플 에이전트 호출이 trace로 수신되는지 확인.
+
+**Acceptance Scenarios**:
+
+1. **Given** 개발자가 리포지토리를 방금 클론했다, **When** `docker compose -f docker-compose.dev.yml up -d`를 실행한다, **Then** Langfuse UI(:3000)가 healthy 상태로 뜨고, 종속된 모든 백엔드 컨테이너가 정상 기동한다.
+2. **Given** Langfuse가 로컬에서 실행 중이다, **When** 개발자가 한 번 에이전트 호출을 수행한다, **Then** 10초 이내에 Langfuse UI의 "Traces" 탭에 그 호출이 나타난다.
+
+---
+
+### Edge Cases
+
+- Langfuse 엔드포인트가 **HTTP/protobuf만** 수신하고 gRPC는 받지 않을 때: export가 gRPC로 시도되면 연결 실패하되, 애플리케이션 흐름은 중단되지 않아야 한다. 기본 설정은 반드시 HTTP/protobuf.
+- OTel semantic conventions가 "Development" 안정성이라 향후 breaking rename 가능: 발생 시 KOSMOS는 최신 rename을 반영하되, 이전 속성명은 유지하지 않는다(수동 span이라 매핑이 명확하므로).
+- `event.metadata`에 실수로 PII 키(예: `user_email`)가 포함된 경우: 기존 `ObservabilityEventLogger`의 whitelist가 키를 제거하는 기존 동작을 유지하면서, OTel span 속성으로도 **동일 whitelist 이후의 값만** 전파.
+- FriendliAI `429` + `Retry-After` 헤더가 온 경우: 재시도 카운터 metric은 증가하되, LLM chat span 하나 안에서 재시도가 일어난 것으로 기록(재시도마다 별개 span을 만들지 않는다).
+- 스트리밍 응답 중간에 연결이 끊긴 경우: 그때까지 누적된 사용량(usage)만 span에 기록하고, span 상태는 `ERROR`로 마감.
+- Langfuse 서버가 다운되어 export backlog가 메모리에 쌓이는 경우: BatchSpanProcessor의 큐가 가득 차면 신규 span이 폐기(drop)되고 애플리케이션은 영향받지 않는다.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Spans (what operations are traced)
+
+- **FR-001**: 사용자의 한 질의가 에이전트 루프에 진입하면 시스템은 `invoke_agent kosmos-query` 이름의 부모 span을 생성한다. 이 span은 `gen_ai.conversation.id` 속성으로 세션 식별자를 달고, 자식 span들이 모두 이 부모 아래에 묶인다.
+- **FR-002**: LLM 스트리밍 호출이 발생하면 시스템은 `chat` 이름의 자식 span을 생성하고, 호출이 끝나면(또는 에러로 마감되면) 입력/출력 토큰 수, 모델명, provider 이름, 마감 사유(finish reason)를 span 속성으로 남긴다.
+- **FR-003**: 도구 실행이 발생하면 시스템은 `execute_tool <tool_id>` 이름의 자식 span을 생성하고, 도구 ID와 실행 성공 여부를 span 속성으로 남긴다. 도구가 예외를 던지면 span 상태는 `ERROR`로 마감되고 에러 클래스가 속성에 기록된다.
+- **FR-004**: 세 종류의 span(`invoke_agent`, `chat`, `execute_tool`)은 OpenTelemetry GenAI Semantic Conventions v1.40을 따르며, GenAI 관련 속성은 `gen_ai.*` 네임스페이스를 사용한다. 구체적으로 provider 식별은 `gen_ai.provider.name`을 사용한다(과거 `gen_ai.system`은 사용하지 않는다).
+
+#### Streaming & retries
+
+- **FR-005**: 스트리밍 chat 호출에서 토큰 사용량은 스트림이 완료된 시점에 **집계된 값 하나**로 span에 기록한다(청크당 기록하지 않는다).
+- **FR-006**: LLM 호출이 HTTP 429를 받아 재시도를 수행할 때마다 시스템은 별도의 counter metric을 1 증가시킨다. 이 counter에는 provider 이름과 모델명이 label로 붙는다. 재시도가 일어나도 `chat` span은 하나로 유지된다.
+
+#### Export & configuration
+
+- **FR-007**: 완성된 span들은 OTLP **HTTP/protobuf** 프로토콜로 export한다. gRPC는 사용하지 않는다.
+- **FR-008**: 시스템은 다음 환경변수를 인식한다: `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SDK_DISABLED`, `OTEL_SEMCONV_STABILITY_OPT_IN`. 기본값은 `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf` 및 `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`.
+- **FR-009**: `OTEL_SDK_DISABLED=true`가 설정되면 OTel SDK는 초기화되지 않고 어떠한 export 시도도 하지 않는다. 이 경로에서 기존 기능의 모든 자동화 테스트가 통과한다.
+- **FR-010**: OTLP 엔드포인트가 설정되지 않았거나 collector가 도달 불가능한 경우, 시스템은 경고 로그 1회를 남기고 애플리케이션 흐름을 중단하지 않는다. export 실패는 사용자 요청의 응답 성공/실패에 영향을 주지 않는다.
+
+#### Bridge with existing observability
+
+- **FR-011**: 기존 `ObservabilityEventLogger`의 PII 키 whitelist(`tool_id`, `step`, `decision`, `error_class`, `model`)는 변경 없이 유지된다. whitelist를 통과한 값만 OTel span 속성으로 전파될 수 있다.
+- **FR-012**: 기존 `MetricsCollector`가 기록하는 카운터·히스토그램·게이지는 동작이 변하지 않는다. OTel metric은 **추가 레이어**로서 존재하며, 기존 수집값을 중복 기록하거나 대체하지 않는다.
+- **FR-013**: 기존 `ObservabilityEvent` 이벤트 타입들(`llm_call`, `permission_decision`, `tool_call` 등)은 그대로 유지되며, OTel span과 병렬로 발생한다.
+
+#### Local development stack
+
+- **FR-014**: 리포지토리에는 `docker-compose.dev.yml` 파일이 있어, 한 줄 명령으로 Langfuse UI와 그 의존 백엔드(Postgres, Redis, ClickHouse, S3 호환 오브젝트 스토리지)를 로컬에 구동할 수 있다.
+- **FR-015**: `.env.example` 파일은 텔레메트리에 필요한 모든 환경변수의 예시와 설명을 포함한다. 실 키는 커밋되지 않는다.
+
+#### Dependencies constraint
+
+- **FR-016**: 외부 런타임 의존성은 `opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`, `opentelemetry-semantic-conventions` **정확히 3개만** 추가한다. auto-instrumentor 계열(`opentelemetry-instrumentation-*`, `openllmetry`, `traceloop` 등)은 추가하지 않는다.
+
+### Key Entities
+
+- **Trace**: 한 사용자 질의 → 최종 응답 사이의 모든 span 집합. `session_id`로 묶인다.
+- **Span**: 에이전트 루프 내 한 구간(에이전트 전체 호출 / 1회 LLM chat / 1회 도구 실행)을 나타내는 기록. 이름·속성·시작·종료 타임스탬프·상태를 가진다.
+- **Usage**: LLM 호출 시 입력 토큰·출력 토큰·모델·provider 집계. `chat` span의 속성으로 기록된다.
+- **Retry counter**: `429` 재시도 횟수를 provider/모델별로 집계하는 metric.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001** (단일 trace 가시성): 로컬 Langfuse 인스턴스에서 한 세션의 전체 호출(사용자 질의 → LLM → 도구 → LLM → 응답)을 **1개의 trace**로 열람할 수 있다. 그 trace 내에서 부모-자식 계층이 최소 3단계 이상(에이전트 → chat → tool) 표현된다.
+- **SC-002** (사용량 기록 완전성): 스트리밍 chat 호출 100회 연속 테스트에서 **100/100 회** 모두 입력 토큰, 출력 토큰, 모델명, provider 이름이 span 속성에 기록된다.
+- **SC-003** (CI 친화성): `OTEL_SDK_DISABLED=true` 환경에서 전체 자동화 테스트 스위트가 100% 통과하며, 테스트 실행 중 외부 네트워크 요청은 0회 발생한다.
+- **SC-004** (장애 내성): Langfuse collector가 다운된 상태에서 에이전트 세션을 10회 수행해도 **사용자 응답 실패율 0%**를 유지한다.
+- **SC-005** (로컬 부트스트랩 시간): 깨끗한 개발 머신에서 리포지토리 클론 완료 후 Langfuse UI에서 첫 trace를 확인하기까지 걸리는 시간이 **10분 이내**다(Docker 이미지 pull 시간 포함).
+- **SC-006** (의존성 예산): `pyproject.toml`에 신규 추가되는 외부 런타임 패키지는 정확히 3개(`opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`, `opentelemetry-semantic-conventions`)다. auto-instrumentor 계열 패키지는 0개다.
+
+## Assumptions
+
+- KSC 심사자 및 운영자는 Docker Desktop 또는 Docker Engine을 로컬에서 실행할 수 있다. Docker가 없는 환경을 위한 대체 부트스트랩은 제공하지 않는다.
+- Langfuse v3.x 계열의 자체 호스팅 공식 `docker-compose` 참조 구성을 기반으로 프로젝트 로컬용을 파생한다. Langfuse Cloud는 선택지가 아니다.
+- K-EXAONE 호출은 FriendliAI Serverless(OpenAI-compatible)을 통해 순수 `httpx`로 수행되고 있다. `openai` SDK 객체는 존재하지 않기 때문에 auto-instrumentor는 원천적으로 불가능하다. 수동 span authoring만 가능하다.
+- 프로덕션 환경(배포용)의 OTLP collector 운영 방식은 이 epic의 범위가 아니다. 로컬 self-hosted 구동만 대상.
+- OTel GenAI semconv v1.40은 전 속성이 "Development" 안정성이며, 향후 rename이 있을 수 있다. 그 경우 새 속성명으로 **대체**하며 legacy alias는 유지하지 않는다.
+- PII 정책은 기존 `ObservabilityEventLogger`의 whitelist 정책을 단일 진실 소스로 본다. 속성 이름 정책은 OTel semconv를 따르되, **값은** whitelist를 통과한 것만 전파한다.
+
+## Scope Boundaries & Deferred Items *(mandatory)*
+
+### Out of Scope (Permanent)
+
+- **Auto-instrumentors (`opentelemetry-instrumentation-*`, OpenLLMetry/Traceloop 등)**: KOSMOS의 LLM 호출은 `httpx` 기반 수동 프로토콜이며 auto-instrumentor가 훅 걸 대상이 없다. AGENTS.md 외부 의존성 최소 원칙과도 상충.
+- **gRPC OTLP export**: Langfuse는 gRPC를 수신하지 않는다. 프로토콜은 HTTP/protobuf만 지원한다.
+- **Log signal(OTel Logs)**: 기존 `logging` + `ObservabilityEventLogger`가 로그 영역을 담당한다. OTel Logs 연계는 이 epic에 포함하지 않는다(trace와 metric만 취급).
+- **Langfuse Cloud 계약**: 자체 호스팅 전제. Cloud 계정 연동은 범위 밖.
+- **Legacy `gen_ai.system` 속성**: v1.37에서 `gen_ai.provider.name`으로 대체되었으므로 legacy 이름은 **사용하지 않는다**.
+
+### Deferred to Future Work
+
+| Item | Reason for Deferral | Target Epic/Phase | Tracking Issue |
+|------|---------------------|-------------------|----------------|
+| Production OTLP collector 운영 (중앙 Langfuse 클러스터, 보존 정책, 대시보드 표준화) | Phase 2 시나리오가 먼저 안정화된 뒤 운영 배포 epic에서 다룸 | Phase 3 Ops | #501 |
+| OTel Logs 시그널 통합 (기존 `logging`을 OTel Logs로도 전송) | 이 epic은 trace·metric로 범위를 좁힘. 로그 통합은 별개 설계 결정을 필요로 함 | 이후 관측성 확장 Epic | #502 |
+| Span 샘플링/필터링 정책(대용량 트래픽 대비) | 현재 규모에서 불필요, 1:1 샘플링으로 충분 | Phase 3 Ops | #503 |
+| 자동 평가(eval)와 Langfuse datasets 연동 | 평가 파이프라인은 별도 epic에서 설계 | Evaluation Epic | #504 |

--- a/specs/021-observability-otel-genai/tasks.md
+++ b/specs/021-observability-otel-genai/tasks.md
@@ -1,0 +1,176 @@
+# Tasks — Observability (OpenTelemetry GenAI + Langfuse)
+
+**Feature**: `021-observability-otel-genai`
+**Branch**: `main` (feature dir only)
+**Input**: `specs/021-observability-otel-genai/` (spec.md, plan.md, research.md, data-model.md, contracts/otel-span-contract.md, quickstart.md)
+
+All paths are absolute from repository root `/Users/um-yunsang/KOSMOS/`.
+
+## Phase 1 — Setup
+
+- [ ] T001 Add exactly 3 runtime dependencies to `pyproject.toml` (`opentelemetry-sdk`, `opentelemetry-exporter-otlp-proto-http`, `opentelemetry-semantic-conventions`) under `[project].dependencies`; run `uv sync` to materialize `uv.lock`. Verify `grep -E 'opentelemetry-instrumentation|openllmetry|traceloop' pyproject.toml` returns nothing (FR-016, SC-006).
+- [ ] T002 [P] Append the Observability env block (`OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL=http/protobuf`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SEMCONV_STABILITY_OPT_IN=gen_ai_latest_experimental`, commented `OTEL_SDK_DISABLED`) to `.env.example` per research.md § D10 (FR-015).
+- [ ] T003 [P] Create empty package marker `tests/observability/__init__.py` to host the new test module.
+
+## Phase 2 — Foundational (blocking prerequisites)
+
+**No user story work may begin until this phase is green.**
+
+- [ ] T004 [P] Create `src/kosmos/observability/semconv.py` exporting GenAI attribute-name constants (`GEN_AI_OPERATION_NAME`, `GEN_AI_AGENT_NAME`, `GEN_AI_PROVIDER_NAME`, `GEN_AI_CONVERSATION_ID`, `GEN_AI_REQUEST_MODEL`, `GEN_AI_RESPONSE_MODEL`, `GEN_AI_USAGE_INPUT_TOKENS`, `GEN_AI_USAGE_OUTPUT_TOKENS`, `GEN_AI_RESPONSE_FINISH_REASONS`, `GEN_AI_TOOL_NAME`, `GEN_AI_TOOL_TYPE`, `GEN_AI_TOOL_CALL_ID`, `ERROR_TYPE`) as a single source of truth; prefer `opentelemetry.semconv.attributes.gen_ai_attributes` re-exports where available, otherwise define string literals per OTel GenAI semconv v1.40 (FR-004, research.md § D2).
+- [ ] T005 [P] Create `src/kosmos/observability/otel_bridge.py` with `filter_metadata(raw: dict) -> dict` that imports `_ALLOWED_METADATA_KEYS` from `src/kosmos/observability/event_logger.py` (no duplicate whitelist) and drops non-primitive values per data-model.md § E5 (FR-011, research.md § D8).
+- [ ] T006 Create `src/kosmos/observability/tracing.py` with `TracingSettings` Pydantic v2 model (`frozen=True`, `extra="forbid"`) per data-model.md § E1, plus `setup_tracing(settings: TracingSettings | None = None) -> TracerProvider` that:
+  - reads env vars (`OTEL_SDK_DISABLED`, `OTEL_EXPORTER_OTLP_ENDPOINT`, `OTEL_EXPORTER_OTLP_PROTOCOL`, `OTEL_EXPORTER_OTLP_HEADERS`, `OTEL_SEMCONV_STABILITY_OPT_IN`, `OTEL_DEPLOYMENT_ENVIRONMENT`) when `settings is None`
+  - returns `NoOpTracerProvider` if `OTEL_SDK_DISABLED=true` or endpoint missing
+  - otherwise configures `TracerProvider` with `Resource({service.name: "kosmos", service.version, deployment.environment.name})`, `BatchSpanProcessor(OTLPSpanExporter(endpoint, protocol="http/protobuf"))` (FR-007, FR-008, FR-009, FR-010, research.md § D3, D4, D5).
+- [ ] T007 [P] Update `src/kosmos/observability/__init__.py` to re-export `setup_tracing`, `TracingSettings`, `filter_metadata`, and the semconv constants.
+
+**Checkpoint**: `uv run python -c "from kosmos.observability import setup_tracing; setup_tracing()"` must succeed in a fresh shell with only `OTEL_SDK_DISABLED=true` set (no-op) and exit without network activity.
+
+## Phase 3 — User Story 1: Developer traces a production agent failure end-to-end (P1) 🎯 MVP
+
+**Story goal**: One user query produces one trace in Langfuse with three-tier hierarchy (`invoke_agent` → `chat` → `execute_tool`), each span carrying the required GenAI attributes; PII stays out.
+
+**Independent test**: With Langfuse running and `OTEL_SDK_DISABLED` unset, run `uv run python -m kosmos.cli "..."` and verify in Langfuse UI: one trace, parent `invoke_agent kosmos-query` with `gen_ai.conversation.id=<uuid>`, child `chat` with `gen_ai.provider.name=friendliai`, child `execute_tool <tool>` with correct `gen_ai.tool.name`; no raw payloads in attributes.
+
+- [ ] T008 [P] [US1] Instrument `src/kosmos/engine/query.py` `query()` entry: open `tracer.start_as_current_span("invoke_agent kosmos-query")`, set `gen_ai.operation.name=invoke_agent`, `gen_ai.agent.name=kosmos-query`, and `gen_ai.conversation.id=session_context.session_id` (attach only if `session_context is not None`). On exception propagation: `Status(ERROR)` + `span.record_exception(exc)` + `error.type` (contracts § Span 1, FR-001).
+- [ ] T009 [P] [US1] Instrument `src/kosmos/tools/executor.py` `ToolExecutor.dispatch`: wrap each tool call in `tracer.start_as_current_span(f"execute_tool {tool_id}")`, set `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name=<tool_id>`, `gen_ai.tool.type="function"`, `gen_ai.tool.call.id` when available. Map `ToolResult.success=False` → `Status(ERROR)` + `error.type=<filter_metadata({"error_class": ...})["error_class"]>`. NO payloads as attributes (contracts § Span 3, FR-003, FR-011).
+- [ ] T010 [P] [US1] Instrument `src/kosmos/llm/client.py` `LLMClient.generate_stream`: open `tracer.start_as_current_span("chat")`, set `gen_ai.operation.name=chat`, `gen_ai.provider.name="friendliai"`, `gen_ai.request.model=<req.model>`, and optional `gen_ai.request.temperature`/`max_tokens`/`top_p` when present (contracts § Span 2; token aggregation + finish_reasons deferred to Phase 5/US2).
+- [ ] T011 [US1] Wire `setup_tracing()` invocation into CLI bootstrap (`src/kosmos/cli/*` main entry — locate current bootstrap module and call once before first query). Ensure tracer acquisition uses module-level `trace.get_tracer(__name__)` (research.md § IP1) in `query.py`, `client.py`, `executor.py`. Depends on: T008, T009, T010.
+- [ ] T012 [P] [US1] Add `tests/observability/test_tracing_init.py`: set `OTEL_SDK_DISABLED=true` → `setup_tracing()` returns a `NoOpTracerProvider` and no `BatchSpanProcessor` is registered; set endpoint+headers → returns real `TracerProvider`.
+- [ ] T013 [P] [US1] Add `tests/observability/test_query_parent_span.py`: use `InMemorySpanExporter` + `SimpleSpanProcessor`, run a mocked `query()` end-to-end, assert trace has exactly one `invoke_agent kosmos-query` root with `gen_ai.conversation.id` attached and at least one child per `chat` + `execute_tool` kind (FR-001, SC-001).
+- [ ] T014 [P] [US1] Add `tests/observability/test_tool_execute_span.py`: assert `execute_tool <id>` span captures `gen_ai.tool.name`, `gen_ai.tool.type="function"`, and that a raised `ToolError` yields `Status.ERROR` + `error.type` attribute; verify tool-arg dict is NOT a span attribute (FR-003, FR-011).
+- [ ] T015 [P] [US1] Add `tests/observability/test_otel_bridge_pii.py`: feed `filter_metadata` with `{"tool_id": "x", "step": 1, "user_input": "홍길동", "pii_email": "a@b"}` and assert only `tool_id` + `step` remain; assert the key set exactly matches `event_logger._ALLOWED_METADATA_KEYS` ∩ input-keys (FR-011, data-model.md § E5 invariant).
+
+**Checkpoint**: US1 tests green with `uv run pytest tests/observability/`. MVP deliverable complete.
+
+## Phase 4 — User Story 3: CI runs without an OTLP collector (P1)
+
+**Story goal**: `OTEL_SDK_DISABLED=true` yields zero network activity and zero behavioral drift from the pre-OTel baseline.
+
+**Independent test**: With `OTEL_SDK_DISABLED=true`, `uv run pytest` passes end-to-end; no HTTP calls to any OTLP endpoint are made (verified by a test that monkeypatches `httpx` and asserts zero OTLP-shaped requests).
+
+- [ ] T016 [US3] Verify `src/kosmos/observability/tracing.py` `setup_tracing()` short-circuits BEFORE any `OTLPSpanExporter` / `BatchSpanProcessor` construction when `OTEL_SDK_DISABLED=true` (guard at the top of the function); add a warn-once log when endpoint is missing but `OTEL_SDK_DISABLED` is unset (FR-009, FR-010).
+- [ ] T017 [P] [US3] Add `tests/observability/test_otel_sdk_disabled.py`: set `OTEL_SDK_DISABLED=true` via `monkeypatch.setenv`, run a mocked `query()` call; assert (a) all spans returned are no-op (`span.is_recording() is False`), (b) no `BatchSpanProcessor` instance exists on the tracer provider, (c) module-level counter of OTLP HTTP calls remains 0 (FR-009, SC-003).
+- [ ] T018 [US3] Update `.github/workflows/*.yml` (whichever runs `pytest`) to inject `OTEL_SDK_DISABLED=true` as a job-level env; locate the file via `grep -l "uv run pytest" .github/workflows/` and add the env. Document in `docs/testing.md` if that file exists (FR-009, SC-003).
+
+**Checkpoint**: Full `uv run pytest` passes locally with `OTEL_SDK_DISABLED=true`; CI workflow reflects the env.
+
+## Phase 5 — User Story 2: SRE monitors token spend and streaming throughput (P2)
+
+**Story goal**: Every completed streaming chat writes one set of usage attributes (`gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.model`, `gen_ai.response.finish_reasons`) exactly once at stream end; 429 retries increment a labeled counter without cloning the span.
+
+**Independent test**: Run 100 mocked streaming calls; assert 100/100 spans carry all four usage attributes and each attribute appears at most once per span. Simulate a 429 with `Retry-After: 2` → one `chat` span, one increment on `kosmos_llm_rate_limit_retries_total{provider=friendliai, model=<m>}`.
+
+- [ ] T019 [US2] In `src/kosmos/llm/client.py` `generate_stream`, accumulate usage/finish_reasons internally (reuse existing pattern in `src/kosmos/llm/usage.py`); at stream finalize (success OR clean EOF), call `span.set_attributes({GEN_AI_USAGE_INPUT_TOKENS: i, GEN_AI_USAGE_OUTPUT_TOKENS: o, GEN_AI_RESPONSE_MODEL: m, GEN_AI_RESPONSE_FINISH_REASONS: [...]})` exactly once. Extend T010 — do NOT write per chunk (FR-002, FR-005, research.md § D6).
+- [ ] T020 [US2] In `src/kosmos/llm/client.py` retry loop (from spec 019), increment metric `kosmos_llm_rate_limit_retries_total` via the existing `MetricsCollector` API with labels `{provider: "friendliai", model: <req.model>}` each time a 429 is received and a retry is about to be issued (after `Retry-After` honor). Do NOT create per-attempt spans (FR-006, research.md § D7).
+- [ ] T021 [P] [US2] Add `tests/observability/test_llm_chat_span.py`: drive `LLMClient.generate_stream` against a mocked streaming source that emits N token chunks + usage; assert the resulting `chat` span has the four required usage attributes set exactly once (count attribute writes via a custom span recorder) (FR-002, FR-005, SC-002).
+- [ ] T022 [P] [US2] Add `tests/observability/test_retry_429_counter.py`: mock httpx to return `429` with `Retry-After: 0` twice then succeed; assert (a) metric counter incremented by 2 with correct labels, (b) exactly one `chat` span is emitted (FR-006).
+
+**Checkpoint**: US1 + US2 + US3 tests all green; 100-call stress test confirms SC-002 100/100.
+
+## Phase 6 — User Story 4: Operator brings up the local Langfuse stack with one command (P2)
+
+**Story goal**: `docker compose -f docker-compose.dev.yml up -d` brings Langfuse v3 online locally so a developer can see their first trace within 10 minutes of clone.
+
+**Independent test**: From a fresh clone on a machine with Docker: follow `quickstart.md § A` → first trace visible in Langfuse UI in ≤10 min (SC-005).
+
+- [ ] T023 [US4] Create `docker-compose.dev.yml` with the Langfuse v3 stack (`langfuse-web`, `langfuse-worker`, `postgres`, `redis`, `clickhouse`, `minio`) based on the official reference in research.md § D9; expose port 3000 for the web UI + OTLP ingest. Include named volumes for postgres/clickhouse/minio; do NOT commit any secrets (FR-014, SC-005).
+- [ ] T024 [US4] Manual validation walkthrough using `quickstart.md § A` on the current dev machine; record observed boot time and first-trace time in the PR description (not a checked-in artifact). Confirms SC-005 ≤10 min.
+
+## Phase 7 — Polish & cross-cutting
+
+- [ ] T025 [P] Run `uv run pytest` twice — once with `OTEL_SDK_DISABLED=true`, once unset with a mocked OTLP sink — and confirm both pass with zero flakes (SC-003, SC-004).
+- [ ] T026 [P] Audit span attributes with a grep over the three instrumented modules (`src/kosmos/engine/query.py`, `src/kosmos/llm/client.py`, `src/kosmos/tools/executor.py`): no `span.set_attribute` call passes raw tool arguments, response bodies, user message text, or any key outside `_ALLOWED_METADATA_KEYS` ∪ `gen_ai.*` semconv constants (FR-011, contracts § PII rule).
+- [ ] T027 Confirm dependency budget: `grep -E '^\s*"opentelemetry' pyproject.toml` returns exactly 3 lines (sdk / exporter-otlp-proto-http / semantic-conventions); `grep -E 'instrumentation|openllmetry|traceloop' pyproject.toml uv.lock` returns zero matches (SC-006, FR-016).
+- [ ] T028 [P] Verify Langfuse UI manually renders: `invoke_agent`-kind-aware view shows token usage, `execute_tool` child spans render, gen_ai dashboard auto-populates — this validates that attribute names match semconv exactly (SC-001).
+- [ ] T029 [P] Add `tests/observability/test_metrics_collector_unchanged.py`: capture a snapshot of `MetricsCollector` public API output (counter/histogram/gauge method signatures + emitted metric names/labels) before and after `setup_tracing()` is invoked; assert equality. Guards FR-012 (existing MetricsCollector behavior unchanged).
+- [ ] T030 [P] Add `tests/observability/test_observability_event_unchanged.py`: run a mocked agent loop with OTel enabled; assert every `ObservabilityEvent` emitted by the legacy `ObservabilityEventLogger` is byte-identical to the pre-OTel baseline (event name, metadata keys after whitelist, timestamps fields present). Guards FR-013 (parallel emission, no drift).
+
+## Dependencies
+
+```
+T001 ──► T002 [P]
+         T003 [P]
+         │
+         ▼
+Phase 2: T004 [P] ──┐
+         T005 [P] ──┤
+         T006 ──────┤ (depends on T004, T005)
+         T007 [P] ◄─┘
+         │
+         ▼ (checkpoint)
+Phase 3 US1:
+         T008 [P] ──┐
+         T009 [P] ──┤
+         T010 [P] ──┤
+         T011 ◄─────┘ (wires T008+T009+T010 into bootstrap)
+         T012 [P] ──┐
+         T013 [P] ──┤ (tests can run after T011)
+         T014 [P] ──┤
+         T015 [P] ──┘
+         │
+         ▼ (MVP checkpoint)
+Phase 4 US3 (independent of US1 tests but reuses T006):
+         T016 ─► T017 [P]
+         T018
+         │
+         ▼
+Phase 5 US2 (extends T010):
+         T019 ─► T021 [P]
+         T020 ─► T022 [P]
+         │
+         ▼
+Phase 6 US4 (independent, needs T002):
+         T023 ─► T024
+         │
+         ▼
+Phase 7 Polish:
+         T025 [P], T026 [P], T027, T028 [P], T029 [P], T030 [P]
+```
+
+**User story independence**: US1 and US3 can proceed in parallel after Phase 2. US2 depends on US1's `chat` span existing (T010). US4 depends only on Phase 1 (T002).
+
+## Parallel execution examples
+
+**Within Phase 2** (foundational):
+```
+# Launch T004, T005, T007 in parallel; T006 follows (imports T004+T005)
+[P] T004 semconv constants
+[P] T005 otel_bridge filter_metadata
+[P] T007 package re-exports
+# then:
+T006 tracing.py setup_tracing()
+```
+
+**Within Phase 3 (US1 MVP)**:
+```
+# After Phase 2 checkpoint, launch T008/T009/T010 in parallel (different files)
+[P] T008 engine/query.py invoke_agent span
+[P] T009 tools/executor.py execute_tool span
+[P] T010 llm/client.py chat span (base)
+# then serialize:
+T011 CLI bootstrap wires setup_tracing
+# then launch all US1 tests in parallel (separate files):
+[P] T012 test_tracing_init
+[P] T013 test_query_parent_span
+[P] T014 test_tool_execute_span
+[P] T015 test_otel_bridge_pii
+```
+
+**Phase 5 (US2)** — can launch T019 and T020 in parallel (different sections of client.py but non-overlapping edits: streaming finalize vs retry loop). Tests T021/T022 [P] after.
+
+## Implementation strategy
+
+1. **MVP = Phase 1 + Phase 2 + Phase 3 (US1)**. Stop here and validate one full trace in Langfuse UI — this delivers SC-001. Land as incremental PR if scope feels too large otherwise.
+2. **Add P1 safety**: Phase 4 (US3) makes CI safe. Land together with MVP if possible; infra-level, small risk.
+3. **Add P2 operational value**: Phase 5 (US2) gives SRE their token/retry data. Phase 6 (US4) lowers developer onboarding friction.
+4. **Polish**: Phase 7 is audit + proof; never skip T026 (PII audit) and T027 (dependency budget) before merge.
+
+## Validation checklist
+
+- [ ] All tasks start with `- [ ]` checkbox, have `TNNN` ID, and cite concrete file paths
+- [ ] Every user-story task carries a `[USn]` label
+- [ ] Setup/Foundational/Polish tasks have no story label
+- [ ] Parallelizable tasks marked `[P]` touch different files
+- [ ] All 16 FRs map to at least one task; all 6 SCs map to at least one validation task
+- [ ] Dependencies graph has no cycles

--- a/src/kosmos/cli/app.py
+++ b/src/kosmos/cli/app.py
@@ -16,6 +16,7 @@ from kosmos._dotenv import load_repo_dotenv
 from kosmos.cli.config import CLIConfig
 from kosmos.cli.renderer import EventRenderer
 from kosmos.cli.repl import REPLLoop
+from kosmos.observability import setup_tracing
 
 logger = logging.getLogger(__name__)
 
@@ -244,4 +245,5 @@ def _run_repl(resume_session_id: str | None = None) -> None:
 def main() -> None:
     """Public entry point called by ``[project.scripts]`` and ``__main__.py``."""
     load_repo_dotenv()
+    setup_tracing()  # configure global TracerProvider once before any query dispatch
     _app()

--- a/src/kosmos/engine/query.py
+++ b/src/kosmos/engine/query.py
@@ -16,12 +16,22 @@ from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
+from opentelemetry import context as _otel_context
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
+
 from kosmos.engine.events import QueryEvent, StopReason
 from kosmos.engine.models import QueryContext
 from kosmos.engine.preprocessing import PreprocessingPipeline
 from kosmos.engine.tokens import estimate_tokens
 from kosmos.llm.errors import BudgetExceededError, StreamInterruptedError
 from kosmos.llm.models import ChatMessage, FunctionCall, ToolCall, ToolDefinition
+from kosmos.observability import (
+    ERROR_TYPE,
+    GEN_AI_AGENT_NAME,
+    GEN_AI_CONVERSATION_ID,
+    GEN_AI_OPERATION_NAME,
+)
 from kosmos.tools.errors import ToolNotFoundError
 from kosmos.tools.executor import ToolExecutor
 from kosmos.tools.models import ToolResult
@@ -32,6 +42,8 @@ if TYPE_CHECKING:
     from kosmos.permissions.pipeline import PermissionPipeline
 
 logger = logging.getLogger(__name__)
+
+_tracer = trace.get_tracer(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -198,6 +210,52 @@ async def query(ctx: QueryContext) -> AsyncIterator[QueryEvent]:  # noqa: C901
 
     Yields:
         QueryEvent stream as described above.
+    """
+    # Open the parent OTel span manually (not via context manager) so that the
+    # span lifetime covers the entire async-generator consumption, including
+    # every yield point.  A context-manager approach would close the span at the
+    # first ``yield``, which is incorrect for async generators.
+    span = _tracer.start_span("invoke_agent kosmos-query")
+
+    # Required attributes (contracts § Span 1)
+    span.set_attribute(GEN_AI_OPERATION_NAME, "invoke_agent")
+    span.set_attribute(GEN_AI_AGENT_NAME, "kosmos-query")
+
+    # Conditional attribute: conversation ID — only when session_context is present.
+    # FR-011: do NOT include user_message/query_text (PII).  session_id is a
+    # random UUID and is not personal data under PIPA.
+    if ctx.session_context is not None:
+        span.set_attribute(GEN_AI_CONVERSATION_ID, str(ctx.session_context.session_id))
+
+    # Attach the span as the current span in this asyncio context so that all
+    # child coroutines (LLM client, tool executor) inherit the parent via
+    # contextvars propagation.  Using context_api.attach/detach rather than
+    # start_as_current_span avoids premature span closure at the first ``yield``,
+    # which is the central problem with async generators and context managers.
+    ctx_with_span = trace.set_span_in_context(span)
+    token = _otel_context.attach(ctx_with_span)
+
+    try:
+        async for event in _query_inner(ctx):
+            yield event
+    except Exception as exc:
+        # Map exception → ERROR status per contracts § Span 1 status mapping.
+        span.set_status(Status(StatusCode.ERROR))
+        span.record_exception(exc)
+        span.set_attribute(ERROR_TYPE, exc.__class__.__name__)
+        raise
+    finally:
+        # Detach then close span — always, regardless of normal exit, exception,
+        # or mid-stream generator abandonment (generator.close() / .throw()).
+        _otel_context.detach(token)
+        span.end()
+
+
+async def _query_inner(ctx: QueryContext) -> AsyncIterator[QueryEvent]:  # noqa: C901
+    """Inner async generator: core query loop without span management.
+
+    Separated so that ``query()`` can manage the OTel span lifetime across the
+    full generator consumption while keeping the loop logic self-contained.
     """
     iteration = 0
     stream_interrupted_count = 0

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -13,6 +13,8 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
 import httpx
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 from pydantic import ValidationError
 
 from kosmos.llm.config import LLMClientConfig
@@ -33,6 +35,16 @@ from kosmos.llm.models import (
     ToolDefinition,
 )
 from kosmos.llm.usage import UsageTracker
+from kosmos.observability.semconv import (
+    ERROR_TYPE,
+    GEN_AI_OPERATION_NAME,
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_MODEL,
+    GEN_AI_RESPONSE_FINISH_REASONS,
+    GEN_AI_RESPONSE_MODEL,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
 
 if TYPE_CHECKING:
     from kosmos.observability.event_logger import ObservabilityEventLogger
@@ -40,6 +52,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 rate_limit_logger = logging.getLogger("kosmos.llm")
+
+_tracer = trace.get_tracer(__name__)
 
 
 @dataclass(frozen=True)
@@ -321,21 +335,91 @@ class LLMClient:
             len(messages),
         )
 
-        async for event in self._stream_with_retry(payload):
-            yield event
+        # T010: open a single "chat" span for the entire logical streaming call
+        # (including all retry attempts — see T020 for per-retry counter).
+        # Use start_span + explicit end() so the span stays alive across yield
+        # boundaries in the async generator lifetime.
+        span = _tracer.start_span("chat")
+        span.set_attribute(GEN_AI_OPERATION_NAME, "chat")
+        span.set_attribute(GEN_AI_PROVIDER_NAME, "friendliai")
+        span.set_attribute(GEN_AI_REQUEST_MODEL, self._config.model)
+        # Optional attributes — only when present in this call's payload.
+        if temperature is not None:
+            span.set_attribute("gen_ai.request.temperature", float(temperature))
+        if max_tokens is not None:
+            span.set_attribute("gen_ai.request.max_tokens", int(max_tokens))
+        if top_p is not None:
+            span.set_attribute("gen_ai.request.top_p", float(top_p))
+
+        # Attach span as the active context for child spans (execute_tool, etc.)
+        # while preserving the caller's context on generator close.
+        ctx = trace.use_span(span, end_on_exit=False)
+        ctx.__enter__()
+
+        # T019: mutable container to collect finalize info from _stream_with_retry().
+        # Populated on the success path only; remains empty if an exception is raised.
+        _finalize: dict[str, object] = {}
+
+        try:
+            async for event in self._stream_with_retry(payload, _finalize):
+                yield event
+        except Exception as exc:
+            span.set_status(Status(StatusCode.ERROR))
+            span.record_exception(exc)
+            span.set_attribute(ERROR_TYPE, exc.__class__.__name__)
+            raise
+        else:
+            # T019: success path — write span attributes exactly once.
+            # Guard: only write when _finalize was populated (stream completed normally).
+            if _finalize:
+                span.set_attributes(
+                    {
+                        GEN_AI_USAGE_INPUT_TOKENS: int(
+                            _finalize.get("input_tokens", self._usage.input_tokens_used)
+                        ),
+                        GEN_AI_USAGE_OUTPUT_TOKENS: int(
+                            _finalize.get("output_tokens", self._usage.output_tokens_used)
+                        ),
+                        GEN_AI_RESPONSE_MODEL: str(
+                            _finalize.get("response_model", self._config.model)
+                        ),
+                        GEN_AI_RESPONSE_FINISH_REASONS: list(
+                            _finalize.get("finish_reasons", [])
+                        ),
+                    }
+                )
+        finally:
+            ctx.__exit__(None, None, None)
+            span.end()
 
     async def _stream_with_retry(  # noqa: C901
-        self, payload: dict[str, object]
+        self,
+        payload: dict[str, object],
+        _finalize: dict[str, object],
     ) -> AsyncIterator[StreamEvent]:
         """Execute stream() with Retry-After-first backoff loop (T015/T016).
 
         Acquires the session-level concurrency gate (T014) around each provider call.
         Pre-stream 429 and mid-stream 429 envelopes both route through the same policy.
+
+        Args:
+            payload: The request payload dict.
+            _finalize: Mutable container populated on success with keys
+                ``input_tokens``, ``output_tokens``, ``response_model``,
+                ``finish_reasons`` — consumed by ``stream()`` for T019 span
+                attributes.  Must be an empty dict on entry; written at most once.
         """
         policy = self._rate_limit_policy
         _stream_start = time.monotonic()
         _metrics_recorded = False
         last_exc: Exception | None = None
+
+        # T019: per-stream accumulators (reset on each successful attempt).
+        _finish_reasons: set[str] = set()
+        _response_model: str | None = None
+        # Snapshot usage before stream starts so we can compute the delta.
+        _usage_input_before = self._usage.input_tokens_used
+        _usage_output_before = self._usage.output_tokens_used
 
         for attempt in range(policy.max_attempts):
             try:
@@ -358,8 +442,28 @@ class LLMClient:
                                 f"Rate limited (HTTP 429) on stream attempt {attempt + 1}",
                                 status_code=429,
                             )
+                            # T020: increment retry counter before sleeping/retrying.
                             if attempt < policy.max_attempts - 1:
+                                if self._metrics is not None:
+                                    try:
+                                        self._metrics.increment(
+                                            "kosmos_llm_rate_limit_retries_total",
+                                            labels={
+                                                "provider": "friendliai",
+                                                "model": self._config.model,
+                                            },
+                                        )
+                                    except Exception:  # noqa: BLE001
+                                        logger.debug(
+                                            "LLMClient: rate_limit counter increment failed",
+                                            exc_info=True,
+                                        )
                                 await asyncio.sleep(delay)
+                            # Reset accumulators for the next attempt.
+                            _finish_reasons = set()
+                            _response_model = None
+                            _usage_input_before = self._usage.input_tokens_used
+                            _usage_output_before = self._usage.output_tokens_used
                             continue
 
                         await self._raise_for_status(response)
@@ -383,9 +487,32 @@ class LLMClient:
                                     f"attempt {attempt + 1}",
                                     status_code=429,
                                 )
+                                # T020: increment retry counter before sleeping/retrying.
                                 if attempt < policy.max_attempts - 1:
+                                    if self._metrics is not None:
+                                        try:
+                                            self._metrics.increment(
+                                                "kosmos_llm_rate_limit_retries_total",
+                                                labels={
+                                                    "provider": "friendliai",
+                                                    "model": self._config.model,
+                                                },
+                                            )
+                                        except Exception:  # noqa: BLE001
+                                            logger.debug(
+                                                "LLMClient: rate_limit counter increment failed",
+                                                exc_info=True,
+                                            )
                                     await asyncio.sleep(delay)
                                 break
+
+                            # T019: intercept chunk metadata before/after yielding.
+                            chunk_info = self._extract_chunk_metadata(line)
+                            if chunk_info.get("finish_reason"):
+                                _finish_reasons.add(chunk_info["finish_reason"])  # type: ignore[arg-type]
+                            if chunk_info.get("model"):
+                                _response_model = chunk_info["model"]  # type: ignore[assignment]
+
                             async for event in self._parse_sse_line(line):
                                 yield event
                                 if event.type == "done":
@@ -394,9 +521,25 @@ class LLMClient:
                                         success=True, duration_ms=_duration_ms
                                     )
                                     _metrics_recorded = True
+                                    # T019: populate finalize container on clean EOF.
+                                    _finalize["input_tokens"] = (
+                                        self._usage.input_tokens_used - _usage_input_before
+                                    )
+                                    _finalize["output_tokens"] = (
+                                        self._usage.output_tokens_used - _usage_output_before
+                                    )
+                                    _finalize["response_model"] = (
+                                        _response_model or payload.get("model", self._config.model)
+                                    )
+                                    _finalize["finish_reasons"] = sorted(_finish_reasons)
                                     return
 
                         if rate_limited_mid_stream:
+                            # Reset accumulators for the next attempt.
+                            _finish_reasons = set()
+                            _response_model = None
+                            _usage_input_before = self._usage.input_tokens_used
+                            _usage_output_before = self._usage.output_tokens_used
                             # Outer loop will retry
                             continue
 
@@ -405,6 +548,17 @@ class LLMClient:
                             _duration_ms = (time.monotonic() - _stream_start) * 1000
                             self._metrics_record_call(success=True, duration_ms=_duration_ms)
                             _metrics_recorded = True
+                        # T019: populate finalize container (no [DONE] path).
+                        _finalize["input_tokens"] = (
+                            self._usage.input_tokens_used - _usage_input_before
+                        )
+                        _finalize["output_tokens"] = (
+                            self._usage.output_tokens_used - _usage_output_before
+                        )
+                        _finalize["response_model"] = (
+                            _response_model or payload.get("model", self._config.model)
+                        )
+                        _finalize["finish_reasons"] = sorted(_finish_reasons)
                         return
 
             except (AuthenticationError, BudgetExceededError):
@@ -492,6 +646,38 @@ class LLMClient:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    @staticmethod
+    def _extract_chunk_metadata(line: str) -> dict[str, str | None]:
+        """Extract ``finish_reason`` and ``model`` from a raw SSE data line.
+
+        Returns a dict with keys ``"finish_reason"`` and ``"model"`` (both may
+        be ``None`` when absent or unparseable).  Used by ``_stream_with_retry``
+        to accumulate T019 finalize data without duplicating JSON parsing.
+        """
+        result: dict[str, str | None] = {"finish_reason": None, "model": None}
+        if not line or not line.startswith("data: "):
+            return result
+        payload_text = line[len("data: "):].strip()
+        if not payload_text or payload_text == "[DONE]":
+            return result
+        try:
+            chunk = json.loads(payload_text)
+        except json.JSONDecodeError:
+            return result
+        if not isinstance(chunk, dict):
+            return result
+        # Extract model field.
+        model_val = chunk.get("model")
+        if isinstance(model_val, str) and model_val:
+            result["model"] = model_val
+        # Extract finish_reason from the first choice.
+        choices = chunk.get("choices")
+        if isinstance(choices, list) and choices:
+            fr = choices[0].get("finish_reason")
+            if isinstance(fr, str) and fr:
+                result["finish_reason"] = fr
+        return result
 
     @staticmethod
     def _is_rate_limit_envelope(line: str) -> bool:

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -10,7 +10,7 @@ import random
 import time
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 import httpx
 from opentelemetry import trace
@@ -375,15 +375,23 @@ class LLMClient:
                 span.set_attributes(
                     {
                         GEN_AI_USAGE_INPUT_TOKENS: int(
-                            _finalize.get("input_tokens", self._usage.input_tokens_used)
+                            cast(
+                                int,
+                                _finalize.get("input_tokens", self._usage.input_tokens_used),
+                            )
                         ),
                         GEN_AI_USAGE_OUTPUT_TOKENS: int(
-                            _finalize.get("output_tokens", self._usage.output_tokens_used)
+                            cast(
+                                int,
+                                _finalize.get("output_tokens", self._usage.output_tokens_used),
+                            )
                         ),
                         GEN_AI_RESPONSE_MODEL: str(
                             _finalize.get("response_model", self._config.model)
                         ),
-                        GEN_AI_RESPONSE_FINISH_REASONS: list(_finalize.get("finish_reasons", [])),
+                        GEN_AI_RESPONSE_FINISH_REASONS: list(
+                            cast(list[str], _finalize.get("finish_reasons", []))
+                        ),
                     }
                 )
         finally:
@@ -509,7 +517,7 @@ class LLMClient:
                             if chunk_info.get("finish_reason"):
                                 _finish_reasons.add(chunk_info["finish_reason"])  # type: ignore[arg-type]
                             if chunk_info.get("model"):
-                                _response_model = chunk_info["model"]  # type: ignore[assignment]
+                                _response_model = chunk_info["model"]
 
                             async for event in self._parse_sse_line(line):
                                 yield event

--- a/src/kosmos/llm/client.py
+++ b/src/kosmos/llm/client.py
@@ -383,9 +383,7 @@ class LLMClient:
                         GEN_AI_RESPONSE_MODEL: str(
                             _finalize.get("response_model", self._config.model)
                         ),
-                        GEN_AI_RESPONSE_FINISH_REASONS: list(
-                            _finalize.get("finish_reasons", [])
-                        ),
+                        GEN_AI_RESPONSE_FINISH_REASONS: list(_finalize.get("finish_reasons", [])),
                     }
                 )
         finally:
@@ -528,8 +526,8 @@ class LLMClient:
                                     _finalize["output_tokens"] = (
                                         self._usage.output_tokens_used - _usage_output_before
                                     )
-                                    _finalize["response_model"] = (
-                                        _response_model or payload.get("model", self._config.model)
+                                    _finalize["response_model"] = _response_model or payload.get(
+                                        "model", self._config.model
                                     )
                                     _finalize["finish_reasons"] = sorted(_finish_reasons)
                                     return
@@ -555,8 +553,8 @@ class LLMClient:
                         _finalize["output_tokens"] = (
                             self._usage.output_tokens_used - _usage_output_before
                         )
-                        _finalize["response_model"] = (
-                            _response_model or payload.get("model", self._config.model)
+                        _finalize["response_model"] = _response_model or payload.get(
+                            "model", self._config.model
                         )
                         _finalize["finish_reasons"] = sorted(_finish_reasons)
                         return
@@ -658,7 +656,7 @@ class LLMClient:
         result: dict[str, str | None] = {"finish_reason": None, "model": None}
         if not line or not line.startswith("data: "):
             return result
-        payload_text = line[len("data: "):].strip()
+        payload_text = line[len("data: ") :].strip()
         if not payload_text or payload_text == "[DONE]":
             return result
         try:

--- a/src/kosmos/llm/usage.py
+++ b/src/kosmos/llm/usage.py
@@ -127,3 +127,13 @@ class UsageTracker:
     def total_used(self) -> int:
         """Total tokens consumed so far."""
         return self._input_tokens_used + self._output_tokens_used
+
+    @property
+    def input_tokens_used(self) -> int:
+        """Total input tokens consumed so far in this session."""
+        return self._input_tokens_used
+
+    @property
+    def output_tokens_used(self) -> int:
+        """Total output tokens consumed so far in this session."""
+        return self._output_tokens_used

--- a/src/kosmos/observability/__init__.py
+++ b/src/kosmos/observability/__init__.py
@@ -1,12 +1,17 @@
 # SPDX-License-Identifier: Apache-2.0
 """KOSMOS observability package.
 
-Provides in-process metrics collection and structured event logging for
-the tool execution and error-recovery pipelines.
+Provides in-process metrics collection, structured event logging, and
+OpenTelemetry tracing setup for the tool execution and error-recovery
+pipelines.
 
-Public API::
+Public API (legacy — FR-012/FR-013 backwards compatibility)::
 
     from kosmos.observability import MetricsCollector, ObservabilityEvent
+
+Public API (OTel tracing — spec 021)::
+
+    from kosmos.observability import setup_tracing, TracingSettings, filter_metadata
 
 The ``MetricsCollector`` is intentionally lightweight — no external agents,
 no network calls.  It collects counters, gauges, and histograms purely in
@@ -17,9 +22,45 @@ endpoints.
 from kosmos.observability.event_logger import ObservabilityEventLogger
 from kosmos.observability.events import ObservabilityEvent
 from kosmos.observability.metrics import MetricsCollector
+from kosmos.observability.otel_bridge import filter_metadata
+from kosmos.observability.semconv import (
+    ERROR_TYPE,
+    GEN_AI_AGENT_NAME,
+    GEN_AI_CONVERSATION_ID,
+    GEN_AI_OPERATION_NAME,
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_MODEL,
+    GEN_AI_RESPONSE_FINISH_REASONS,
+    GEN_AI_RESPONSE_MODEL,
+    GEN_AI_TOOL_CALL_ID,
+    GEN_AI_TOOL_NAME,
+    GEN_AI_TOOL_TYPE,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+from kosmos.observability.tracing import TracingSettings, setup_tracing
 
 __all__ = [
+    # Legacy exports — do not remove (FR-012, FR-013)
     "MetricsCollector",
     "ObservabilityEvent",
     "ObservabilityEventLogger",
+    # OTel tracing — spec 021
+    "TracingSettings",
+    "filter_metadata",
+    "setup_tracing",
+    # GenAI semconv constants — spec 021
+    "ERROR_TYPE",
+    "GEN_AI_AGENT_NAME",
+    "GEN_AI_CONVERSATION_ID",
+    "GEN_AI_OPERATION_NAME",
+    "GEN_AI_PROVIDER_NAME",
+    "GEN_AI_REQUEST_MODEL",
+    "GEN_AI_RESPONSE_FINISH_REASONS",
+    "GEN_AI_RESPONSE_MODEL",
+    "GEN_AI_TOOL_CALL_ID",
+    "GEN_AI_TOOL_NAME",
+    "GEN_AI_TOOL_TYPE",
+    "GEN_AI_USAGE_INPUT_TOKENS",
+    "GEN_AI_USAGE_OUTPUT_TOKENS",
 ]

--- a/src/kosmos/observability/otel_bridge.py
+++ b/src/kosmos/observability/otel_bridge.py
@@ -1,0 +1,67 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OTel bridge utilities for KOSMOS observability.
+
+Provides ``filter_metadata``, a PII-safe prefilter that strips non-whitelisted
+keys and non-primitive values from a raw metadata dict before it is attached
+as span attributes.
+
+The whitelist is imported from ``event_logger._ALLOWED_METADATA_KEYS`` — that
+module is the **single source of truth** for which metadata keys may be
+observed.  This module must never define its own parallel whitelist.
+
+Usage::
+
+    from kosmos.observability.otel_bridge import filter_metadata
+
+    safe_attrs = filter_metadata({"tool_id": "koroad_accident", "step": 3})
+    span.set_attributes(safe_attrs)
+"""
+
+from __future__ import annotations
+
+from typing import Union
+
+from kosmos.observability.event_logger import _ALLOWED_METADATA_KEYS
+
+# Primitive types accepted by the OTel AttributeValue spec.
+_Primitive = Union[str, bool, int, float]
+
+
+def _is_primitive(value: object) -> bool:
+    """Return True if *value* is a scalar OTel-compatible primitive."""
+    # Note: bool must be checked before int because bool is a subclass of int.
+    return isinstance(value, (str, bool, int, float))
+
+
+def _is_primitive_list(value: object) -> bool:
+    """Return True if *value* is a list whose every element is a primitive."""
+    if not isinstance(value, list):
+        return False
+    return all(_is_primitive(item) for item in value)
+
+
+def filter_metadata(raw: dict[str, object]) -> dict[str, object]:
+    """Return a whitelisted, type-safe copy of *raw* suitable for span attributes.
+
+    Rules applied in order:
+    1. Drop any key not in ``_ALLOWED_METADATA_KEYS`` (PII prefilter, data-model § E5).
+    2. Drop any value that is not ``str | bool | int | float`` or a homogeneous
+       list of those primitives (OTel AttributeValue compatibility).
+
+    The original dict is never mutated.  Dropped entries are silently discarded
+    to avoid log noise on hot paths.
+
+    Args:
+        raw: Arbitrary metadata dictionary from the tool execution pipeline.
+
+    Returns:
+        A new dict containing only the entries that pass both the whitelist and
+        the type filter.
+    """
+    result: dict[str, object] = {}
+    for key, value in raw.items():
+        if key not in _ALLOWED_METADATA_KEYS:
+            continue
+        if _is_primitive(value) or _is_primitive_list(value):
+            result[key] = value
+    return result

--- a/src/kosmos/observability/otel_bridge.py
+++ b/src/kosmos/observability/otel_bridge.py
@@ -19,12 +19,10 @@ Usage::
 
 from __future__ import annotations
 
-from typing import Union
-
 from kosmos.observability.event_logger import _ALLOWED_METADATA_KEYS
 
 # Primitive types accepted by the OTel AttributeValue spec.
-_Primitive = Union[str, bool, int, float]
+_Primitive = str | bool | int | float
 
 
 def _is_primitive(value: object) -> bool:

--- a/src/kosmos/observability/semconv.py
+++ b/src/kosmos/observability/semconv.py
@@ -1,0 +1,55 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenTelemetry GenAI semantic convention constants for KOSMOS.
+
+Re-exports attribute-name constants from the official
+``opentelemetry-semantic-conventions`` package where available (incubating
+GenAI module, v1.40 Development stability).  Any constant not yet shipped by
+the SDK package is defined here as a string literal, matching the OTel GenAI
+semconv v1.40 specification.
+
+Deprecated names (e.g. ``gen_ai.system`` renamed to ``gen_ai.provider.name``
+in v1.37) are intentionally absent.  Use the constants in this module as the
+single source of truth across all KOSMOS instrumentation code.
+
+Usage::
+
+    from kosmos.observability.semconv import (
+        GEN_AI_OPERATION_NAME,
+        GEN_AI_PROVIDER_NAME,
+        ERROR_TYPE,
+    )
+"""
+
+from __future__ import annotations
+
+from opentelemetry.semconv._incubating.attributes.gen_ai_attributes import (
+    GEN_AI_AGENT_NAME,
+    GEN_AI_CONVERSATION_ID,
+    GEN_AI_OPERATION_NAME,
+    GEN_AI_PROVIDER_NAME,
+    GEN_AI_REQUEST_MODEL,
+    GEN_AI_RESPONSE_FINISH_REASONS,
+    GEN_AI_RESPONSE_MODEL,
+    GEN_AI_TOOL_CALL_ID,
+    GEN_AI_TOOL_NAME,
+    GEN_AI_TOOL_TYPE,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+from opentelemetry.semconv.attributes.error_attributes import ERROR_TYPE
+
+__all__ = [
+    "ERROR_TYPE",
+    "GEN_AI_AGENT_NAME",
+    "GEN_AI_CONVERSATION_ID",
+    "GEN_AI_OPERATION_NAME",
+    "GEN_AI_PROVIDER_NAME",
+    "GEN_AI_REQUEST_MODEL",
+    "GEN_AI_RESPONSE_FINISH_REASONS",
+    "GEN_AI_RESPONSE_MODEL",
+    "GEN_AI_TOOL_CALL_ID",
+    "GEN_AI_TOOL_NAME",
+    "GEN_AI_TOOL_TYPE",
+    "GEN_AI_USAGE_INPUT_TOKENS",
+    "GEN_AI_USAGE_OUTPUT_TOKENS",
+]

--- a/src/kosmos/observability/tracing.py
+++ b/src/kosmos/observability/tracing.py
@@ -130,9 +130,7 @@ class TracingSettings(BaseModel):
     )
     service_version: str = Field(
         default="0.0.0",
-        description=(
-            "OTel resource service.version attribute.  Read from pyproject.toml at boot."
-        ),
+        description=("OTel resource service.version attribute.  Read from pyproject.toml at boot."),
     )
     environment: str = Field(
         default="dev",
@@ -240,9 +238,7 @@ def _settings_from_env() -> TracingSettings:
     endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or None
     headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or None
     environment = os.environ.get("OTEL_DEPLOYMENT_ENVIRONMENT", "dev")
-    semconv_opt_in = os.environ.get(
-        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
-    )
+    semconv_opt_in = os.environ.get("OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental")
 
     return TracingSettings(
         endpoint=endpoint,

--- a/src/kosmos/observability/tracing.py
+++ b/src/kosmos/observability/tracing.py
@@ -30,10 +30,10 @@ from functools import lru_cache
 from typing import Literal
 
 from opentelemetry import trace
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.trace import NoOpTracerProvider
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -54,15 +54,15 @@ def _read_project_version() -> str:
     and finally falls back to ``"0.0.0"`` if neither succeeds.
     """
     try:
-        from importlib.metadata import version, PackageNotFoundError
+        from importlib.metadata import version
 
         return version("kosmos")
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001, S110
         pass
 
     try:
-        import tomllib
         import pathlib
+        import tomllib
 
         # Walk up from this file to the repo root and find pyproject.toml.
         root = pathlib.Path(__file__).parent
@@ -73,7 +73,7 @@ def _read_project_version() -> str:
                     data = tomllib.load(fh)
                 return str(data["project"]["version"])
             root = root.parent
-    except Exception:  # noqa: BLE001
+    except Exception:  # noqa: BLE001, S110
         pass
 
     return "0.0.0"

--- a/src/kosmos/observability/tracing.py
+++ b/src/kosmos/observability/tracing.py
@@ -1,0 +1,254 @@
+# SPDX-License-Identifier: Apache-2.0
+"""OpenTelemetry TracerProvider bootstrap for KOSMOS.
+
+Provides ``TracingSettings`` (a Pydantic v2 model) and ``setup_tracing``, a
+factory function that configures the global ``TracerProvider`` once at
+application startup.
+
+Design decisions:
+- Only ``http/protobuf`` OTLP transport is supported (gRPC is prohibited per
+  the wire contract; see ``contracts/otel-span-contract.md § Transport``).
+- When ``OTEL_SDK_DISABLED=true`` or the endpoint is missing, a
+  ``NoOpTracerProvider`` is returned and **no** ``BatchSpanProcessor`` or
+  ``OTLPSpanExporter`` is ever constructed — guaranteeing zero network
+  activity in CI (FR-009, SC-003, research.md § D4).
+- ``service.version`` is read from ``pyproject.toml`` at boot time so it does
+  not need to be hard-coded in the env file.
+
+Usage::
+
+    from kosmos.observability.tracing import setup_tracing
+
+    provider = setup_tracing()   # reads env vars; returns NoOp if disabled
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from functools import lru_cache
+from typing import Literal
+
+from opentelemetry import trace
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+from opentelemetry.trace import NoOpTracerProvider
+from pydantic import BaseModel, ConfigDict, Field
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Version helper
+# ---------------------------------------------------------------------------
+
+
+@lru_cache(maxsize=1)
+def _read_project_version() -> str:
+    """Read ``[project].version`` from ``pyproject.toml``.
+
+    Uses ``importlib.metadata`` as the primary path (works once the package is
+    installed/editable).  Falls back to parsing ``pyproject.toml`` directly,
+    and finally falls back to ``"0.0.0"`` if neither succeeds.
+    """
+    try:
+        from importlib.metadata import version, PackageNotFoundError
+
+        return version("kosmos")
+    except Exception:  # noqa: BLE001
+        pass
+
+    try:
+        import tomllib
+        import pathlib
+
+        # Walk up from this file to the repo root and find pyproject.toml.
+        root = pathlib.Path(__file__).parent
+        for _ in range(6):  # search up to 6 levels
+            candidate = root / "pyproject.toml"
+            if candidate.exists():
+                with candidate.open("rb") as fh:
+                    data = tomllib.load(fh)
+                return str(data["project"]["version"])
+            root = root.parent
+    except Exception:  # noqa: BLE001
+        pass
+
+    return "0.0.0"
+
+
+# ---------------------------------------------------------------------------
+# TracingSettings
+# ---------------------------------------------------------------------------
+
+
+class TracingSettings(BaseModel):
+    """Immutable tracing configuration derived from environment variables.
+
+    All fields carry explicit types to satisfy Pydantic v2 strict mode.
+    The model is ``frozen=True`` — instances are constructed once at boot and
+    never mutated.
+
+    Attributes:
+        endpoint: OTLP HTTP endpoint URL.  ``None`` disables tracing (no-op).
+        protocol: OTLP wire protocol.  Only ``"http/protobuf"`` is allowed.
+        headers: Raw ``OTEL_EXPORTER_OTLP_HEADERS`` string (e.g.
+            ``"Authorization=Basic%20<token>"``).
+        service_name: OTel ``service.name`` resource attribute.
+        service_version: OTel ``service.version`` resource attribute.
+        environment: OTel ``deployment.environment.name`` resource attribute.
+        semconv_opt_in: Value of ``OTEL_SEMCONV_STABILITY_OPT_IN``.
+        disabled: When ``True``, ``setup_tracing`` returns ``NoOpTracerProvider``
+            without constructing any exporter or processor.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    endpoint: str | None = Field(
+        default=None,
+        description=(
+            "OTLP HTTP endpoint URL.  None means no exporter is configured"
+            " and tracing falls back to no-op."
+        ),
+    )
+    protocol: Literal["http/protobuf"] = Field(
+        default="http/protobuf",
+        description="OTLP wire protocol.  Only http/protobuf is supported (gRPC prohibited).",
+    )
+    headers: str | None = Field(
+        default=None,
+        description=(
+            "Raw OTEL_EXPORTER_OTLP_HEADERS string, e.g. "
+            "'Authorization=Basic%20<token>'.  Never logged."
+        ),
+    )
+    service_name: str = Field(
+        default="kosmos",
+        description="OTel resource service.name attribute.",
+    )
+    service_version: str = Field(
+        default="0.0.0",
+        description=(
+            "OTel resource service.version attribute.  Read from pyproject.toml at boot."
+        ),
+    )
+    environment: str = Field(
+        default="dev",
+        description="OTel resource deployment.environment.name attribute.",
+    )
+    semconv_opt_in: str = Field(
+        default="gen_ai_latest_experimental",
+        description=(
+            "Value of OTEL_SEMCONV_STABILITY_OPT_IN.  Controls which experimental"
+            " semconv attributes are exposed by the SDK."
+        ),
+    )
+    disabled: bool = Field(
+        default=False,
+        description=(
+            "When True, setup_tracing returns NoOpTracerProvider with zero"
+            " background threads or network activity."
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# setup_tracing
+# ---------------------------------------------------------------------------
+
+_WARN_MISSING_ENDPOINT_ONCE = True  # module-level sentinel for warn-once
+
+
+def setup_tracing(settings: TracingSettings | None = None) -> TracerProvider | NoOpTracerProvider:
+    """Configure and return the global ``TracerProvider``.
+
+    When *settings* is ``None``, configuration is read from environment
+    variables.  The returned provider is also registered as the global
+    provider via ``trace.set_tracer_provider``.
+
+    No-op paths (returns ``NoOpTracerProvider`` without constructing any
+    exporter or processor):
+    - ``OTEL_SDK_DISABLED=true`` (or ``settings.disabled=True``)
+    - Endpoint not configured (``OTEL_EXPORTER_OTLP_ENDPOINT`` unset or
+      ``settings.endpoint is None``)
+
+    Args:
+        settings: Pre-constructed settings.  When ``None``, env vars are read.
+
+    Returns:
+        A live ``TracerProvider`` if tracing is enabled and the endpoint is
+        set; otherwise a ``NoOpTracerProvider``.
+    """
+    global _WARN_MISSING_ENDPOINT_ONCE  # noqa: PLW0603
+
+    if settings is None:
+        settings = _settings_from_env()
+
+    if settings.disabled:
+        provider: TracerProvider | NoOpTracerProvider = NoOpTracerProvider()
+        trace.set_tracer_provider(provider)
+        return provider
+
+    if settings.endpoint is None:
+        if _WARN_MISSING_ENDPOINT_ONCE:
+            logger.warning(
+                "KOSMOS tracing: OTEL_EXPORTER_OTLP_ENDPOINT is not set and"
+                " OTEL_SDK_DISABLED is not 'true'.  Tracing will be disabled"
+                " (no-op).  Set the endpoint or set OTEL_SDK_DISABLED=true to"
+                " suppress this warning."
+            )
+            _WARN_MISSING_ENDPOINT_ONCE = False
+        provider = NoOpTracerProvider()
+        trace.set_tracer_provider(provider)
+        return provider
+
+    # Build real TracerProvider.
+    resource = Resource.create(
+        {
+            "service.name": settings.service_name,
+            "service.version": settings.service_version,
+            "deployment.environment.name": settings.environment,
+        }
+    )
+
+    exporter_kwargs: dict[str, str] = {"endpoint": settings.endpoint}
+    if settings.headers:
+        exporter_kwargs["headers"] = settings.headers  # type: ignore[assignment]
+
+    exporter = OTLPSpanExporter(**exporter_kwargs)  # type: ignore[arg-type]
+    processor = BatchSpanProcessor(exporter)
+
+    real_provider = TracerProvider(resource=resource)
+    real_provider.add_span_processor(processor)
+
+    trace.set_tracer_provider(real_provider)
+    return real_provider
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _settings_from_env() -> TracingSettings:
+    """Build ``TracingSettings`` by reading standard OTel environment variables."""
+    disabled_raw = os.environ.get("OTEL_SDK_DISABLED", "false").strip().lower()
+    disabled = disabled_raw == "true"
+
+    endpoint = os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT") or None
+    headers = os.environ.get("OTEL_EXPORTER_OTLP_HEADERS") or None
+    environment = os.environ.get("OTEL_DEPLOYMENT_ENVIRONMENT", "dev")
+    semconv_opt_in = os.environ.get(
+        "OTEL_SEMCONV_STABILITY_OPT_IN", "gen_ai_latest_experimental"
+    )
+
+    return TracingSettings(
+        endpoint=endpoint,
+        headers=headers,
+        service_version=_read_project_version(),
+        environment=environment,
+        semconv_opt_in=semconv_opt_in,
+        disabled=disabled,
+    )

--- a/src/kosmos/observability/tracing.py
+++ b/src/kosmos/observability/tracing.py
@@ -213,7 +213,7 @@ def setup_tracing(settings: TracingSettings | None = None) -> TracerProvider | N
 
     exporter_kwargs: dict[str, str] = {"endpoint": settings.endpoint}
     if settings.headers:
-        exporter_kwargs["headers"] = settings.headers  # type: ignore[assignment]
+        exporter_kwargs["headers"] = settings.headers
 
     exporter = OTLPSpanExporter(**exporter_kwargs)  # type: ignore[arg-type]
     processor = BatchSpanProcessor(exporter)

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -223,9 +223,7 @@ class ToolExecutor:
                     try:
                         result_dict = await adapter(validated_input)
                     except Exception as exc:
-                        logger.exception(
-                            "Adapter execution failed for tool %s: %s", tool_name, exc
-                        )
+                        logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)
                         self._metrics_increment("tool.error_count", tool_name)
                         self._metrics_observe_duration(
                             "tool.duration_ms",

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -14,8 +14,18 @@ import time
 from collections.abc import Awaitable, Callable
 from typing import TYPE_CHECKING, Any
 
+from opentelemetry import trace
+from opentelemetry.trace import Status, StatusCode
 from pydantic import BaseModel, ValidationError
 
+from kosmos.observability import (
+    ERROR_TYPE,
+    GEN_AI_OPERATION_NAME,
+    GEN_AI_TOOL_CALL_ID,
+    GEN_AI_TOOL_NAME,
+    GEN_AI_TOOL_TYPE,
+    filter_metadata,
+)
 from kosmos.tools.errors import ToolNotFoundError
 from kosmos.tools.models import ToolResult
 from kosmos.tools.registry import ToolRegistry
@@ -26,6 +36,8 @@ if TYPE_CHECKING:
     from kosmos.recovery.executor import RecoveryExecutor
 
 logger = logging.getLogger(__name__)
+
+_tracer = trace.get_tracer(__name__)
 
 AdapterFn = Callable[[BaseModel], Awaitable[dict[str, Any]]]
 
@@ -83,176 +95,207 @@ class ToolExecutor:
         self._adapters[tool_id] = adapter
         logger.debug("Registered adapter for tool: %s", tool_id)
 
-    async def dispatch(self, tool_name: str, arguments_json: str) -> ToolResult:  # noqa: C901
+    async def dispatch(  # noqa: C901
+        self,
+        tool_name: str,
+        arguments_json: str,
+        tool_call_id: str | None = None,
+    ) -> ToolResult:
         """Execute a tool call end-to-end.
 
         Args:
             tool_name: The tool identifier to look up in the registry.
             arguments_json: JSON string of the tool arguments.
+            tool_call_id: Optional LLM-assigned tool call identifier; when
+                provided it is attached to the OTel span as
+                ``gen_ai.tool.call.id`` (contract § Span 3).
 
         Returns:
             ToolResult with success=True and data on success, or
             success=False with error/error_type on any failure.
         """
-        dispatch_start = time.monotonic()
-        self._metrics_increment("tool.call_count", tool_name)
-        _final_result: ToolResult | None = None
+        with _tracer.start_as_current_span(f"execute_tool {tool_name}") as span:
+            span.set_attribute(GEN_AI_OPERATION_NAME, "execute_tool")
+            span.set_attribute(GEN_AI_TOOL_NAME, tool_name)
+            span.set_attribute(GEN_AI_TOOL_TYPE, "function")
+            if tool_call_id is not None:
+                span.set_attribute(GEN_AI_TOOL_CALL_ID, tool_call_id)
 
-        try:
-            # Step 1: Lookup tool
+            dispatch_start = time.monotonic()
+            self._metrics_increment("tool.call_count", tool_name)
+            _final_result: ToolResult | None = None
+
             try:
-                tool = self._registry.lookup(tool_name)
-            except ToolNotFoundError as exc:
-                logger.warning("Tool not found: %s", tool_name)
-                self._metrics_increment("tool.error_count", tool_name)
-                _final_result = ToolResult(
-                    tool_id=tool_name,
-                    success=False,
-                    error=str(exc),
-                    error_type="not_found",
-                )
-                return _final_result
-
-            # Step 2: Parse and validate input
-            try:
-                raw_args = json.loads(arguments_json)
-                validated_input = tool.input_schema.model_validate(raw_args)
-            except (TypeError, json.JSONDecodeError, ValidationError) as exc:
-                # Avoid logging the raw arguments — they may carry user PII
-                # (addresses, names, IDs). Log only length metadata here;
-                # the corrective-hint payload already surfaces the structural
-                # problem to the model.
-                _raw_len = len(arguments_json) if isinstance(arguments_json, str) else 0
-                logger.warning(
-                    "Input validation failed for tool %s: %s | raw_args_len=%d",
-                    tool_name,
-                    exc,
-                    _raw_len,
-                )
-                self._metrics_increment("tool.error_count", tool_name)
-                _final_result = ToolResult(
-                    tool_id=tool_name,
-                    success=False,
-                    error=str(exc),
-                    error_type="validation",
-                )
-                return _final_result
-
-            # Step 3: Verify adapter exists before consuming a rate-limit slot
-            adapter = self._adapters.get(tool_name)
-            if adapter is None:
-                logger.warning("No adapter registered for tool: %s", tool_name)
-                self._metrics_increment("tool.error_count", tool_name)
-                _final_result = ToolResult(
-                    tool_id=tool_name,
-                    success=False,
-                    error=f"No adapter registered for tool {tool_name!r}",
-                    error_type="execution",
-                )
-                return _final_result
-
-            # Step 4/5: Execute adapter with rate limiting + optional recovery.
-            #
-            # Rate-limit check runs first to reject early when over quota.
-            # ``record()`` is deferred to just before the actual adapter call so
-            # that RecoveryExecutor short-circuits (cache hit, circuit-open) do
-            # NOT consume a rate-limit slot.
-            rate_limiter = self._registry.get_rate_limiter(tool_name)
-            if not rate_limiter.check():
-                logger.warning("Rate limit exceeded for tool: %s", tool_name)
-                self._metrics_increment("tool.error_count", tool_name)
-                _final_result = ToolResult(
-                    tool_id=tool_name,
-                    success=False,
-                    error=f"Rate limit exceeded for tool {tool_name!r}",
-                    error_type="rate_limit",
-                )
-                return _final_result
-
-            if self._recovery_executor is not None:
-                # Pass rate_limiter to RecoveryExecutor so record() is called
-                # only when the adapter is actually invoked (not on cache hit
-                # or circuit-open short-circuit).
-                recovery_result = await self._recovery_executor.execute(
-                    tool,
-                    adapter,
-                    validated_input,
-                    is_foreground=True,
-                    rate_limiter=rate_limiter,
-                )
-                tool_result = recovery_result.tool_result
-                if not tool_result.success:
-                    self._metrics_increment("tool.error_count", tool_name)
-                    self._metrics_observe_duration(
-                        "tool.duration_ms", tool_name, (time.monotonic() - dispatch_start) * 1000
-                    )
-                    _final_result = tool_result
-                    return _final_result
-                result_dict = dict(tool_result.data or {})
-            else:
-                rate_limiter.record()
+                # Step 1: Lookup tool
                 try:
-                    result_dict = await adapter(validated_input)
-                except Exception as exc:
-                    logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)
+                    tool = self._registry.lookup(tool_name)
+                except ToolNotFoundError as exc:
+                    logger.warning("Tool not found: %s", tool_name)
+                    self._metrics_increment("tool.error_count", tool_name)
+                    _final_result = ToolResult(
+                        tool_id=tool_name,
+                        success=False,
+                        error=str(exc),
+                        error_type="not_found",
+                    )
+                    return _final_result
+
+                # Step 2: Parse and validate input
+                try:
+                    raw_args = json.loads(arguments_json)
+                    validated_input = tool.input_schema.model_validate(raw_args)
+                except (TypeError, json.JSONDecodeError, ValidationError) as exc:
+                    # Avoid logging the raw arguments — they may carry user PII
+                    # (addresses, names, IDs). Log only length metadata here;
+                    # the corrective-hint payload already surfaces the structural
+                    # problem to the model.
+                    _raw_len = len(arguments_json) if isinstance(arguments_json, str) else 0
+                    logger.warning(
+                        "Input validation failed for tool %s: %s | raw_args_len=%d",
+                        tool_name,
+                        exc,
+                        _raw_len,
+                    )
+                    self._metrics_increment("tool.error_count", tool_name)
+                    _final_result = ToolResult(
+                        tool_id=tool_name,
+                        success=False,
+                        error=str(exc),
+                        error_type="validation",
+                    )
+                    return _final_result
+
+                # Step 3: Verify adapter exists before consuming a rate-limit slot
+                adapter = self._adapters.get(tool_name)
+                if adapter is None:
+                    logger.warning("No adapter registered for tool: %s", tool_name)
+                    self._metrics_increment("tool.error_count", tool_name)
+                    _final_result = ToolResult(
+                        tool_id=tool_name,
+                        success=False,
+                        error=f"No adapter registered for tool {tool_name!r}",
+                        error_type="execution",
+                    )
+                    return _final_result
+
+                # Step 4/5: Execute adapter with rate limiting + optional recovery.
+                #
+                # Rate-limit check runs first to reject early when over quota.
+                # ``record()`` is deferred to just before the actual adapter call so
+                # that RecoveryExecutor short-circuits (cache hit, circuit-open) do
+                # NOT consume a rate-limit slot.
+                rate_limiter = self._registry.get_rate_limiter(tool_name)
+                if not rate_limiter.check():
+                    logger.warning("Rate limit exceeded for tool: %s", tool_name)
+                    self._metrics_increment("tool.error_count", tool_name)
+                    _final_result = ToolResult(
+                        tool_id=tool_name,
+                        success=False,
+                        error=f"Rate limit exceeded for tool {tool_name!r}",
+                        error_type="rate_limit",
+                    )
+                    return _final_result
+
+                if self._recovery_executor is not None:
+                    # Pass rate_limiter to RecoveryExecutor so record() is called
+                    # only when the adapter is actually invoked (not on cache hit
+                    # or circuit-open short-circuit).
+                    recovery_result = await self._recovery_executor.execute(
+                        tool,
+                        adapter,
+                        validated_input,
+                        is_foreground=True,
+                        rate_limiter=rate_limiter,
+                    )
+                    tool_result = recovery_result.tool_result
+                    if not tool_result.success:
+                        self._metrics_increment("tool.error_count", tool_name)
+                        self._metrics_observe_duration(
+                            "tool.duration_ms",
+                            tool_name,
+                            (time.monotonic() - dispatch_start) * 1000,
+                        )
+                        _final_result = tool_result
+                        return _final_result
+                    result_dict = dict(tool_result.data or {})
+                else:
+                    rate_limiter.record()
+                    try:
+                        result_dict = await adapter(validated_input)
+                    except Exception as exc:
+                        logger.exception(
+                            "Adapter execution failed for tool %s: %s", tool_name, exc
+                        )
+                        self._metrics_increment("tool.error_count", tool_name)
+                        self._metrics_observe_duration(
+                            "tool.duration_ms",
+                            tool_name,
+                            (time.monotonic() - dispatch_start) * 1000,
+                        )
+                        _final_result = ToolResult(
+                            tool_id=tool_name,
+                            success=False,
+                            error=str(exc),
+                            error_type="execution",
+                        )
+                        return _final_result
+
+                # Step 6: Validate output
+                try:
+                    validated_output = tool.output_schema.model_validate(result_dict)
+                except ValidationError as exc:
+                    logger.warning("Output schema mismatch for tool %s: %s", tool_name, exc)
                     self._metrics_increment("tool.error_count", tool_name)
                     self._metrics_observe_duration(
-                        "tool.duration_ms", tool_name, (time.monotonic() - dispatch_start) * 1000
+                        "tool.duration_ms",
+                        tool_name,
+                        (time.monotonic() - dispatch_start) * 1000,
                     )
                     _final_result = ToolResult(
                         tool_id=tool_name,
                         success=False,
                         error=str(exc),
-                        error_type="execution",
+                        error_type="schema_mismatch",
                     )
                     return _final_result
 
-            # Step 6: Validate output
-            try:
-                validated_output = tool.output_schema.model_validate(result_dict)
-            except ValidationError as exc:
-                logger.warning("Output schema mismatch for tool %s: %s", tool_name, exc)
-                self._metrics_increment("tool.error_count", tool_name)
+                # Step 7: Return success
+                logger.info("Tool dispatch succeeded: %s", tool_name)
+                self._metrics_increment("tool.success_count", tool_name)
                 self._metrics_observe_duration(
                     "tool.duration_ms", tool_name, (time.monotonic() - dispatch_start) * 1000
                 )
                 _final_result = ToolResult(
                     tool_id=tool_name,
-                    success=False,
-                    error=str(exc),
-                    error_type="schema_mismatch",
+                    success=True,
+                    data=validated_output.model_dump(),
                 )
                 return _final_result
 
-            # Step 7: Return success
-            logger.info("Tool dispatch succeeded: %s", tool_name)
-            self._metrics_increment("tool.success_count", tool_name)
-            self._metrics_observe_duration(
-                "tool.duration_ms", tool_name, (time.monotonic() - dispatch_start) * 1000
-            )
-            _final_result = ToolResult(
-                tool_id=tool_name,
-                success=True,
-                data=validated_output.model_dump(),
-            )
-            return _final_result
+            except Exception as exc:
+                # Catch unexpected exceptions so dispatch() never raises and the
+                # finally block can still emit the tool_call event (AC-A6).
+                _final_result = self._handle_unexpected_error(tool_name, exc)
+                return _final_result
 
-        except Exception as exc:
-            # Catch unexpected exceptions so dispatch() never raises and the
-            # finally block can still emit the tool_call event (AC-A6).
-            _final_result = self._handle_unexpected_error(tool_name, exc)
-            return _final_result
+            finally:
+                # Map ToolResult.success=False → OTel ERROR status (contract § Span 3).
+                if _final_result is not None and not _final_result.success:
+                    span.set_status(Status(StatusCode.ERROR))
+                    if _final_result.error_type is not None:
+                        filtered = filter_metadata({"error_class": _final_result.error_type})
+                        if "error_class" in filtered:
+                            span.set_attribute(ERROR_TYPE, filtered["error_class"])
 
-        finally:
-            # Emit structured tool_call event (AC-A6).
-            if _final_result is not None:
-                _duration_ms = (time.monotonic() - dispatch_start) * 1000
-                self._event_emit_tool_call(
-                    tool_name=tool_name,
-                    success=_final_result.success,
-                    duration_ms=_duration_ms,
-                    error_type=_final_result.error_type,
-                )
+                # Emit structured tool_call event (AC-A6).
+                if _final_result is not None:
+                    _duration_ms = (time.monotonic() - dispatch_start) * 1000
+                    self._event_emit_tool_call(
+                        tool_name=tool_name,
+                        success=_final_result.success,
+                        duration_ms=_duration_ms,
+                        error_type=_final_result.error_type,
+                    )
 
     # ------------------------------------------------------------------
     # Private metrics helpers (fail-safe: never raise)

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -283,7 +283,7 @@ class ToolExecutor:
                     if _final_result.error_type is not None:
                         filtered = filter_metadata({"error_class": _final_result.error_type})
                         if "error_class" in filtered:
-                            span.set_attribute(ERROR_TYPE, filtered["error_class"])
+                            span.set_attribute(ERROR_TYPE, str(filtered["error_class"]))
 
                 # Emit structured tool_call event (AC-A6).
                 if _final_result is not None:

--- a/tests/observability/test_llm_chat_span.py
+++ b/tests/observability/test_llm_chat_span.py
@@ -231,9 +231,7 @@ async def test_chat_span_stop_finish_reason(
     assert GEN_AI_USAGE_OUTPUT_TOKENS in attrs, (
         f"{GEN_AI_USAGE_OUTPUT_TOKENS!r} missing. attrs={attrs}"
     )
-    assert GEN_AI_RESPONSE_MODEL in attrs, (
-        f"{GEN_AI_RESPONSE_MODEL!r} missing. attrs={attrs}"
-    )
+    assert GEN_AI_RESPONSE_MODEL in attrs, f"{GEN_AI_RESPONSE_MODEL!r} missing. attrs={attrs}"
     assert GEN_AI_RESPONSE_FINISH_REASONS in attrs, (
         f"{GEN_AI_RESPONSE_FINISH_REASONS!r} missing. attrs={attrs}"
     )
@@ -242,8 +240,7 @@ async def test_chat_span_stop_finish_reason(
         f"input_tokens mismatch: expected {INPUT_TOKENS}, got {attrs[GEN_AI_USAGE_INPUT_TOKENS]}"
     )
     assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == OUTPUT_TOKENS, (
-        f"output_tokens mismatch: expected {OUTPUT_TOKENS}, "
-        f"got {attrs[GEN_AI_USAGE_OUTPUT_TOKENS]}"
+        f"output_tokens mismatch: expected {OUTPUT_TOKENS}, got {attrs[GEN_AI_USAGE_OUTPUT_TOKENS]}"
     )
     assert attrs[GEN_AI_RESPONSE_MODEL] == RESPONSE_MODEL, (
         f"response_model mismatch: expected {RESPONSE_MODEL!r}, "
@@ -332,13 +329,10 @@ async def test_chat_span_tool_calls_finish_reason(
         f"input_tokens mismatch: expected {INPUT_TOKENS}, got {attrs[GEN_AI_USAGE_INPUT_TOKENS]}"
     )
     assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == OUTPUT_TOKENS, (
-        f"output_tokens mismatch: expected {OUTPUT_TOKENS}, "
-        f"got {attrs[GEN_AI_USAGE_OUTPUT_TOKENS]}"
+        f"output_tokens mismatch: expected {OUTPUT_TOKENS}, got {attrs[GEN_AI_USAGE_OUTPUT_TOKENS]}"
     )
 
     # --- Assert: a tool_call_delta event was emitted ---
     tool_events = [e for e in events if e.type == "tool_call_delta"]
-    assert len(tool_events) == 1, (
-        f"Expected 1 tool_call_delta event, got {len(tool_events)}"
-    )
+    assert len(tool_events) == 1, f"Expected 1 tool_call_delta event, got {len(tool_events)}"
     assert tool_events[0].function_name == "search_traffic"

--- a/tests/observability/test_llm_chat_span.py
+++ b/tests/observability/test_llm_chat_span.py
@@ -1,0 +1,345 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T021 — Tests for the 'chat' span usage aggregation written by LLMClient.stream().
+
+Verifies:
+- Exactly one 'chat' span is exported per stream() call.
+- All 4 T019 usage attributes are present and correct on the span:
+    gen_ai.usage.input_tokens, gen_ai.usage.output_tokens,
+    gen_ai.response.model, gen_ai.response.finish_reasons.
+- Write-once invariant: set_attributes() is called exactly once for the 4 usage
+  keys (via a spy wrapper on the span object produced by the test tracer).
+- Values match the mock's final usage totals.
+
+Strategy:
+- Monkeypatch the module-level ``_tracer`` in ``kosmos.llm.client`` to use a
+  dedicated TracerProvider backed by an InMemorySpanExporter, following the
+  proven pattern from test_tool_execute_span.py.
+- Patch ``LLMClient._stream_with_retry`` to yield a controlled sequence of
+  StreamEvent objects and populate ``_finalize`` deterministically.  This avoids
+  any live HTTP traffic and keeps the test under 2 seconds.
+- A spy wrapper around the real span's ``set_attributes`` method counts how many
+  times each of the 4 usage keys is written, asserting write-once semantics.
+"""
+
+from __future__ import annotations
+
+import os
+from collections import defaultdict
+from collections.abc import AsyncIterator
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from kosmos.llm.models import ChatMessage, StreamEvent, TokenUsage
+from kosmos.observability.semconv import (
+    GEN_AI_RESPONSE_FINISH_REASONS,
+    GEN_AI_RESPONSE_MODEL,
+    GEN_AI_USAGE_INPUT_TOKENS,
+    GEN_AI_USAGE_OUTPUT_TOKENS,
+)
+
+# Usage-attribute keys we track for write-once assertions.
+_USAGE_KEYS = frozenset(
+    [
+        GEN_AI_USAGE_INPUT_TOKENS,
+        GEN_AI_USAGE_OUTPUT_TOKENS,
+        GEN_AI_RESPONSE_MODEL,
+        GEN_AI_RESPONSE_FINISH_REASONS,
+    ]
+)
+
+# Minimal valid env so LLMClientConfig loads without touching the network.
+_FAKE_ENV = {"KOSMOS_FRIENDLI_TOKEN": "test-token-for-unit-tests"}
+
+
+# ---------------------------------------------------------------------------
+# Fixture: per-test InMemorySpanExporter with _tracer monkeypatch
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mem_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    """Patch _tracer in kosmos.llm.client with a dedicated test TracerProvider."""
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    import kosmos.llm.client as client_mod
+
+    monkeypatch.setattr(client_mod, "_tracer", provider.get_tracer("kosmos.llm.client"))
+    exporter.clear()
+    return exporter
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal LLMClient (no real HTTP)
+# ---------------------------------------------------------------------------
+
+
+def _make_client() -> Any:
+    """Create an LLMClient with fake env vars (no network calls)."""
+    from kosmos.llm.client import LLMClient
+    from kosmos.llm.config import LLMClientConfig
+
+    with patch.dict(os.environ, _FAKE_ENV):
+        config = LLMClientConfig()
+
+    return LLMClient(config=config)
+
+
+# ---------------------------------------------------------------------------
+# Helper: mock _stream_with_retry factory
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_stream_with_retry(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    response_model: str,
+    finish_reasons: list[str],
+    extra_events: list[StreamEvent] | None = None,
+) -> Any:
+    """Return a coroutine function that replaces _stream_with_retry.
+
+    It yields ``extra_events`` (defaults to a single content_delta) and then
+    populates ``_finalize`` to simulate a clean EOF, exactly as the real
+    implementation does.
+    """
+
+    async def _fake(
+        self: Any,
+        payload: dict[str, object],
+        _finalize: dict[str, object],
+    ) -> AsyncIterator[StreamEvent]:
+        events = extra_events or [
+            StreamEvent(type="content_delta", content="Hello world."),
+            StreamEvent(
+                type="usage",
+                usage=TokenUsage(input_tokens=input_tokens, output_tokens=output_tokens),
+            ),
+        ]
+        for event in events:
+            # Debit usage into the tracker so input/output_tokens_used are updated.
+            if event.type == "usage" and event.usage is not None:
+                self._usage.debit(event.usage)
+            yield event
+
+        # Populate _finalize exactly as _stream_with_retry does on clean EOF.
+        _finalize["input_tokens"] = self._usage.input_tokens_used
+        _finalize["output_tokens"] = self._usage.output_tokens_used
+        _finalize["response_model"] = response_model
+        _finalize["finish_reasons"] = sorted(finish_reasons)
+
+    return _fake
+
+
+# ---------------------------------------------------------------------------
+# Spy: wrap span.set_attributes to count writes per key
+# ---------------------------------------------------------------------------
+
+
+class _SetAttributesSpy:
+    """Wraps a span's set_attributes to count per-key calls."""
+
+    def __init__(self, span: Any) -> None:
+        self._span = span
+        self.call_count: dict[str, int] = defaultdict(int)
+        self._original = span.set_attributes
+
+    def __call__(self, attributes: dict[str, Any]) -> None:
+        for key in attributes:
+            self.call_count[key] += 1
+        self._original(attributes)
+
+    def install(self) -> None:
+        self._span.set_attributes = self  # type: ignore[method-assign]
+
+
+# ---------------------------------------------------------------------------
+# T021-A: Success path with finish_reason='stop'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_span_stop_finish_reason(
+    mem_exporter: InMemorySpanExporter,
+) -> None:
+    """stream() with finish_reason='stop' must produce exactly one 'chat' span
+    with all 4 usage attributes set exactly once, values matching the mock totals."""
+    INPUT_TOKENS = 42
+    OUTPUT_TOKENS = 17
+    RESPONSE_MODEL = "LGAI-EXAONE/K-EXAONE-236B-A23B"
+    FINISH_REASONS = ["stop"]
+
+    client = _make_client()
+
+    mock_fn = _make_mock_stream_with_retry(
+        input_tokens=INPUT_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+        response_model=RESPONSE_MODEL,
+        finish_reasons=FINISH_REASONS,
+    )
+
+    # Install spy BEFORE stream() is called so the span is captured.
+    # We inject the spy via a custom start_span wrapper that instruments the span
+    # after _tracer.start_span("chat") creates it.
+    import kosmos.llm.client as client_mod
+
+    original_start_span = client_mod._tracer.start_span  # type: ignore[attr-defined]
+    captured_spies: list[_SetAttributesSpy] = []
+
+    def _spy_start_span(name: str, **kwargs: Any) -> Any:
+        span = original_start_span(name, **kwargs)
+        if name == "chat":
+            spy = _SetAttributesSpy(span)
+            spy.install()
+            captured_spies.append(spy)
+        return span
+
+    client_mod._tracer.start_span = _spy_start_span  # type: ignore[method-assign]
+
+    try:
+        with patch.object(type(client), "_stream_with_retry", mock_fn):
+            messages = [ChatMessage(role="user", content="test query")]
+            events: list[StreamEvent] = []
+            async for event in client.stream(messages):
+                events.append(event)
+    finally:
+        # Restore original start_span regardless of test outcome.
+        client_mod._tracer.start_span = original_start_span  # type: ignore[method-assign]
+
+    # --- Assert: exactly one 'chat' span exported ---
+    spans = mem_exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.name == "chat"]
+    assert len(chat_spans) == 1, (
+        f"Expected exactly 1 'chat' span, got {len(chat_spans)}. "
+        f"All spans: {[s.name for s in spans]}"
+    )
+    span = chat_spans[0]
+    attrs = dict(span.attributes or {})
+
+    # --- Assert: all 4 usage attributes present and correct ---
+    assert GEN_AI_USAGE_INPUT_TOKENS in attrs, (
+        f"{GEN_AI_USAGE_INPUT_TOKENS!r} missing. attrs={attrs}"
+    )
+    assert GEN_AI_USAGE_OUTPUT_TOKENS in attrs, (
+        f"{GEN_AI_USAGE_OUTPUT_TOKENS!r} missing. attrs={attrs}"
+    )
+    assert GEN_AI_RESPONSE_MODEL in attrs, (
+        f"{GEN_AI_RESPONSE_MODEL!r} missing. attrs={attrs}"
+    )
+    assert GEN_AI_RESPONSE_FINISH_REASONS in attrs, (
+        f"{GEN_AI_RESPONSE_FINISH_REASONS!r} missing. attrs={attrs}"
+    )
+
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == INPUT_TOKENS, (
+        f"input_tokens mismatch: expected {INPUT_TOKENS}, got {attrs[GEN_AI_USAGE_INPUT_TOKENS]}"
+    )
+    assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == OUTPUT_TOKENS, (
+        f"output_tokens mismatch: expected {OUTPUT_TOKENS}, "
+        f"got {attrs[GEN_AI_USAGE_OUTPUT_TOKENS]}"
+    )
+    assert attrs[GEN_AI_RESPONSE_MODEL] == RESPONSE_MODEL, (
+        f"response_model mismatch: expected {RESPONSE_MODEL!r}, "
+        f"got {attrs[GEN_AI_RESPONSE_MODEL]!r}"
+    )
+    # OTel SDK serialises list attrs as tuples.
+    assert list(attrs[GEN_AI_RESPONSE_FINISH_REASONS]) == FINISH_REASONS, (
+        f"finish_reasons mismatch: expected {FINISH_REASONS}, "
+        f"got {list(attrs[GEN_AI_RESPONSE_FINISH_REASONS])}"
+    )
+
+    # --- Assert: write-once invariant via spy ---
+    assert len(captured_spies) == 1, "Expected spy to be installed on exactly one chat span"
+    spy = captured_spies[0]
+    for key in _USAGE_KEYS:
+        count = spy.call_count.get(key, 0)
+        assert count == 1, (
+            f"Expected usage key {key!r} to be written exactly once, was written {count} times"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T021-B: finish_reason='tool_calls'
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_chat_span_tool_calls_finish_reason(
+    mem_exporter: InMemorySpanExporter,
+) -> None:
+    """stream() with finish_reason='tool_calls' must export a 'chat' span with
+    finish_reasons=['tool_calls'] and correct token counts."""
+    INPUT_TOKENS = 100
+    OUTPUT_TOKENS = 30
+    RESPONSE_MODEL = "LGAI-EXAONE/K-EXAONE-236B-A23B"
+    FINISH_REASONS = ["tool_calls"]
+
+    client = _make_client()
+
+    extra_events = [
+        StreamEvent(
+            type="tool_call_delta",
+            tool_call_index=0,
+            tool_call_id="call-xyz",
+            function_name="search_traffic",
+            function_args_delta='{"road_id": "1"}',
+        ),
+        StreamEvent(
+            type="usage",
+            usage=TokenUsage(input_tokens=INPUT_TOKENS, output_tokens=OUTPUT_TOKENS),
+        ),
+    ]
+
+    mock_fn = _make_mock_stream_with_retry(
+        input_tokens=INPUT_TOKENS,
+        output_tokens=OUTPUT_TOKENS,
+        response_model=RESPONSE_MODEL,
+        finish_reasons=FINISH_REASONS,
+        extra_events=extra_events,
+    )
+
+    with patch.object(type(client), "_stream_with_retry", mock_fn):
+        messages = [ChatMessage(role="user", content="경부고속도로 혼잡 상황 알려줘")]
+        events: list[StreamEvent] = []
+        async for event in client.stream(messages):
+            events.append(event)
+
+    # --- Assert: exactly one 'chat' span ---
+    spans = mem_exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.name == "chat"]
+    assert len(chat_spans) == 1, (
+        f"Expected exactly 1 'chat' span, got {len(chat_spans)}. "
+        f"All spans: {[s.name for s in spans]}"
+    )
+    span = chat_spans[0]
+    attrs = dict(span.attributes or {})
+
+    # --- Assert: finish_reasons=['tool_calls'] ---
+    assert list(attrs[GEN_AI_RESPONSE_FINISH_REASONS]) == FINISH_REASONS, (
+        f"finish_reasons mismatch: expected {FINISH_REASONS}, "
+        f"got {list(attrs[GEN_AI_RESPONSE_FINISH_REASONS])}"
+    )
+
+    # --- Assert: token counts ---
+    assert attrs[GEN_AI_USAGE_INPUT_TOKENS] == INPUT_TOKENS, (
+        f"input_tokens mismatch: expected {INPUT_TOKENS}, got {attrs[GEN_AI_USAGE_INPUT_TOKENS]}"
+    )
+    assert attrs[GEN_AI_USAGE_OUTPUT_TOKENS] == OUTPUT_TOKENS, (
+        f"output_tokens mismatch: expected {OUTPUT_TOKENS}, "
+        f"got {attrs[GEN_AI_USAGE_OUTPUT_TOKENS]}"
+    )
+
+    # --- Assert: a tool_call_delta event was emitted ---
+    tool_events = [e for e in events if e.type == "tool_call_delta"]
+    assert len(tool_events) == 1, (
+        f"Expected 1 tool_call_delta event, got {len(tool_events)}"
+    )
+    assert tool_events[0].function_name == "search_traffic"

--- a/tests/observability/test_llm_chat_span.py
+++ b/tests/observability/test_llm_chat_span.py
@@ -30,7 +30,6 @@ from typing import Any
 from unittest.mock import patch
 
 import pytest
-
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -173,10 +172,10 @@ async def test_chat_span_stop_finish_reason(
 ) -> None:
     """stream() with finish_reason='stop' must produce exactly one 'chat' span
     with all 4 usage attributes set exactly once, values matching the mock totals."""
-    INPUT_TOKENS = 42
-    OUTPUT_TOKENS = 17
-    RESPONSE_MODEL = "LGAI-EXAONE/K-EXAONE-236B-A23B"
-    FINISH_REASONS = ["stop"]
+    INPUT_TOKENS = 42  # noqa: N806
+    OUTPUT_TOKENS = 17  # noqa: N806
+    RESPONSE_MODEL = "LGAI-EXAONE/K-EXAONE-236B-A23B"  # noqa: N806
+    FINISH_REASONS = ["stop"]  # noqa: N806
 
     client = _make_client()
 
@@ -277,10 +276,10 @@ async def test_chat_span_tool_calls_finish_reason(
 ) -> None:
     """stream() with finish_reason='tool_calls' must export a 'chat' span with
     finish_reasons=['tool_calls'] and correct token counts."""
-    INPUT_TOKENS = 100
-    OUTPUT_TOKENS = 30
-    RESPONSE_MODEL = "LGAI-EXAONE/K-EXAONE-236B-A23B"
-    FINISH_REASONS = ["tool_calls"]
+    INPUT_TOKENS = 100  # noqa: N806
+    OUTPUT_TOKENS = 30  # noqa: N806
+    RESPONSE_MODEL = "LGAI-EXAONE/K-EXAONE-236B-A23B"  # noqa: N806
+    FINISH_REASONS = ["tool_calls"]  # noqa: N806
 
     client = _make_client()
 

--- a/tests/observability/test_metrics_collector_unchanged.py
+++ b/tests/observability/test_metrics_collector_unchanged.py
@@ -13,13 +13,11 @@ Guard covers:
 from __future__ import annotations
 
 import inspect
-import os
 from typing import Any
 
 import pytest
 
 from kosmos.observability.metrics import MetricsCollector
-
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -66,7 +64,9 @@ def _snapshot_instance_behavior(mc: MetricsCollector) -> dict[str, Any]:
 
     return {
         "counter": mc.get_counter("test_counter", labels={"tool_id": "guard"}),
-        "histogram_avg": mc.get_histogram_stats("test_histogram", labels={"tool_id": "guard"})["avg"],
+        "histogram_avg": mc.get_histogram_stats(
+            "test_histogram", labels={"tool_id": "guard"}
+        )["avg"],
         "gauge": mc.snapshot()["gauges"]["test_gauge"],
         "snapshot_keys": sorted(mc.snapshot().keys()),
     }
@@ -87,7 +87,7 @@ class TestMetricsCollectorUnchanged:
 
         # Call setup_tracing with SDK disabled (no network, no background thread)
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
@@ -105,7 +105,7 @@ class TestMetricsCollectorUnchanged:
         snapshot_before = _snapshot_api(MetricsCollector)
 
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
@@ -113,7 +113,7 @@ class TestMetricsCollectorUnchanged:
 
         assert snapshot_before["method_signatures"] == snapshot_after["method_signatures"], (
             "MetricsCollector method signatures changed after setup_tracing()! "
-            f"Diff: {set(snapshot_before['method_signatures'].items()) ^ set(snapshot_after['method_signatures'].items())}"
+            f"Diff: {set(snapshot_before['method_signatures'].items()) ^ set(snapshot_after['method_signatures'].items())}"  # noqa: E501
         )
 
     def test_class_level_attrs_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -121,7 +121,7 @@ class TestMetricsCollectorUnchanged:
         snapshot_before = _snapshot_api(MetricsCollector)
 
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
@@ -155,7 +155,7 @@ class TestMetricsCollectorBehaviorUnchanged:
     def test_instance_behavior_after_setup_tracing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """MetricsCollector works identically after OTel has been initialized (no-op mode)."""
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
@@ -173,7 +173,7 @@ class TestMetricsCollectorBehaviorUnchanged:
         behavior_before = _snapshot_instance_behavior(mc_before)
 
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
@@ -190,7 +190,7 @@ class TestMetricsCollectorBehaviorUnchanged:
     ) -> None:
         """reset() must clear all state identically before and after OTel init."""
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 

--- a/tests/observability/test_metrics_collector_unchanged.py
+++ b/tests/observability/test_metrics_collector_unchanged.py
@@ -1,0 +1,205 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guard: MetricsCollector public API must be unchanged after setup_tracing().
+
+This test captures a structural snapshot of MetricsCollector (method names +
+signatures + instance behavior) before and after calling setup_tracing() with
+OTEL_SDK_DISABLED=true. Any accidental monkeypatching of MetricsCollector by
+the OTel layer will cause this test to fail immediately.
+
+Guard covers:
+- T029: MetricsCollector public API invariant
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+from typing import Any
+
+import pytest
+
+from kosmos.observability.metrics import MetricsCollector
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _public_methods(cls: type) -> dict[str, inspect.Signature]:
+    """Return a mapping of public method name -> Signature for *cls*."""
+    return {
+        name: inspect.signature(method)
+        for name, method in inspect.getmembers(cls, predicate=inspect.isfunction)
+        if not name.startswith("_")
+    }
+
+
+def _class_level_attrs(cls: type) -> dict[str, Any]:
+    """Return class-level attributes that are NOT callable and NOT dunder."""
+    return {
+        name: value
+        for name, value in vars(cls).items()
+        if not name.startswith("_") and not callable(value)
+    }
+
+
+def _snapshot_api(cls: type) -> dict[str, Any]:
+    """Capture a full structural snapshot of *cls* public API."""
+    methods = _public_methods(cls)
+    return {
+        "method_names": sorted(methods.keys()),
+        "method_signatures": {name: str(sig) for name, sig in methods.items()},
+        "class_attrs": _class_level_attrs(cls),
+    }
+
+
+def _snapshot_instance_behavior(mc: MetricsCollector) -> dict[str, Any]:
+    """Invoke each public write method with trivial args and return a snapshot.
+
+    This verifies that the *instance* works identically regardless of whether
+    OTel tracing was set up.
+    """
+    mc.increment("test_counter", value=3, labels={"tool_id": "guard"})
+    mc.observe("test_histogram", 42.0, labels={"tool_id": "guard"})
+    mc.set_gauge("test_gauge", 7.5)
+
+    return {
+        "counter": mc.get_counter("test_counter", labels={"tool_id": "guard"}),
+        "histogram_avg": mc.get_histogram_stats("test_histogram", labels={"tool_id": "guard"})["avg"],
+        "gauge": mc.snapshot()["gauges"]["test_gauge"],
+        "snapshot_keys": sorted(mc.snapshot().keys()),
+    }
+
+
+# ---------------------------------------------------------------------------
+# T029: Structural invariant guard
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsCollectorUnchanged:
+    """Assert that setup_tracing() does not alter MetricsCollector's public API."""
+
+    def test_public_method_names_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Public method names on MetricsCollector must be identical before and after OTel init."""
+        # Snapshot BEFORE setup_tracing
+        snapshot_before = _snapshot_api(MetricsCollector)
+
+        # Call setup_tracing with SDK disabled (no network, no background thread)
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        # Snapshot AFTER setup_tracing
+        snapshot_after = _snapshot_api(MetricsCollector)
+
+        assert snapshot_before["method_names"] == snapshot_after["method_names"], (
+            "MetricsCollector public method list changed after setup_tracing()! "
+            f"Before: {snapshot_before['method_names']}  "
+            f"After: {snapshot_after['method_names']}"
+        )
+
+    def test_public_method_signatures_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Method signatures must be byte-identical before and after OTel init."""
+        snapshot_before = _snapshot_api(MetricsCollector)
+
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        snapshot_after = _snapshot_api(MetricsCollector)
+
+        assert snapshot_before["method_signatures"] == snapshot_after["method_signatures"], (
+            "MetricsCollector method signatures changed after setup_tracing()! "
+            f"Diff: {set(snapshot_before['method_signatures'].items()) ^ set(snapshot_after['method_signatures'].items())}"
+        )
+
+    def test_class_level_attrs_unchanged(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Class-level (non-callable) attributes must be unchanged after OTel init."""
+        snapshot_before = _snapshot_api(MetricsCollector)
+
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        snapshot_after = _snapshot_api(MetricsCollector)
+
+        assert snapshot_before["class_attrs"] == snapshot_after["class_attrs"], (
+            "MetricsCollector class-level attributes changed after setup_tracing()! "
+            f"Before: {snapshot_before['class_attrs']}  "
+            f"After: {snapshot_after['class_attrs']}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T029: Instance behavior invariant guard
+# ---------------------------------------------------------------------------
+
+
+class TestMetricsCollectorBehaviorUnchanged:
+    """Verify that MetricsCollector instances behave identically before/after OTel init."""
+
+    def test_instance_behavior_before_setup_tracing(self) -> None:
+        """MetricsCollector works correctly when OTel has NOT been initialized."""
+        mc = MetricsCollector()
+        behavior = _snapshot_instance_behavior(mc)
+
+        assert behavior["counter"] == 3
+        assert behavior["histogram_avg"] == 42.0
+        assert behavior["gauge"] == 7.5
+        assert behavior["snapshot_keys"] == ["counters", "gauges", "histograms"]
+
+    def test_instance_behavior_after_setup_tracing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """MetricsCollector works identically after OTel has been initialized (no-op mode)."""
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        mc = MetricsCollector()
+        behavior = _snapshot_instance_behavior(mc)
+
+        assert behavior["counter"] == 3
+        assert behavior["histogram_avg"] == 42.0
+        assert behavior["gauge"] == 7.5
+        assert behavior["snapshot_keys"] == ["counters", "gauges", "histograms"]
+
+    def test_instance_behavior_is_byte_identical(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Behavior snapshot dict must be equal before and after setup_tracing."""
+        mc_before = MetricsCollector()
+        behavior_before = _snapshot_instance_behavior(mc_before)
+
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        mc_after = MetricsCollector()
+        behavior_after = _snapshot_instance_behavior(mc_after)
+
+        assert behavior_before == behavior_after, (
+            "MetricsCollector instance behavior changed after setup_tracing()! "
+            f"Before: {behavior_before}  After: {behavior_after}"
+        )
+
+    def test_reset_works_identically_after_setup_tracing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """reset() must clear all state identically before and after OTel init."""
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        mc = MetricsCollector()
+        mc.increment("x", value=10)
+        mc.observe("y", 99.0)
+        mc.set_gauge("z", 1.0)
+        mc.reset()
+
+        assert mc.get_counter("x") == 0
+        assert mc.get_histogram_stats("y")["count"] == 0.0
+        assert mc.snapshot() == {"counters": {}, "gauges": {}, "histograms": {}}

--- a/tests/observability/test_metrics_collector_unchanged.py
+++ b/tests/observability/test_metrics_collector_unchanged.py
@@ -64,9 +64,9 @@ def _snapshot_instance_behavior(mc: MetricsCollector) -> dict[str, Any]:
 
     return {
         "counter": mc.get_counter("test_counter", labels={"tool_id": "guard"}),
-        "histogram_avg": mc.get_histogram_stats(
-            "test_histogram", labels={"tool_id": "guard"}
-        )["avg"],
+        "histogram_avg": mc.get_histogram_stats("test_histogram", labels={"tool_id": "guard"})[
+            "avg"
+        ],
         "gauge": mc.snapshot()["gauges"]["test_gauge"],
         "snapshot_keys": sorted(mc.snapshot().keys()),
     }

--- a/tests/observability/test_observability_event_unchanged.py
+++ b/tests/observability/test_observability_event_unchanged.py
@@ -48,9 +48,7 @@ def _event_field_snapshot(cls: type) -> dict[str, Any]:
     fields = cls.model_fields  # type: ignore[attr-defined]
     return {
         "field_names": sorted(fields.keys()),
-        "field_types": {
-            name: str(field.annotation) for name, field in fields.items()
-        },
+        "field_types": {name: str(field.annotation) for name, field in fields.items()},
     }
 
 
@@ -124,9 +122,7 @@ class TestAllowedMetadataKeysConstant:
             f"_ALLOWED_METADATA_KEYS must contain exactly 5 keys, got {len(_ALLOWED_METADATA_KEYS)}"
         )
 
-    def test_whitelist_unchanged_after_setup_tracing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_whitelist_unchanged_after_setup_tracing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """setup_tracing() must not modify _ALLOWED_METADATA_KEYS."""
         snapshot_before = frozenset(_ALLOWED_METADATA_KEYS)
 
@@ -157,17 +153,19 @@ class TestObservabilityEventSchemaUnchanged:
     def test_field_names_present(self) -> None:
         """All expected fields exist on ObservabilityEvent."""
         expected_fields = {
-            "timestamp", "event_type", "tool_id", "duration_ms", "success", "metadata"
+            "timestamp",
+            "event_type",
+            "tool_id",
+            "duration_ms",
+            "success",
+            "metadata",
         }
         actual_fields = set(ObservabilityEvent.model_fields.keys())
         assert expected_fields == actual_fields, (
-            f"ObservabilityEvent field set changed! "
-            f"Expected {expected_fields}, got {actual_fields}"
+            f"ObservabilityEvent field set changed! Expected {expected_fields}, got {actual_fields}"
         )
 
-    def test_schema_unchanged_after_setup_tracing(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_schema_unchanged_after_setup_tracing(self, monkeypatch: pytest.MonkeyPatch) -> None:
         """Field snapshot must be byte-identical before and after setup_tracing()."""
         snapshot_before = _event_field_snapshot(ObservabilityEvent)
 

--- a/tests/observability/test_observability_event_unchanged.py
+++ b/tests/observability/test_observability_event_unchanged.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import inspect
 import json
 import logging
+from datetime import UTC
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -26,7 +27,7 @@ from kosmos.observability.event_logger import (
     _ALLOWED_METADATA_KEYS,
     ObservabilityEventLogger,
 )
-from kosmos.observability.events import ObservabilityEvent, EventType
+from kosmos.observability.events import ObservabilityEvent
 
 # ---------------------------------------------------------------------------
 # Expected whitelist (single source of truth in this guard)
@@ -43,7 +44,6 @@ _EXPECTED_ALLOWED_KEYS: frozenset[str] = frozenset(
 
 def _event_field_snapshot(cls: type) -> dict[str, Any]:
     """Return a snapshot of Pydantic model fields: names and outer type strings."""
-    import pydantic
 
     fields = cls.model_fields  # type: ignore[attr-defined]
     return {
@@ -131,12 +131,14 @@ class TestAllowedMetadataKeysConstant:
         snapshot_before = frozenset(_ALLOWED_METADATA_KEYS)
 
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
         # Re-import to pick up any potential modification
-        from kosmos.observability.event_logger import _ALLOWED_METADATA_KEYS as after_keys
+        from kosmos.observability.event_logger import (
+            _ALLOWED_METADATA_KEYS as after_keys,  # noqa: N811
+        )
 
         assert snapshot_before == frozenset(after_keys), (
             f"_ALLOWED_METADATA_KEYS was modified by setup_tracing()! "
@@ -154,7 +156,9 @@ class TestObservabilityEventSchemaUnchanged:
 
     def test_field_names_present(self) -> None:
         """All expected fields exist on ObservabilityEvent."""
-        expected_fields = {"timestamp", "event_type", "tool_id", "duration_ms", "success", "metadata"}
+        expected_fields = {
+            "timestamp", "event_type", "tool_id", "duration_ms", "success", "metadata"
+        }
         actual_fields = set(ObservabilityEvent.model_fields.keys())
         assert expected_fields == actual_fields, (
             f"ObservabilityEvent field set changed! "
@@ -168,7 +172,7 @@ class TestObservabilityEventSchemaUnchanged:
         snapshot_before = _event_field_snapshot(ObservabilityEvent)
 
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
@@ -182,7 +186,7 @@ class TestObservabilityEventSchemaUnchanged:
     def test_model_is_frozen(self) -> None:
         """ObservabilityEvent must remain frozen (immutable)."""
         event = ObservabilityEvent(event_type="tool_call")
-        with pytest.raises(Exception):
+        with pytest.raises(Exception):  # noqa: B017
             event.success = False  # type: ignore[misc]
 
     def test_default_success_is_true(self) -> None:
@@ -222,7 +226,7 @@ class TestObservabilityEventLoggerSignatureUnchanged:
         sig_before = str(inspect.signature(ObservabilityEventLogger.emit))
 
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 
@@ -299,9 +303,9 @@ class TestMetadataWhitelistEnforcement:
         which is pinned), emit them through the logger, and compare the captured JSON
         strings.  The timestamp is set explicitly to avoid drift.
         """
-        from datetime import datetime, timezone
+        from datetime import datetime
 
-        fixed_ts = datetime(2026, 4, 15, 0, 0, 0, tzinfo=timezone.utc)
+        fixed_ts = datetime(2026, 4, 15, 0, 0, 0, tzinfo=UTC)
 
         def _make_event() -> ObservabilityEvent:
             return ObservabilityEvent(
@@ -343,7 +347,7 @@ class TestMetadataWhitelistEnforcement:
 
         # --- call setup_tracing (no-op) ---
         monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
-        from kosmos.observability.tracing import setup_tracing, TracingSettings
+        from kosmos.observability.tracing import TracingSettings, setup_tracing
 
         setup_tracing(TracingSettings(disabled=True))
 

--- a/tests/observability/test_observability_event_unchanged.py
+++ b/tests/observability/test_observability_event_unchanged.py
@@ -1,0 +1,385 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Regression guard: ObservabilityEvent schema and ObservabilityEventLogger API must
+be unchanged after setup_tracing().
+
+Verifies:
+- ObservabilityEvent Pydantic field names, types, and whitelist constants are stable.
+- ObservabilityEventLogger.emit() signature is unchanged.
+- _ALLOWED_METADATA_KEYS == frozenset({"tool_id", "step", "decision", "error_class", "model"}).
+- Metadata whitelist enforcement produces byte-identical serialization before/after OTel init.
+
+Guard covers:
+- T030: ObservabilityEvent + ObservabilityEventLogger invariant
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+import logging
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from kosmos.observability.event_logger import (
+    _ALLOWED_METADATA_KEYS,
+    ObservabilityEventLogger,
+)
+from kosmos.observability.events import ObservabilityEvent, EventType
+
+# ---------------------------------------------------------------------------
+# Expected whitelist (single source of truth in this guard)
+# ---------------------------------------------------------------------------
+
+_EXPECTED_ALLOWED_KEYS: frozenset[str] = frozenset(
+    {"tool_id", "step", "decision", "error_class", "model"}
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _event_field_snapshot(cls: type) -> dict[str, Any]:
+    """Return a snapshot of Pydantic model fields: names and outer type strings."""
+    import pydantic
+
+    fields = cls.model_fields  # type: ignore[attr-defined]
+    return {
+        "field_names": sorted(fields.keys()),
+        "field_types": {
+            name: str(field.annotation) for name, field in fields.items()
+        },
+    }
+
+
+def _emit_with_mixed_metadata(
+    logger: ObservabilityEventLogger,
+) -> tuple[ObservabilityEvent, str]:
+    """Construct an event with both whitelisted and non-whitelisted metadata keys.
+
+    Pass it through emit() using a capturing handler, and return the (clean)
+    event and its JSON serialization as captured by the handler.
+    """
+    captured: list[str] = []
+
+    class _Handler(logging.Handler):
+        def emit(self, record: logging.LogRecord) -> None:
+            captured.append(record.getMessage())
+
+    backing_logger = logging.getLogger("kosmos.events.test_guard")
+    backing_logger.setLevel(logging.DEBUG)
+    handler = _Handler()
+    backing_logger.addHandler(handler)
+
+    try:
+        event = ObservabilityEvent(
+            event_type="tool_call",
+            tool_id="koroad_guard",
+            success=True,
+            metadata={
+                # whitelisted keys
+                "tool_id": "koroad_guard",
+                "step": "1",
+                "decision": "allow",
+                "error_class": "none",
+                "model": "k-exaone-3.5",
+                # non-whitelisted keys — must be stripped
+                "user_phone": "010-1234-5678",
+                "ip_address": "192.168.1.1",
+                "session_cookie": "secret-token",
+            },
+        )
+        oel = ObservabilityEventLogger(logger=backing_logger)
+        oel.emit(event)
+    finally:
+        backing_logger.removeHandler(handler)
+
+    assert len(captured) == 1, f"Expected exactly 1 log message, got {len(captured)}"
+    return event, captured[0]
+
+
+# ---------------------------------------------------------------------------
+# T030-A: Whitelist constant guard
+# ---------------------------------------------------------------------------
+
+
+class TestAllowedMetadataKeysConstant:
+    """_ALLOWED_METADATA_KEYS must equal the expected frozenset exactly."""
+
+    def test_whitelist_exact_equality(self) -> None:
+        assert _ALLOWED_METADATA_KEYS == _EXPECTED_ALLOWED_KEYS, (
+            f"_ALLOWED_METADATA_KEYS changed! "
+            f"Expected {_EXPECTED_ALLOWED_KEYS}, got {_ALLOWED_METADATA_KEYS}"
+        )
+
+    def test_whitelist_is_frozenset(self) -> None:
+        assert isinstance(_ALLOWED_METADATA_KEYS, frozenset), (
+            f"_ALLOWED_METADATA_KEYS must be a frozenset, got {type(_ALLOWED_METADATA_KEYS)}"
+        )
+
+    def test_whitelist_size(self) -> None:
+        assert len(_ALLOWED_METADATA_KEYS) == 5, (
+            f"_ALLOWED_METADATA_KEYS must contain exactly 5 keys, got {len(_ALLOWED_METADATA_KEYS)}"
+        )
+
+    def test_whitelist_unchanged_after_setup_tracing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """setup_tracing() must not modify _ALLOWED_METADATA_KEYS."""
+        snapshot_before = frozenset(_ALLOWED_METADATA_KEYS)
+
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        # Re-import to pick up any potential modification
+        from kosmos.observability.event_logger import _ALLOWED_METADATA_KEYS as after_keys
+
+        assert snapshot_before == frozenset(after_keys), (
+            f"_ALLOWED_METADATA_KEYS was modified by setup_tracing()! "
+            f"Before: {snapshot_before}  After: {frozenset(after_keys)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T030-B: ObservabilityEvent schema guard
+# ---------------------------------------------------------------------------
+
+
+class TestObservabilityEventSchemaUnchanged:
+    """Pydantic field names and types must be identical before/after OTel init."""
+
+    def test_field_names_present(self) -> None:
+        """All expected fields exist on ObservabilityEvent."""
+        expected_fields = {"timestamp", "event_type", "tool_id", "duration_ms", "success", "metadata"}
+        actual_fields = set(ObservabilityEvent.model_fields.keys())
+        assert expected_fields == actual_fields, (
+            f"ObservabilityEvent field set changed! "
+            f"Expected {expected_fields}, got {actual_fields}"
+        )
+
+    def test_schema_unchanged_after_setup_tracing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Field snapshot must be byte-identical before and after setup_tracing()."""
+        snapshot_before = _event_field_snapshot(ObservabilityEvent)
+
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        snapshot_after = _event_field_snapshot(ObservabilityEvent)
+
+        assert snapshot_before == snapshot_after, (
+            f"ObservabilityEvent schema changed after setup_tracing()! "
+            f"Before: {snapshot_before}  After: {snapshot_after}"
+        )
+
+    def test_model_is_frozen(self) -> None:
+        """ObservabilityEvent must remain frozen (immutable)."""
+        event = ObservabilityEvent(event_type="tool_call")
+        with pytest.raises(Exception):
+            event.success = False  # type: ignore[misc]
+
+    def test_default_success_is_true(self) -> None:
+        event = ObservabilityEvent(event_type="tool_call")
+        assert event.success is True
+
+    def test_metadata_defaults_to_empty_dict(self) -> None:
+        event = ObservabilityEvent(event_type="llm_call")
+        assert event.metadata == {}
+
+
+# ---------------------------------------------------------------------------
+# T030-C: ObservabilityEventLogger.emit signature guard
+# ---------------------------------------------------------------------------
+
+
+class TestObservabilityEventLoggerSignatureUnchanged:
+    """ObservabilityEventLogger.emit() signature must be unchanged."""
+
+    def test_emit_method_exists(self) -> None:
+        assert hasattr(ObservabilityEventLogger, "emit"), (
+            "ObservabilityEventLogger.emit() method is missing!"
+        )
+
+    def test_emit_signature(self) -> None:
+        sig = inspect.signature(ObservabilityEventLogger.emit)
+        params = list(sig.parameters.keys())
+        # Must have 'self' and 'event' — no more, no less
+        assert params == ["self", "event"], (
+            f"ObservabilityEventLogger.emit signature changed! "
+            f"Expected ['self', 'event'], got {params}"
+        )
+
+    def test_emit_signature_unchanged_after_setup_tracing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sig_before = str(inspect.signature(ObservabilityEventLogger.emit))
+
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        sig_after = str(inspect.signature(ObservabilityEventLogger.emit))
+
+        assert sig_before == sig_after, (
+            f"ObservabilityEventLogger.emit signature changed after setup_tracing()! "
+            f"Before: {sig_before}  After: {sig_after}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T030-D: Metadata whitelist enforcement — before/after byte-identical
+# ---------------------------------------------------------------------------
+
+
+class TestMetadataWhitelistEnforcement:
+    """Metadata whitelist strip behavior must produce byte-identical JSON before/after OTel init."""
+
+    def test_whitelist_strips_non_allowed_keys(self) -> None:
+        """Non-whitelisted keys are removed from emitted metadata."""
+        mock_log = MagicMock()
+        oel = ObservabilityEventLogger(logger=mock_log)
+
+        event = ObservabilityEvent(
+            event_type="tool_call",
+            metadata={
+                "tool_id": "koroad",
+                "user_ip": "192.168.1.1",
+                "phone": "010-0000-0000",
+            },
+        )
+        oel.emit(event)
+
+        log_json = mock_log.log.call_args[0][1]
+        parsed = json.loads(log_json)
+
+        assert "tool_id" in parsed["metadata"]
+        assert "user_ip" not in parsed["metadata"]
+        assert "phone" not in parsed["metadata"]
+
+    def test_whitelist_retains_all_allowed_keys(self) -> None:
+        """All five whitelisted keys pass through unchanged."""
+        mock_log = MagicMock()
+        oel = ObservabilityEventLogger(logger=mock_log)
+
+        event = ObservabilityEvent(
+            event_type="llm_call",
+            metadata={
+                "tool_id": "t1",
+                "step": "2",
+                "decision": "allow",
+                "error_class": "none",
+                "model": "k-exaone",
+            },
+        )
+        oel.emit(event)
+
+        log_json = mock_log.log.call_args[0][1]
+        parsed = json.loads(log_json)
+
+        assert parsed["metadata"]["tool_id"] == "t1"
+        assert parsed["metadata"]["step"] == "2"
+        assert parsed["metadata"]["decision"] == "allow"
+        assert parsed["metadata"]["error_class"] == "none"
+        assert parsed["metadata"]["model"] == "k-exaone"
+
+    def test_serialization_byte_identical_before_after_setup_tracing(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """model_dump_json() output for equivalent events must be identical before/after OTel init.
+
+        Strategy: construct two events with the same field values (except timestamp,
+        which is pinned), emit them through the logger, and compare the captured JSON
+        strings.  The timestamp is set explicitly to avoid drift.
+        """
+        from datetime import datetime, timezone
+
+        fixed_ts = datetime(2026, 4, 15, 0, 0, 0, tzinfo=timezone.utc)
+
+        def _make_event() -> ObservabilityEvent:
+            return ObservabilityEvent(
+                timestamp=fixed_ts,
+                event_type="tool_call",
+                tool_id="koroad_guard",
+                success=True,
+                duration_ms=10.0,
+                metadata={
+                    "tool_id": "koroad_guard",
+                    "step": "1",
+                    "decision": "allow",
+                    "error_class": "none",
+                    "model": "k-exaone",
+                    # non-whitelisted — will be stripped
+                    "raw_user_input": "서울 교통사고",
+                },
+            )
+
+        captured_before: list[str] = []
+        captured_after: list[str] = []
+
+        # --- BEFORE setup_tracing ---
+        class _BeforeHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                # Capture only the structured event JSON (INFO level), not the
+                # PII-warning message (WARNING level) that precedes it.
+                if record.levelno == logging.INFO:
+                    captured_before.append(record.getMessage())
+
+        before_logger = logging.getLogger("kosmos.events.before_guard")
+        before_logger.setLevel(logging.DEBUG)
+        h_before = _BeforeHandler()
+        before_logger.addHandler(h_before)
+        try:
+            ObservabilityEventLogger(logger=before_logger).emit(_make_event())
+        finally:
+            before_logger.removeHandler(h_before)
+
+        # --- call setup_tracing (no-op) ---
+        monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+        from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+        setup_tracing(TracingSettings(disabled=True))
+
+        # --- AFTER setup_tracing ---
+        class _AfterHandler(logging.Handler):
+            def emit(self, record: logging.LogRecord) -> None:
+                # Same: capture only the structured event JSON at INFO level.
+                if record.levelno == logging.INFO:
+                    captured_after.append(record.getMessage())
+
+        after_logger = logging.getLogger("kosmos.events.after_guard")
+        after_logger.setLevel(logging.DEBUG)
+        h_after = _AfterHandler()
+        after_logger.addHandler(h_after)
+        try:
+            ObservabilityEventLogger(logger=after_logger).emit(_make_event())
+        finally:
+            after_logger.removeHandler(h_after)
+
+        assert len(captured_before) == 1, (
+            f"Expected 1 INFO event log, got {len(captured_before)}: {captured_before}"
+        )
+        assert len(captured_after) == 1, (
+            f"Expected 1 INFO event log, got {len(captured_after)}: {captured_after}"
+        )
+
+        json_before = json.loads(captured_before[0])
+        json_after = json.loads(captured_after[0])
+
+        # raw_user_input must be stripped in both
+        assert "raw_user_input" not in json_before["metadata"]
+        assert "raw_user_input" not in json_after["metadata"]
+
+        # The two JSON outputs must be structurally identical
+        assert json_before == json_after, (
+            f"JSON serialization changed after setup_tracing()!\n"
+            f"Before: {captured_before[0]}\n"
+            f"After:  {captured_after[0]}"
+        )

--- a/tests/observability/test_otel_bridge_pii.py
+++ b/tests/observability/test_otel_bridge_pii.py
@@ -49,9 +49,7 @@ def test_filter_metadata_output_keys_match_whitelist_intersection() -> None:
     result = filter_metadata(_RAW)
 
     expected = _ALLOWED_METADATA_KEYS & _RAW.keys()
-    assert set(result.keys()) == expected, (
-        f"Expected keys {expected}, got {set(result.keys())}"
-    )
+    assert set(result.keys()) == expected, f"Expected keys {expected}, got {set(result.keys())}"
     assert set(result.keys()) == _EXPECTED_KEYS
 
 
@@ -111,9 +109,7 @@ def test_filter_metadata_drops_dict_value_for_whitelisted_key() -> None:
         "step": 2,
     }
     result = filter_metadata(raw)
-    assert "tool_id" not in result, (
-        "Dict value under whitelisted key must be dropped"
-    )
+    assert "tool_id" not in result, "Dict value under whitelisted key must be dropped"
     assert result.get("step") == 2
 
 
@@ -128,9 +124,7 @@ def test_filter_metadata_drops_object_value() -> None:
         "model": "K-EXAONE",
     }
     result = filter_metadata(raw)
-    assert "tool_id" not in result, (
-        "Object value under whitelisted key must be dropped"
-    )
+    assert "tool_id" not in result, "Object value under whitelisted key must be dropped"
     assert result.get("model") == "K-EXAONE"
 
 
@@ -141,9 +135,7 @@ def test_filter_metadata_drops_list_of_mixed_types() -> None:
         "step": 3,
     }
     result = filter_metadata(raw)
-    assert "tool_id" not in result, (
-        "Mixed-type list under whitelisted key must be dropped"
-    )
+    assert "tool_id" not in result, "Mixed-type list under whitelisted key must be dropped"
     assert result.get("step") == 3
 
 
@@ -154,9 +146,7 @@ def test_filter_metadata_accepts_homogeneous_primitive_list() -> None:
         "step": 1,
     }
     result = filter_metadata(raw)
-    assert result.get("tool_id") == ["a", "b", "c"], (
-        "Homogeneous primitive list must pass through"
-    )
+    assert result.get("tool_id") == ["a", "b", "c"], "Homogeneous primitive list must pass through"
 
 
 # ---------------------------------------------------------------------------
@@ -169,9 +159,7 @@ def test_filter_metadata_full_reference_input() -> None:
     result = filter_metadata(_RAW)
 
     assert result == _EXPECTED_VALUES, (
-        f"filter_metadata output mismatch.\n"
-        f"Expected: {_EXPECTED_VALUES}\n"
-        f"Got:      {result}"
+        f"filter_metadata output mismatch.\nExpected: {_EXPECTED_VALUES}\nGot:      {result}"
     )
 
 
@@ -194,9 +182,7 @@ def test_filter_metadata_all_pii_input() -> None:
         "ssn": "900101-1234567",
     }
     result = filter_metadata(raw)
-    assert result == {}, (
-        f"Expected empty output for all-PII input, got: {result}"
-    )
+    assert result == {}, f"Expected empty output for all-PII input, got: {result}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/observability/test_otel_bridge_pii.py
+++ b/tests/observability/test_otel_bridge_pii.py
@@ -11,11 +11,8 @@ Verifies:
 
 from __future__ import annotations
 
-import pytest
-
-from kosmos.observability.otel_bridge import filter_metadata
 from kosmos.observability.event_logger import _ALLOWED_METADATA_KEYS
-
+from kosmos.observability.otel_bridge import filter_metadata
 
 # ---------------------------------------------------------------------------
 # Reference input from task spec

--- a/tests/observability/test_otel_bridge_pii.py
+++ b/tests/observability/test_otel_bridge_pii.py
@@ -1,0 +1,225 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T015 — Unit tests for filter_metadata() PII prefilter in otel_bridge.py.
+
+Verifies:
+- Only whitelisted keys pass through.
+- PII keys (user_input, pii_email, payload) are dropped.
+- Values are preserved exactly for whitelisted keys.
+- Non-primitive values (dict, object) are dropped even if key is whitelisted.
+- Output keys == _ALLOWED_METADATA_KEYS ∩ raw.keys().
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from kosmos.observability.otel_bridge import filter_metadata
+from kosmos.observability.event_logger import _ALLOWED_METADATA_KEYS
+
+
+# ---------------------------------------------------------------------------
+# Reference input from task spec
+# ---------------------------------------------------------------------------
+
+_RAW: dict[str, object] = {
+    "tool_id": "koroad_accident_search",
+    "step": 1,
+    "decision": "call",
+    "user_input": "홍길동 010-1234-5678",
+    "pii_email": "a@b.com",
+    "model": "K-EXAONE",
+    "payload": {"deep": "nested"},
+    "error_class": "TimeoutError",
+}
+
+_EXPECTED_KEYS = {"tool_id", "step", "decision", "model", "error_class"}
+_EXPECTED_VALUES = {
+    "tool_id": "koroad_accident_search",
+    "step": 1,
+    "decision": "call",
+    "model": "K-EXAONE",
+    "error_class": "TimeoutError",
+}
+
+
+# ---------------------------------------------------------------------------
+# T015-A: Output keys == whitelist ∩ raw.keys()
+# ---------------------------------------------------------------------------
+
+
+def test_filter_metadata_output_keys_match_whitelist_intersection() -> None:
+    """Output keys must equal _ALLOWED_METADATA_KEYS ∩ raw.keys()."""
+    result = filter_metadata(_RAW)
+
+    expected = _ALLOWED_METADATA_KEYS & _RAW.keys()
+    assert set(result.keys()) == expected, (
+        f"Expected keys {expected}, got {set(result.keys())}"
+    )
+    assert set(result.keys()) == _EXPECTED_KEYS
+
+
+# ---------------------------------------------------------------------------
+# T015-B: PII keys are dropped
+# ---------------------------------------------------------------------------
+
+
+def test_filter_metadata_drops_user_input() -> None:
+    """'user_input' must be dropped (not in whitelist)."""
+    result = filter_metadata(_RAW)
+    assert "user_input" not in result, (
+        f"'user_input' must not appear in filtered output. Got keys: {set(result.keys())}"
+    )
+
+
+def test_filter_metadata_drops_pii_email() -> None:
+    """'pii_email' must be dropped (not in whitelist)."""
+    result = filter_metadata(_RAW)
+    assert "pii_email" not in result, (
+        f"'pii_email' must not appear in filtered output. Got keys: {set(result.keys())}"
+    )
+
+
+def test_filter_metadata_drops_payload() -> None:
+    """'payload' (nested dict) must be dropped (not in whitelist + non-primitive)."""
+    result = filter_metadata(_RAW)
+    assert "payload" not in result, (
+        f"'payload' must not appear in filtered output. Got keys: {set(result.keys())}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T015-C: Values preserved exactly for whitelisted keys
+# ---------------------------------------------------------------------------
+
+
+def test_filter_metadata_preserves_whitelisted_values() -> None:
+    """Whitelisted primitive values must be preserved unchanged."""
+    result = filter_metadata(_RAW)
+    for key, expected_val in _EXPECTED_VALUES.items():
+        assert key in result, f"Expected key {key!r} in result"
+        assert result[key] == expected_val, (
+            f"Value mismatch for {key!r}: expected {expected_val!r}, got {result[key]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T015-D: Non-primitive values are dropped even when key is whitelisted
+# ---------------------------------------------------------------------------
+
+
+def test_filter_metadata_drops_dict_value_for_whitelisted_key() -> None:
+    """A whitelisted key with a dict value must be dropped (non-primitive)."""
+    raw = {
+        "tool_id": {"nested": "oops"},  # whitelisted key, non-primitive value
+        "step": 2,
+    }
+    result = filter_metadata(raw)
+    assert "tool_id" not in result, (
+        "Dict value under whitelisted key must be dropped"
+    )
+    assert result.get("step") == 2
+
+
+def test_filter_metadata_drops_object_value() -> None:
+    """A whitelisted key with an arbitrary object value must be dropped."""
+
+    class _Opaque:
+        pass
+
+    raw: dict[str, object] = {
+        "tool_id": _Opaque(),  # non-primitive
+        "model": "K-EXAONE",
+    }
+    result = filter_metadata(raw)
+    assert "tool_id" not in result, (
+        "Object value under whitelisted key must be dropped"
+    )
+    assert result.get("model") == "K-EXAONE"
+
+
+def test_filter_metadata_drops_list_of_mixed_types() -> None:
+    """A list containing non-primitives must be dropped."""
+    raw: dict[str, object] = {
+        "tool_id": ["koroad", {"bad": True}],  # mixed list → drop
+        "step": 3,
+    }
+    result = filter_metadata(raw)
+    assert "tool_id" not in result, (
+        "Mixed-type list under whitelisted key must be dropped"
+    )
+    assert result.get("step") == 3
+
+
+def test_filter_metadata_accepts_homogeneous_primitive_list() -> None:
+    """A homogeneous list of primitives under a whitelisted key is accepted."""
+    raw: dict[str, object] = {
+        "tool_id": ["a", "b", "c"],  # homogeneous str list → allowed
+        "step": 1,
+    }
+    result = filter_metadata(raw)
+    assert result.get("tool_id") == ["a", "b", "c"], (
+        "Homogeneous primitive list must pass through"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T015-E: Full reference input — exact equality check
+# ---------------------------------------------------------------------------
+
+
+def test_filter_metadata_full_reference_input() -> None:
+    """Full reference input from spec: output matches expected exactly."""
+    result = filter_metadata(_RAW)
+
+    assert result == _EXPECTED_VALUES, (
+        f"filter_metadata output mismatch.\n"
+        f"Expected: {_EXPECTED_VALUES}\n"
+        f"Got:      {result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T015-F: Empty input / all-PII input → empty output
+# ---------------------------------------------------------------------------
+
+
+def test_filter_metadata_empty_input() -> None:
+    """Empty dict input must produce empty dict output."""
+    assert filter_metadata({}) == {}
+
+
+def test_filter_metadata_all_pii_input() -> None:
+    """Dict with only non-whitelisted keys must produce empty output."""
+    raw: dict[str, object] = {
+        "user_name": "홍길동",
+        "phone": "010-1234-5678",
+        "email": "user@example.com",
+        "ssn": "900101-1234567",
+    }
+    result = filter_metadata(raw)
+    assert result == {}, (
+        f"Expected empty output for all-PII input, got: {result}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T015-G: All whitelisted primitives pass through
+# ---------------------------------------------------------------------------
+
+
+def test_filter_metadata_all_allowed_primitives() -> None:
+    """All _ALLOWED_METADATA_KEYS with primitive values must pass through."""
+    raw: dict[str, object] = {
+        "tool_id": "koroad_accident",
+        "step": 5,
+        "decision": "allow",
+        "error_class": "TimeoutError",
+        "model": "K-EXAONE",
+    }
+    result = filter_metadata(raw)
+    assert set(result.keys()) == _ALLOWED_METADATA_KEYS
+    assert result["tool_id"] == "koroad_accident"
+    assert result["step"] == 5
+    assert result["decision"] == "allow"
+    assert result["error_class"] == "TimeoutError"
+    assert result["model"] == "K-EXAONE"

--- a/tests/observability/test_otel_sdk_disabled.py
+++ b/tests/observability/test_otel_sdk_disabled.py
@@ -1,0 +1,137 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests verifying that OTEL_SDK_DISABLED=true produces a fully no-op tracer.
+
+Acceptance criteria (spec 021 / T017):
+- setup_tracing() returns a provider whose tracer yields non-recording spans.
+- No BatchSpanProcessor is registered (provider is NoOpTracerProvider).
+- Zero OTLP-shaped HTTP calls are made when spans are created/ended.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from opentelemetry import trace as otel_trace
+from opentelemetry.trace import NoOpTracerProvider
+
+from kosmos.observability.tracing import _settings_from_env, setup_tracing, TracingSettings
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _noop_settings() -> TracingSettings:
+    """Return a settings object that explicitly disables the SDK."""
+    return TracingSettings(disabled=True)
+
+
+# ---------------------------------------------------------------------------
+# T017-A: returned provider is NoOpTracerProvider; spans are non-recording
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_disabled_returns_noop_provider(monkeypatch: pytest.MonkeyPatch) -> None:
+    """setup_tracing() with disabled=True must return a NoOpTracerProvider."""
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    provider = setup_tracing(_noop_settings())
+
+    assert isinstance(provider, NoOpTracerProvider)
+
+
+def test_sdk_disabled_spans_are_non_recording(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Spans produced by the no-op provider must report is_recording() == False."""
+    provider = setup_tracing(_noop_settings())
+
+    tracer = provider.get_tracer("test-tracer")
+    with tracer.start_as_current_span("test-op") as span:
+        assert span.is_recording() is False
+
+
+def test_sdk_disabled_get_tracer_shorthand(monkeypatch: pytest.MonkeyPatch) -> None:
+    """After setup_tracing(disabled) the global tracer also yields non-recording spans."""
+    setup_tracing(_noop_settings())
+
+    tracer = otel_trace.get_tracer("x")
+    with tracer.start_as_current_span("y") as span:
+        assert span.is_recording() is False
+
+
+# ---------------------------------------------------------------------------
+# T017-B: no BatchSpanProcessor registered
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_disabled_no_batch_processor() -> None:
+    """NoOpTracerProvider must not have any active span processor."""
+    provider = setup_tracing(_noop_settings())
+
+    # NoOpTracerProvider has no _active_span_processor attribute — that is the
+    # cleanest indicator that no BatchSpanProcessor was registered.
+    # We verify by asserting the returned type directly.
+    assert isinstance(provider, NoOpTracerProvider), (
+        "Expected NoOpTracerProvider (no BatchSpanProcessor path taken); "
+        f"got {type(provider)!r}"
+    )
+    # Additionally confirm the SDK TracerProvider subclass was NOT used.
+    from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider
+
+    assert not isinstance(provider, SDKTracerProvider)
+
+
+# ---------------------------------------------------------------------------
+# T017-C: zero OTLP HTTP calls during span operations
+# ---------------------------------------------------------------------------
+
+
+def test_sdk_disabled_no_otlp_http_calls() -> None:
+    """Span creation/end with no-op provider must not trigger any HTTP activity."""
+    http_post_calls: list[tuple[object, ...]] = []
+
+    mock_post = MagicMock(side_effect=lambda *a, **kw: http_post_calls.append((a, kw)))
+
+    with (
+        patch("httpx.post", mock_post),
+        patch("httpx.Client.post", mock_post),
+    ):
+        provider = setup_tracing(_noop_settings())
+        tracer = provider.get_tracer("kosmos")
+
+        with tracer.start_as_current_span("chat") as span:
+            # Simulate attribute setting — would trigger export in real provider
+            if span.is_recording():
+                span.set_attribute("gen_ai.operation.name", "chat")
+
+    assert len(http_post_calls) == 0, (
+        f"Expected zero HTTP POST calls; got {len(http_post_calls)}: {http_post_calls}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T017-D: _settings_from_env reads OTEL_SDK_DISABLED correctly
+# ---------------------------------------------------------------------------
+
+
+def test_settings_from_env_disabled_true(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_settings_from_env() must set disabled=True when OTEL_SDK_DISABLED=true."""
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    settings = _settings_from_env()
+
+    assert settings.disabled is True
+
+
+def test_settings_from_env_disabled_false_by_default(monkeypatch: pytest.MonkeyPatch) -> None:
+    """_settings_from_env() must set disabled=False when OTEL_SDK_DISABLED is absent."""
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+
+    settings = _settings_from_env()
+
+    assert settings.disabled is False

--- a/tests/observability/test_otel_sdk_disabled.py
+++ b/tests/observability/test_otel_sdk_disabled.py
@@ -73,8 +73,7 @@ def test_sdk_disabled_no_batch_processor() -> None:
     # cleanest indicator that no BatchSpanProcessor was registered.
     # We verify by asserting the returned type directly.
     assert isinstance(provider, NoOpTracerProvider), (
-        "Expected NoOpTracerProvider (no BatchSpanProcessor path taken); "
-        f"got {type(provider)!r}"
+        f"Expected NoOpTracerProvider (no BatchSpanProcessor path taken); got {type(provider)!r}"
     )
     # Additionally confirm the SDK TracerProvider subclass was NOT used.
     from opentelemetry.sdk.trace import TracerProvider as SDKTracerProvider

--- a/tests/observability/test_otel_sdk_disabled.py
+++ b/tests/observability/test_otel_sdk_disabled.py
@@ -12,12 +12,10 @@ from __future__ import annotations
 from unittest.mock import MagicMock, patch
 
 import pytest
-
 from opentelemetry import trace as otel_trace
 from opentelemetry.trace import NoOpTracerProvider
 
-from kosmos.observability.tracing import _settings_from_env, setup_tracing, TracingSettings
-
+from kosmos.observability.tracing import TracingSettings, _settings_from_env, setup_tracing
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/observability/test_query_parent_span.py
+++ b/tests/observability/test_query_parent_span.py
@@ -18,11 +18,9 @@ the global provider.
 from __future__ import annotations
 
 import json
-from typing import AsyncIterator
 from unittest.mock import MagicMock
 
 import pytest
-
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
@@ -38,7 +36,6 @@ from kosmos.permissions.models import SessionContext
 from kosmos.tools.executor import ToolExecutor
 from kosmos.tools.models import GovAPITool
 from kosmos.tools.registry import ToolRegistry
-
 
 # ---------------------------------------------------------------------------
 # Per-test InMemorySpanExporter fixture using dedicated TracerProvider
@@ -140,8 +137,8 @@ async def test_query_produces_root_span_with_correct_attributes(
     # Import after monkeypatch so _tracer is already patched.
     from kosmos.engine.query import query
 
-    TOOL_ID = "dummy_tool"
-    SESSION_ID = "test-uuid"
+    TOOL_ID = "dummy_tool"  # noqa: N806
+    SESSION_ID = "test-uuid"  # noqa: N806
 
     registry = _make_registry_with_tool(TOOL_ID)
     executor = _make_executor(registry, TOOL_ID)

--- a/tests/observability/test_query_parent_span.py
+++ b/tests/observability/test_query_parent_span.py
@@ -223,9 +223,7 @@ async def test_query_produces_root_span_with_correct_attributes(
     assert attrs.get("gen_ai.operation.name") == "invoke_agent", (
         f"gen_ai.operation.name mismatch: {attrs}"
     )
-    assert attrs.get("gen_ai.agent.name") == "kosmos-query", (
-        f"gen_ai.agent.name mismatch: {attrs}"
-    )
+    assert attrs.get("gen_ai.agent.name") == "kosmos-query", f"gen_ai.agent.name mismatch: {attrs}"
     assert attrs.get("gen_ai.conversation.id") == SESSION_ID, (
         f"gen_ai.conversation.id mismatch: {attrs}"
     )
@@ -237,9 +235,7 @@ async def test_query_produces_root_span_with_correct_attributes(
 
     # --- Assert: at least one 'chat' child span ---
     chat_spans = [s for s in spans if s.name == "chat"]
-    assert len(chat_spans) >= 1, (
-        f"Expected at least one 'chat' child span. All spans: {span_names}"
-    )
+    assert len(chat_spans) >= 1, f"Expected at least one 'chat' child span. All spans: {span_names}"
 
     # --- Assert: at least one 'execute_tool *' child span ---
     tool_spans = [s for s in spans if s.name.startswith("execute_tool")]
@@ -250,9 +246,7 @@ async def test_query_produces_root_span_with_correct_attributes(
     # --- Assert: execute_tool spans have root as parent ---
     root_span_id = root.context.span_id
     for child_span in tool_spans:
-        parent_id = (
-            child_span.parent.span_id if child_span.parent is not None else None
-        )
+        parent_id = child_span.parent.span_id if child_span.parent is not None else None
         assert parent_id == root_span_id, (
             f"Span '{child_span.name}' has parent_id {parent_id}, "
             f"expected root span_id {root_span_id}"

--- a/tests/observability/test_query_parent_span.py
+++ b/tests/observability/test_query_parent_span.py
@@ -1,0 +1,262 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T013 — Tests for the root OTel span produced by query().
+
+Verifies:
+- Exactly one root span named 'invoke_agent kosmos-query'.
+- Root span attributes: gen_ai.operation.name, gen_ai.agent.name,
+  gen_ai.conversation.id.
+- At least one 'chat' child span and one 'execute_tool *' child span.
+- Root span status is UNSET on success.
+
+Strategy: Instead of calling trace.set_tracer_provider() (which may be blocked
+by SDK singleton guard), we monkeypatch the module-level _tracer objects in
+query.py, client.py, and executor.py to use a dedicated TracerProvider backed
+by an InMemorySpanExporter. This gives us full span capture without touching
+the global provider.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import AsyncIterator
+from unittest.mock import MagicMock
+
+import pytest
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+from pydantic import BaseModel
+
+from kosmos.engine.config import QueryEngineConfig
+from kosmos.engine.models import QueryContext, QueryState
+from kosmos.llm.client import LLMClient
+from kosmos.llm.models import StreamEvent, TokenUsage
+from kosmos.llm.usage import UsageTracker
+from kosmos.permissions.models import SessionContext
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Per-test InMemorySpanExporter fixture using dedicated TracerProvider
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def memory_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    """Patch _tracer in query, client, and executor modules with a test provider."""
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    import kosmos.engine.query as query_mod
+    import kosmos.tools.executor as executor_mod
+
+    # Patch the module-level _tracer in each instrumented module.
+    monkeypatch.setattr(query_mod, "_tracer", provider.get_tracer("kosmos.engine.query"))
+    monkeypatch.setattr(executor_mod, "_tracer", provider.get_tracer("kosmos.tools.executor"))
+
+    # Also store provider so mock stream can create 'chat' spans on same provider.
+    monkeypatch.setattr(
+        "tests.observability.test_query_parent_span._TEST_PROVIDER",
+        provider,
+        raising=False,
+    )
+
+    # Module-level variable to share provider with inner functions.
+    global _TEST_PROVIDER  # noqa: PLW0603
+    _TEST_PROVIDER = provider
+
+    exporter.clear()
+    return exporter
+
+
+_TEST_PROVIDER: TracerProvider | None = None
+
+
+# ---------------------------------------------------------------------------
+# Schema models used by the test tool
+# ---------------------------------------------------------------------------
+
+
+class _DummyInput(BaseModel):
+    value: str = "x"
+
+
+class _DummyOutput(BaseModel):
+    result: str = "ok"
+
+
+# ---------------------------------------------------------------------------
+# Registry + Executor factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_registry_with_tool(tool_id: str = "dummy_tool") -> ToolRegistry:
+    registry = ToolRegistry()
+    tool = GovAPITool(
+        id=tool_id,
+        name_ko="더미 도구",
+        provider="TestProvider",
+        category=["test"],
+        endpoint="http://example.com/api",
+        auth_type="public",
+        input_schema=_DummyInput,
+        output_schema=_DummyOutput,
+        search_hint="dummy test tool",
+        requires_auth=False,
+        is_concurrency_safe=True,
+        is_personal_data=False,
+    )
+    registry.register(tool)
+    return registry
+
+
+def _make_executor(registry: ToolRegistry, tool_id: str = "dummy_tool") -> ToolExecutor:
+    executor = ToolExecutor(registry=registry)
+
+    async def _adapter(inp: _DummyInput) -> dict:
+        return {"result": "ok"}
+
+    executor.register_adapter(tool_id, _adapter)
+    return executor
+
+
+# ---------------------------------------------------------------------------
+# T013 test
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_query_produces_root_span_with_correct_attributes(
+    memory_exporter: InMemorySpanExporter,
+) -> None:
+    """query() must produce one 'invoke_agent kosmos-query' root span with
+    required attributes and child spans for chat + execute_tool."""
+    # Import after monkeypatch so _tracer is already patched.
+    from kosmos.engine.query import query
+
+    TOOL_ID = "dummy_tool"
+    SESSION_ID = "test-uuid"
+
+    registry = _make_registry_with_tool(TOOL_ID)
+    executor = _make_executor(registry, TOOL_ID)
+
+    usage_tracker = UsageTracker(budget=100_000)
+    state = QueryState(usage=usage_tracker)
+
+    from kosmos.llm.models import ChatMessage
+
+    state.messages.append(ChatMessage(role="user", content="hello"))
+
+    config = QueryEngineConfig(max_iterations=3)
+    session_ctx = SessionContext(session_id=SESSION_ID)
+
+    tool_call_args = json.dumps({"value": "x"})
+    call_count = 0
+
+    async def _stream_dispatch(*args, **kwargs):
+        """Mock stream that creates a 'chat' span on the test provider."""
+        nonlocal call_count
+        call_count += 1
+
+        # Use the test provider to create the 'chat' span, mimicking LLMClient.stream().
+        assert _TEST_PROVIDER is not None
+        _tracer = _TEST_PROVIDER.get_tracer("kosmos.llm.client")
+        span = _tracer.start_span("chat")
+        span.set_attribute("gen_ai.operation.name", "chat")
+        span.set_attribute("gen_ai.provider.name", "friendliai")
+        span.set_attribute("gen_ai.request.model", "test-model")
+
+        try:
+            if call_count == 1:
+                # First call: yield tool_call_delta to trigger one tool dispatch.
+                yield StreamEvent(
+                    type="tool_call_delta",
+                    tool_call_index=0,
+                    tool_call_id="call-001",
+                    function_name=TOOL_ID,
+                    function_args_delta=tool_call_args,
+                )
+            else:
+                # Second call: text content + usage → causes stop.
+                yield StreamEvent(type="content_delta", content="Done.")
+                yield StreamEvent(
+                    type="usage",
+                    usage=TokenUsage(input_tokens=10, output_tokens=5),
+                )
+        finally:
+            span.end()
+
+    mock_llm = MagicMock(spec=LLMClient)
+    mock_llm.stream = _stream_dispatch
+    mock_llm.usage = usage_tracker
+
+    ctx = QueryContext(
+        state=state,
+        llm_client=mock_llm,
+        tool_executor=executor,
+        tool_registry=registry,
+        config=config,
+        session_context=session_ctx,
+    )
+
+    # Consume the full generator.
+    events = []
+    async for event in query(ctx):
+        events.append(event)
+
+    spans = memory_exporter.get_finished_spans()
+    span_names = [s.name for s in spans]
+
+    # --- Assert: exactly one root span named 'invoke_agent kosmos-query' ---
+    root_spans = [s for s in spans if s.name == "invoke_agent kosmos-query"]
+    assert len(root_spans) == 1, (
+        f"Expected exactly 1 root span 'invoke_agent kosmos-query', "
+        f"found {len(root_spans)}. All spans: {span_names}"
+    )
+    root = root_spans[0]
+
+    # --- Assert: root span attributes ---
+    attrs = dict(root.attributes or {})
+    assert attrs.get("gen_ai.operation.name") == "invoke_agent", (
+        f"gen_ai.operation.name mismatch: {attrs}"
+    )
+    assert attrs.get("gen_ai.agent.name") == "kosmos-query", (
+        f"gen_ai.agent.name mismatch: {attrs}"
+    )
+    assert attrs.get("gen_ai.conversation.id") == SESSION_ID, (
+        f"gen_ai.conversation.id mismatch: {attrs}"
+    )
+
+    # --- Assert: root span status UNSET on success ---
+    assert root.status.status_code == StatusCode.UNSET, (
+        f"Expected UNSET status, got {root.status.status_code}"
+    )
+
+    # --- Assert: at least one 'chat' child span ---
+    chat_spans = [s for s in spans if s.name == "chat"]
+    assert len(chat_spans) >= 1, (
+        f"Expected at least one 'chat' child span. All spans: {span_names}"
+    )
+
+    # --- Assert: at least one 'execute_tool *' child span ---
+    tool_spans = [s for s in spans if s.name.startswith("execute_tool")]
+    assert len(tool_spans) >= 1, (
+        f"Expected at least one 'execute_tool *' child span. All spans: {span_names}"
+    )
+
+    # --- Assert: execute_tool spans have root as parent ---
+    root_span_id = root.context.span_id
+    for child_span in tool_spans:
+        parent_id = (
+            child_span.parent.span_id if child_span.parent is not None else None
+        )
+        assert parent_id == root_span_id, (
+            f"Span '{child_span.name}' has parent_id {parent_id}, "
+            f"expected root span_id {root_span_id}"
+        )

--- a/tests/observability/test_retry_429_counter.py
+++ b/tests/observability/test_retry_429_counter.py
@@ -222,8 +222,7 @@ async def test_midstream_429_counter_and_single_chat_span(
     """
     # A body that begins streaming normally, then hits a rate-limit envelope.
     mid_stream_429_body = (
-        f"data: {json.dumps(_delta_chunk('partial'))}\n\n"
-        + _sse_rate_limit_envelope()
+        f"data: {json.dumps(_delta_chunk('partial'))}\n\n" + _sse_rate_limit_envelope()
     ).encode()
 
     success_body = _sse_body(_delta_chunk("done"), _stop_chunk())
@@ -311,6 +310,5 @@ async def test_no_metrics_increment_when_metrics_is_none(
     spans = mem_exporter.get_finished_spans()
     chat_spans = [s for s in spans if s.name == "chat"]
     assert len(chat_spans) == 1, (
-        f"Expected 1 'chat' span even with metrics=None. "
-        f"All spans: {[s.name for s in spans]}"
+        f"Expected 1 'chat' span even with metrics=None. All spans: {[s.name for s in spans]}"
     )

--- a/tests/observability/test_retry_429_counter.py
+++ b/tests/observability/test_retry_429_counter.py
@@ -29,7 +29,6 @@ import os
 import httpx
 import pytest
 import respx
-
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter

--- a/tests/observability/test_retry_429_counter.py
+++ b/tests/observability/test_retry_429_counter.py
@@ -1,0 +1,317 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T022 — Tests for the 429 retry counter and chat span uniqueness.
+
+Verifies:
+- kosmos_llm_rate_limit_retries_total increments exactly once per retry
+  (two 429 → two increments).
+- Exactly one 'chat' span is emitted for the whole logical stream call
+  regardless of how many retry attempts are made.
+- The single 'chat' span has gen_ai.usage.input_tokens set on success.
+- No metric increment occurs when self._metrics is None (None-guard works).
+
+Strategy: monkeypatch kosmos.llm.client._tracer with a dedicated
+TracerProvider backed by InMemorySpanExporter (same pattern as
+test_query_parent_span.py / test_tool_execute_span.py). Use respx to
+mock httpx at the transport level so no real network calls are made.
+asyncio.sleep is monkeypatched to a no-op so tests stay under 3s.
+
+Two 429 paths exist in _stream_with_retry:
+  1. Pre-stream 429 — response.status_code == 429 before reading SSE lines.
+  2. Mid-stream 429 — an SSE line that matches _is_rate_limit_envelope().
+Both are tested independently below.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import httpx
+import pytest
+import respx
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+
+from kosmos.llm.client import LLMClient
+from kosmos.llm.config import LLMClientConfig
+from kosmos.llm.models import ChatMessage
+from kosmos.observability.metrics import MetricsCollector
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+_COMPLETIONS_URL = "https://api.friendli.ai/serverless/v1/chat/completions"
+_MODEL = "LGAI-EXAONE/K-EXAONE-236B-A23B"
+
+# ---------------------------------------------------------------------------
+# SSE body helpers (mirrors test_streaming.py conventions)
+# ---------------------------------------------------------------------------
+
+
+def _delta_chunk(content: str) -> dict:
+    return {
+        "id": "chatcmpl-t022",
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {"content": content}, "finish_reason": None}],
+    }
+
+
+def _stop_chunk(prompt_tokens: int = 12, completion_tokens: int = 4) -> dict:
+    return {
+        "id": "chatcmpl-t022",
+        "object": "chat.completion.chunk",
+        "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+        "usage": {
+            "prompt_tokens": prompt_tokens,
+            "completion_tokens": completion_tokens,
+            "total_tokens": prompt_tokens + completion_tokens,
+        },
+    }
+
+
+def _sse_body(*chunks: dict, done: bool = True) -> bytes:
+    lines = [f"data: {json.dumps(c)}\n\n" for c in chunks]
+    if done:
+        lines.append("data: [DONE]\n\n")
+    return "".join(lines).encode()
+
+
+def _sse_response(body: bytes, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=body,
+        headers={"content-type": "text/event-stream"},
+    )
+
+
+def _sse_rate_limit_envelope() -> str:
+    """A single SSE data line containing a mid-stream 429 error envelope."""
+    payload = {"error": {"status": 429, "type": "rate_limited", "message": "rate limit hit"}}
+    return f"data: {json.dumps(payload)}\n\n"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Strip KOSMOS_ env vars and inject a known test token."""
+    for key in list(os.environ):
+        if key.startswith("KOSMOS_"):
+            monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("KOSMOS_FRIENDLI_TOKEN", "test-token-t022")
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+
+
+@pytest.fixture()
+def mem_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    """Patch kosmos.llm.client._tracer with a dedicated in-memory TracerProvider."""
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    import kosmos.llm.client as client_mod
+
+    monkeypatch.setattr(client_mod, "_tracer", provider.get_tracer("kosmos.llm.client"))
+
+    exporter.clear()
+    return exporter
+
+
+@pytest.fixture()
+def sample_messages() -> list[ChatMessage]:
+    return [ChatMessage(role="user", content="test message")]
+
+
+@pytest.fixture()
+def no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace asyncio.sleep with a no-op to keep tests fast."""
+
+    async def _noop(delay: float) -> None:  # noqa: ARG001
+        pass
+
+    monkeypatch.setattr("asyncio.sleep", _noop)
+
+
+# ---------------------------------------------------------------------------
+# T022-A: pre-stream 429 × 2, then succeed — counter = 2, spans = 1
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_prestream_429_counter_and_single_chat_span(
+    mem_exporter: InMemorySpanExporter,
+    sample_messages: list[ChatMessage],
+    no_sleep: None,
+) -> None:
+    """Pre-stream 429 twice then success: counter incremented exactly twice,
+    exactly one 'chat' span exported."""
+    success_body = _sse_body(_delta_chunk("hi"), _stop_chunk())
+
+    respx.post(_COMPLETIONS_URL).mock(
+        side_effect=[
+            # attempt 0 → 429
+            _sse_response(b"rate limited", status=429),
+            # attempt 1 → 429
+            _sse_response(b"rate limited", status=429),
+            # attempt 2 → success
+            _sse_response(success_body),
+        ]
+    )
+
+    config = LLMClientConfig()
+    metrics = MetricsCollector()
+    client = LLMClient(config=config, metrics=metrics)
+
+    # max_retries default is 3 → max_attempts = 4; two 429s + one success is fine.
+    events = []
+    async for event in client.stream(sample_messages):
+        events.append(event)
+
+    await client.close()
+
+    # --- Assertion 1: counter incremented exactly 2 times ---
+    count = metrics.get_counter(
+        "kosmos_llm_rate_limit_retries_total",
+        labels={"provider": "friendliai", "model": _MODEL},
+    )
+    assert count == 2, (
+        f"Expected retry counter == 2 (one per 429 retry), got {count}. "
+        f"Counters snapshot: {metrics.snapshot()['counters']}"
+    )
+
+    # --- Assertion 2: exactly one 'chat' span ---
+    spans = mem_exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.name == "chat"]
+    assert len(chat_spans) == 1, (
+        f"Expected exactly 1 'chat' span regardless of retry count, "
+        f"got {len(chat_spans)}. All spans: {[s.name for s in spans]}"
+    )
+
+    # --- Assertion 3: span has input_tokens > 0 ---
+    attrs = dict(chat_spans[0].attributes or {})
+    input_tokens = attrs.get("gen_ai.usage.input_tokens", 0)
+    assert int(input_tokens) > 0, (
+        f"Expected gen_ai.usage.input_tokens > 0 on success path. attrs: {attrs}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T022-B: mid-stream 429 × 2, then succeed — counter = 2, spans = 1
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_midstream_429_counter_and_single_chat_span(
+    mem_exporter: InMemorySpanExporter,
+    sample_messages: list[ChatMessage],
+    no_sleep: None,
+) -> None:
+    """Mid-stream 429 envelope twice then success: counter incremented exactly twice,
+    exactly one 'chat' span exported.
+
+    Mid-stream 429 is detected by _is_rate_limit_envelope() inside the SSE line
+    iteration loop. We inject a 200 response whose body contains a 429 error
+    envelope line followed by no [DONE], causing the retry logic to kick in.
+    """
+    # A body that begins streaming normally, then hits a rate-limit envelope.
+    mid_stream_429_body = (
+        f"data: {json.dumps(_delta_chunk('partial'))}\n\n"
+        + _sse_rate_limit_envelope()
+    ).encode()
+
+    success_body = _sse_body(_delta_chunk("done"), _stop_chunk())
+
+    respx.post(_COMPLETIONS_URL).mock(
+        side_effect=[
+            # attempt 0 → mid-stream 429 envelope
+            _sse_response(mid_stream_429_body),
+            # attempt 1 → mid-stream 429 envelope again
+            _sse_response(mid_stream_429_body),
+            # attempt 2 → clean success
+            _sse_response(success_body),
+        ]
+    )
+
+    config = LLMClientConfig()
+    metrics = MetricsCollector()
+    client = LLMClient(config=config, metrics=metrics)
+
+    events = []
+    async for event in client.stream(sample_messages):
+        events.append(event)
+
+    await client.close()
+
+    # --- Assertion 1: counter incremented exactly 2 times ---
+    count = metrics.get_counter(
+        "kosmos_llm_rate_limit_retries_total",
+        labels={"provider": "friendliai", "model": _MODEL},
+    )
+    assert count == 2, (
+        f"Expected retry counter == 2 for mid-stream retries, got {count}. "
+        f"Counters snapshot: {metrics.snapshot()['counters']}"
+    )
+
+    # --- Assertion 2: exactly one 'chat' span ---
+    spans = mem_exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.name == "chat"]
+    assert len(chat_spans) == 1, (
+        f"Expected exactly 1 'chat' span, got {len(chat_spans)}. "
+        f"All spans: {[s.name for s in spans]}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T022-C: metrics=None — no increment, no crash
+# ---------------------------------------------------------------------------
+
+
+@respx.mock
+@pytest.mark.asyncio
+async def test_no_metrics_increment_when_metrics_is_none(
+    mem_exporter: InMemorySpanExporter,
+    sample_messages: list[ChatMessage],
+    no_sleep: None,
+) -> None:
+    """When LLMClient is initialized without a MetricsCollector (metrics=None),
+    a 429 retry must not raise and the stream must still complete successfully."""
+    success_body = _sse_body(_delta_chunk("hello"), _stop_chunk())
+
+    respx.post(_COMPLETIONS_URL).mock(
+        side_effect=[
+            _sse_response(b"rate limited", status=429),
+            _sse_response(success_body),
+        ]
+    )
+
+    config = LLMClientConfig()
+    # Explicitly pass metrics=None — the None guard in _stream_with_retry must handle this.
+    client = LLMClient(config=config, metrics=None)
+
+    events = []
+    async for event in client.stream(sample_messages):
+        events.append(event)
+
+    await client.close()
+
+    # Stream must complete — at least one done event.
+    done_events = [e for e in events if e.type == "done"]
+    assert len(done_events) == 1, (
+        f"Expected stream to complete with one 'done' event, got: {[e.type for e in events]}"
+    )
+
+    # Exactly one chat span still emitted.
+    spans = mem_exporter.get_finished_spans()
+    chat_spans = [s for s in spans if s.name == "chat"]
+    assert len(chat_spans) == 1, (
+        f"Expected 1 'chat' span even with metrics=None. "
+        f"All spans: {[s.name for s in spans]}"
+    )

--- a/tests/observability/test_tool_execute_span.py
+++ b/tests/observability/test_tool_execute_span.py
@@ -17,17 +17,15 @@ from __future__ import annotations
 import json
 
 import pytest
-from pydantic import BaseModel
-
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import StatusCode
+from pydantic import BaseModel
 
 from kosmos.tools.executor import ToolExecutor
 from kosmos.tools.models import GovAPITool
 from kosmos.tools.registry import ToolRegistry
-
 
 # ---------------------------------------------------------------------------
 # Per-test InMemorySpanExporter fixture using _tracer monkeypatching
@@ -110,7 +108,7 @@ async def test_execute_tool_success_span_attributes(
     mem_exporter: InMemorySpanExporter,
 ) -> None:
     """Success path: span has gen_ai attributes and UNSET status."""
-    TOOL_ID = "test_success_tool"
+    TOOL_ID = "test_success_tool"  # noqa: N806
     registry, executor = _build_registry_and_executor(TOOL_ID)
 
     async def _adapter(inp: _SimpleInput) -> dict:
@@ -161,7 +159,7 @@ async def test_execute_tool_failure_span_error_status(
     mem_exporter: InMemorySpanExporter,
 ) -> None:
     """Failure path: adapter raises → span has ERROR status and error.type set."""
-    TOOL_ID = "test_fail_tool"
+    TOOL_ID = "test_fail_tool"  # noqa: N806
     registry, executor = _build_registry_and_executor(TOOL_ID)
 
     async def _failing_adapter(inp: _SimpleInput) -> dict:
@@ -210,7 +208,7 @@ async def test_execute_tool_not_found_span_error(
     mem_exporter: InMemorySpanExporter,
 ) -> None:
     """ToolNotFoundError path: span has ERROR status, error.type is set."""
-    TOOL_ID = "nonexistent_tool"
+    TOOL_ID = "nonexistent_tool"  # noqa: N806
     registry = ToolRegistry()  # empty registry
     executor = ToolExecutor(registry=registry)
 
@@ -241,7 +239,7 @@ async def test_execute_tool_no_pii_in_span_attributes(
     mem_exporter: InMemorySpanExporter,
 ) -> None:
     """Tool input with user_email must not leak into span attributes."""
-    TOOL_ID = "pii_test_tool"
+    TOOL_ID = "pii_test_tool"  # noqa: N806
     registry, executor = _build_registry_and_executor(
         TOOL_ID,
         input_model=_PiiInput,

--- a/tests/observability/test_tool_execute_span.py
+++ b/tests/observability/test_tool_execute_span.py
@@ -1,0 +1,286 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T014 — Tests for execute_tool span produced by ToolExecutor.dispatch().
+
+Covers:
+- Success path: span has correct gen_ai attributes, UNSET status.
+- Failure path (adapter raises): span has ERROR status and error.type attribute.
+- PII check: tool input dict with 'user_email' key must not leak into span
+  attributes.
+
+Strategy: monkeypatch the module-level _tracer in executor.py to use a
+dedicated TracerProvider backed by an InMemorySpanExporter. This avoids the
+SDK singleton guard that blocks multiple trace.set_tracer_provider() calls.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+from pydantic import BaseModel
+
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import StatusCode
+
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Per-test InMemorySpanExporter fixture using _tracer monkeypatching
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def mem_exporter(monkeypatch: pytest.MonkeyPatch) -> InMemorySpanExporter:
+    """Patch _tracer in executor module with a dedicated test TracerProvider."""
+    monkeypatch.delenv("OTEL_SDK_DISABLED", raising=False)
+    exporter = InMemorySpanExporter()
+    provider = TracerProvider()
+    provider.add_span_processor(SimpleSpanProcessor(exporter))
+
+    import kosmos.tools.executor as executor_mod
+
+    monkeypatch.setattr(executor_mod, "_tracer", provider.get_tracer("kosmos.tools.executor"))
+
+    exporter.clear()
+    return exporter
+
+
+# ---------------------------------------------------------------------------
+# Schema models used by test tools
+# ---------------------------------------------------------------------------
+
+
+class _SimpleInput(BaseModel):
+    query: str = "test"
+
+
+class _SimpleOutput(BaseModel):
+    result: str = "ok"
+
+
+class _PiiInput(BaseModel):
+    query: str = "test"
+    user_email: str = "user@example.com"
+
+
+# ---------------------------------------------------------------------------
+# Registry + Executor factory helpers
+# ---------------------------------------------------------------------------
+
+
+def _build_registry_and_executor(
+    tool_id: str,
+    input_model: type[BaseModel] = _SimpleInput,
+    output_model: type[BaseModel] = _SimpleOutput,
+) -> tuple[ToolRegistry, ToolExecutor]:
+    """Create a fresh registry with one tool and a matching executor."""
+    registry = ToolRegistry()
+    tool = GovAPITool(
+        id=tool_id,
+        name_ko="테스트 도구",
+        provider="TestProvider",
+        category=["test"],
+        endpoint="http://example.com/api",
+        auth_type="public",
+        input_schema=input_model,
+        output_schema=output_model,
+        search_hint="test tool for unit testing",
+        requires_auth=False,
+        is_concurrency_safe=True,
+        is_personal_data=False,
+        rate_limit_per_minute=1000,
+    )
+    registry.register(tool)
+    executor = ToolExecutor(registry=registry)
+    return registry, executor
+
+
+# ---------------------------------------------------------------------------
+# T014-A: Success path
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_success_span_attributes(
+    mem_exporter: InMemorySpanExporter,
+) -> None:
+    """Success path: span has gen_ai attributes and UNSET status."""
+    TOOL_ID = "test_success_tool"
+    registry, executor = _build_registry_and_executor(TOOL_ID)
+
+    async def _adapter(inp: _SimpleInput) -> dict:
+        return {"result": "ok"}
+
+    executor.register_adapter(TOOL_ID, _adapter)
+
+    result = await executor.dispatch(TOOL_ID, json.dumps({"query": "hello"}), "call-abc")
+
+    assert result.success is True, f"Expected success, got: {result}"
+
+    spans = mem_exporter.get_finished_spans()
+    tool_spans = [s for s in spans if s.name == f"execute_tool {TOOL_ID}"]
+    assert len(tool_spans) == 1, (
+        f"Expected 1 'execute_tool {TOOL_ID}' span, got {len(tool_spans)}. "
+        f"All spans: {[s.name for s in spans]}"
+    )
+    span = tool_spans[0]
+    attrs = dict(span.attributes or {})
+
+    assert attrs.get("gen_ai.operation.name") == "execute_tool", (
+        f"gen_ai.operation.name mismatch: {attrs}"
+    )
+    assert attrs.get("gen_ai.tool.name") == TOOL_ID, (
+        f"gen_ai.tool.name mismatch: {attrs}"
+    )
+    assert attrs.get("gen_ai.tool.type") == "function", (
+        f"gen_ai.tool.type mismatch: {attrs}"
+    )
+    # tool_call_id is set when provided
+    assert attrs.get("gen_ai.tool.call.id") == "call-abc", (
+        f"gen_ai.tool.call.id mismatch: {attrs}"
+    )
+
+    # Status must be UNSET on success (contracts § Span 3)
+    assert span.status.status_code == StatusCode.UNSET, (
+        f"Expected UNSET status on success, got {span.status.status_code}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# T014-B: Failure path (adapter raises exception)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_failure_span_error_status(
+    mem_exporter: InMemorySpanExporter,
+) -> None:
+    """Failure path: adapter raises → span has ERROR status and error.type set."""
+    TOOL_ID = "test_fail_tool"
+    registry, executor = _build_registry_and_executor(TOOL_ID)
+
+    async def _failing_adapter(inp: _SimpleInput) -> dict:
+        raise RuntimeError("Simulated adapter failure")
+
+    executor.register_adapter(TOOL_ID, _failing_adapter)
+
+    result = await executor.dispatch(TOOL_ID, json.dumps({"query": "fail"}))
+
+    assert result.success is False, "Expected failure result"
+    assert result.error_type is not None, "Expected error_type to be set"
+
+    spans = mem_exporter.get_finished_spans()
+    tool_spans = [s for s in spans if s.name == f"execute_tool {TOOL_ID}"]
+    assert len(tool_spans) == 1, (
+        f"Expected 1 'execute_tool {TOOL_ID}' span. "
+        f"All spans: {[s.name for s in spans]}"
+    )
+    span = tool_spans[0]
+    attrs = dict(span.attributes or {})
+
+    # Status must be ERROR on failure
+    assert span.status.status_code == StatusCode.ERROR, (
+        f"Expected ERROR status on failure, got {span.status.status_code}"
+    )
+
+    # error.type attribute must be set (contracts § Span 3)
+    assert "error.type" in attrs, (
+        f"Expected 'error.type' attribute on failure span. attrs: {attrs}"
+    )
+    assert attrs["error.type"] is not None, "error.type must not be None"
+
+    # Span events: executor catches exception internally; if any events were
+    # recorded, they must have valid names.
+    for ev in span.events:
+        assert ev.name, "Span event name must not be empty"
+
+
+# ---------------------------------------------------------------------------
+# T014-B2: Failure via ToolNotFoundError (tool not in registry)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_not_found_span_error(
+    mem_exporter: InMemorySpanExporter,
+) -> None:
+    """ToolNotFoundError path: span has ERROR status, error.type is set."""
+    TOOL_ID = "nonexistent_tool"
+    registry = ToolRegistry()  # empty registry
+    executor = ToolExecutor(registry=registry)
+
+    result = await executor.dispatch(TOOL_ID, json.dumps({}))
+
+    assert result.success is False
+    assert result.error_type == "not_found"
+
+    spans = mem_exporter.get_finished_spans()
+    tool_spans = [s for s in spans if s.name == f"execute_tool {TOOL_ID}"]
+    assert len(tool_spans) == 1
+
+    span = tool_spans[0]
+    assert span.status.status_code == StatusCode.ERROR, (
+        f"Expected ERROR for not_found. Got {span.status.status_code}"
+    )
+    attrs = dict(span.attributes or {})
+    assert "error.type" in attrs, f"Expected error.type. attrs: {attrs}"
+
+
+# ---------------------------------------------------------------------------
+# T014-C: PII check — user_email must not appear in span attributes
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_execute_tool_no_pii_in_span_attributes(
+    mem_exporter: InMemorySpanExporter,
+) -> None:
+    """Tool input with user_email must not leak into span attributes."""
+    TOOL_ID = "pii_test_tool"
+    registry, executor = _build_registry_and_executor(
+        TOOL_ID,
+        input_model=_PiiInput,
+        output_model=_SimpleOutput,
+    )
+
+    async def _adapter(inp: _PiiInput) -> dict:
+        return {"result": "ok"}
+
+    executor.register_adapter(TOOL_ID, _adapter)
+
+    # Dispatch with PII in arguments
+    args = json.dumps({"query": "search", "user_email": "victim@example.com"})
+    result = await executor.dispatch(TOOL_ID, args)
+
+    assert result.success is True, f"Expected success. Got: {result}"
+
+    spans = mem_exporter.get_finished_spans()
+    tool_spans = [s for s in spans if s.name == f"execute_tool {TOOL_ID}"]
+    assert len(tool_spans) == 1
+
+    span = tool_spans[0]
+    attrs = dict(span.attributes or {})
+
+    # No attribute key or value must contain 'user_email' or the raw email address.
+    for key, val in attrs.items():
+        assert "user_email" not in key.lower(), (
+            f"Span attribute key leaks PII: {key!r}"
+        )
+        if isinstance(val, str):
+            assert "user_email" not in val.lower(), (
+                f"Span attribute value leaks PII field name in key={key!r}: {val!r}"
+            )
+            assert "victim@example.com" not in val, (
+                f"Span attribute value leaks PII email in key={key!r}: {val!r}"
+            )
+
+    # No attribute key must start with 'tool.input'
+    for key in attrs:
+        assert not key.lower().startswith("tool.input"), (
+            f"Span attribute key looks like tool input leakage: {key!r}"
+        )

--- a/tests/observability/test_tool_execute_span.py
+++ b/tests/observability/test_tool_execute_span.py
@@ -132,16 +132,10 @@ async def test_execute_tool_success_span_attributes(
     assert attrs.get("gen_ai.operation.name") == "execute_tool", (
         f"gen_ai.operation.name mismatch: {attrs}"
     )
-    assert attrs.get("gen_ai.tool.name") == TOOL_ID, (
-        f"gen_ai.tool.name mismatch: {attrs}"
-    )
-    assert attrs.get("gen_ai.tool.type") == "function", (
-        f"gen_ai.tool.type mismatch: {attrs}"
-    )
+    assert attrs.get("gen_ai.tool.name") == TOOL_ID, f"gen_ai.tool.name mismatch: {attrs}"
+    assert attrs.get("gen_ai.tool.type") == "function", f"gen_ai.tool.type mismatch: {attrs}"
     # tool_call_id is set when provided
-    assert attrs.get("gen_ai.tool.call.id") == "call-abc", (
-        f"gen_ai.tool.call.id mismatch: {attrs}"
-    )
+    assert attrs.get("gen_ai.tool.call.id") == "call-abc", f"gen_ai.tool.call.id mismatch: {attrs}"
 
     # Status must be UNSET on success (contracts § Span 3)
     assert span.status.status_code == StatusCode.UNSET, (
@@ -175,8 +169,7 @@ async def test_execute_tool_failure_span_error_status(
     spans = mem_exporter.get_finished_spans()
     tool_spans = [s for s in spans if s.name == f"execute_tool {TOOL_ID}"]
     assert len(tool_spans) == 1, (
-        f"Expected 1 'execute_tool {TOOL_ID}' span. "
-        f"All spans: {[s.name for s in spans]}"
+        f"Expected 1 'execute_tool {TOOL_ID}' span. All spans: {[s.name for s in spans]}"
     )
     span = tool_spans[0]
     attrs = dict(span.attributes or {})
@@ -187,9 +180,7 @@ async def test_execute_tool_failure_span_error_status(
     )
 
     # error.type attribute must be set (contracts § Span 3)
-    assert "error.type" in attrs, (
-        f"Expected 'error.type' attribute on failure span. attrs: {attrs}"
-    )
+    assert "error.type" in attrs, f"Expected 'error.type' attribute on failure span. attrs: {attrs}"
     assert attrs["error.type"] is not None, "error.type must not be None"
 
     # Span events: executor catches exception internally; if any events were
@@ -266,9 +257,7 @@ async def test_execute_tool_no_pii_in_span_attributes(
 
     # No attribute key or value must contain 'user_email' or the raw email address.
     for key, val in attrs.items():
-        assert "user_email" not in key.lower(), (
-            f"Span attribute key leaks PII: {key!r}"
-        )
+        assert "user_email" not in key.lower(), f"Span attribute key leaks PII: {key!r}"
         if isinstance(val, str):
             assert "user_email" not in val.lower(), (
                 f"Span attribute value leaks PII field name in key={key!r}: {val!r}"

--- a/tests/observability/test_tracing_init.py
+++ b/tests/observability/test_tracing_init.py
@@ -114,9 +114,9 @@ def test_setup_tracing_with_endpoint_returns_real_provider(
         processors = getattr(span_processor, "_span_processors", None)
         if processors is not None:
             processor_types = [type(p).__name__ for p in processors]
-            assert any(
-                "BatchSpanProcessor" in t for t in processor_types
-            ), f"Expected BatchSpanProcessor in processors, found: {processor_types}"
+            assert any("BatchSpanProcessor" in t for t in processor_types), (
+                f"Expected BatchSpanProcessor in processors, found: {processor_types}"
+            )
 
 
 def test_setup_tracing_real_provider_has_batch_processor(
@@ -172,9 +172,7 @@ def test_setup_tracing_missing_endpoint_warns_once(
     with caplog.at_level(logging.WARNING, logger="kosmos.observability.tracing"):
         provider1 = setup_tracing(settings_no_endpoint)
 
-    warning_messages = [
-        r.message for r in caplog.records if r.levelno == logging.WARNING
-    ]
+    warning_messages = [r.message for r in caplog.records if r.levelno == logging.WARNING]
     assert len(warning_messages) >= 1, "Expected at least one WARNING on first call"
     assert any("OTEL_EXPORTER_OTLP_ENDPOINT" in m for m in warning_messages), (
         "WARNING should mention OTEL_EXPORTER_OTLP_ENDPOINT"
@@ -214,6 +212,5 @@ def test_setup_tracing_missing_endpoint_no_repeat_warn(
     ]
 
     assert len(second_call_warnings) == 0, (
-        "Subsequent call must not re-emit the endpoint warning; "
-        f"got: {second_call_warnings}"
+        f"Subsequent call must not re-emit the endpoint warning; got: {second_call_warnings}"
     )

--- a/tests/observability/test_tracing_init.py
+++ b/tests/observability/test_tracing_init.py
@@ -1,0 +1,227 @@
+# SPDX-License-Identifier: Apache-2.0
+"""T012 — Unit tests for setup_tracing() initialization paths.
+
+Covers:
+- Case 1: OTEL_SDK_DISABLED=true → NoOpTracerProvider returned.
+- Case 2: Endpoint configured → real TracerProvider with BatchSpanProcessor.
+- Case 3: Endpoint missing, disabled unset → WARNING emitted once; subsequent
+          calls do not re-emit the warning.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from opentelemetry.trace import NoOpTracerProvider
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _reset_warn_sentinel() -> None:
+    """Reset the module-level warn-once sentinel so each test starts clean."""
+    import kosmos.observability.tracing as tracing_mod
+
+    tracing_mod._WARN_MISSING_ENDPOINT_ONCE = True
+
+
+# ---------------------------------------------------------------------------
+# Case 1: OTEL_SDK_DISABLED=true → NoOpTracerProvider
+# ---------------------------------------------------------------------------
+
+
+def test_setup_tracing_disabled_returns_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When OTEL_SDK_DISABLED=true, setup_tracing() returns a NoOpTracerProvider."""
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    _reset_warn_sentinel()
+
+    from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+    settings = TracingSettings(disabled=True)
+    provider = setup_tracing(settings)
+
+    assert isinstance(provider, NoOpTracerProvider), (
+        "Expected NoOpTracerProvider when disabled=True, got %s" % type(provider)
+    )
+
+    # Spans from a NoOp provider must be non-recording.
+    tracer = provider.get_tracer("test")
+    span = tracer.start_span("probe")
+    assert not span.is_recording(), "NoOp span must be non-recording"
+    span.end()
+
+
+def test_setup_tracing_disabled_env_flag(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When OTEL_SDK_DISABLED env var is 'true', _settings_from_env sets disabled=True."""
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "true")
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    _reset_warn_sentinel()
+
+    from kosmos.observability.tracing import _settings_from_env
+
+    settings = _settings_from_env()
+    assert settings.disabled is True
+    assert settings.endpoint is None
+
+
+# ---------------------------------------------------------------------------
+# Case 2: Endpoint configured → real TracerProvider with BatchSpanProcessor
+# ---------------------------------------------------------------------------
+
+
+def test_setup_tracing_with_endpoint_returns_real_provider(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When endpoint is set and not disabled, returns a real TracerProvider."""
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "http://localhost:4318")
+    monkeypatch.setenv("OTEL_EXPORTER_OTLP_PROTOCOL", "http/protobuf")
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    _reset_warn_sentinel()
+
+    from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+    # Do not pass headers to avoid SDK header-parsing ValueError in test env.
+    settings = TracingSettings(
+        endpoint="http://localhost:4318",
+        headers=None,
+        protocol="http/protobuf",
+        disabled=False,
+    )
+    provider = setup_tracing(settings)
+
+    assert isinstance(provider, TracerProvider), (
+        "Expected SDK TracerProvider when endpoint is set, got %s" % type(provider)
+    )
+
+    # Verify that a BatchSpanProcessor is registered on the provider.
+    # SDK TracerProvider stores processors in ._active_span_processor which is
+    # a SynchronousMultiSpanProcessor (or similar).  We inspect the internal
+    # list; the exact attribute name varies by SDK version, so we fall back to
+    # checking that the tracer can produce a recording span.
+    tracer = provider.get_tracer("test")
+    span = tracer.start_span("probe")
+    assert span.is_recording(), "Span from real TracerProvider must be recording"
+    span.end()
+
+    # Best-effort: inspect processor list for BatchSpanProcessor presence.
+    span_processor = getattr(provider, "_active_span_processor", None)
+    if span_processor is not None:
+        processors = getattr(span_processor, "_span_processors", None)
+        if processors is not None:
+            processor_types = [type(p).__name__ for p in processors]
+            assert any(
+                "BatchSpanProcessor" in t for t in processor_types
+            ), f"Expected BatchSpanProcessor in processors, found: {processor_types}"
+
+
+def test_setup_tracing_real_provider_has_batch_processor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Directly construct settings and assert BatchSpanProcessor is attached."""
+    _reset_warn_sentinel()
+
+    from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+    settings = TracingSettings(
+        endpoint="http://localhost:4318",
+        disabled=False,
+    )
+    provider = setup_tracing(settings)
+
+    assert isinstance(provider, TracerProvider)
+
+    # Traverse the processor chain and confirm at least one BatchSpanProcessor.
+    found_batch = False
+    sp = getattr(provider, "_active_span_processor", None)
+    if sp is not None:
+        # SynchronousMultiSpanProcessor stores list in ._span_processors
+        inner = getattr(sp, "_span_processors", [])
+        for proc in inner:
+            if isinstance(proc, BatchSpanProcessor):
+                found_batch = True
+                break
+        if not found_batch:
+            # Some SDK versions wrap in a single-processor structure
+            if isinstance(sp, BatchSpanProcessor):
+                found_batch = True
+    assert found_batch, "Expected at least one BatchSpanProcessor registered on provider"
+
+
+# ---------------------------------------------------------------------------
+# Case 3: Endpoint missing, disabled unset → WARNING emitted once only
+# ---------------------------------------------------------------------------
+
+
+def test_setup_tracing_missing_endpoint_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Missing endpoint without OTEL_SDK_DISABLED should emit WARNING exactly once."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    _reset_warn_sentinel()
+
+    from kosmos.observability.tracing import setup_tracing, TracingSettings
+
+    settings_no_endpoint = TracingSettings(endpoint=None, disabled=False)
+
+    with caplog.at_level(logging.WARNING, logger="kosmos.observability.tracing"):
+        provider1 = setup_tracing(settings_no_endpoint)
+
+    warning_messages = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+    assert len(warning_messages) >= 1, "Expected at least one WARNING on first call"
+    assert any("OTEL_EXPORTER_OTLP_ENDPOINT" in m for m in warning_messages), (
+        "WARNING should mention OTEL_EXPORTER_OTLP_ENDPOINT"
+    )
+
+    # Returns NoOpTracerProvider when endpoint is absent.
+    assert isinstance(provider1, NoOpTracerProvider)
+
+
+def test_setup_tracing_missing_endpoint_no_repeat_warn(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Subsequent calls with missing endpoint must NOT re-emit the warning."""
+    monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
+    monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
+    _reset_warn_sentinel()
+
+    from kosmos.observability.tracing import setup_tracing, TracingSettings
+    import kosmos.observability.tracing as tracing_mod
+
+    settings_no_endpoint = TracingSettings(endpoint=None, disabled=False)
+
+    # First call: emits the warning and flips the sentinel to False.
+    with caplog.at_level(logging.WARNING, logger="kosmos.observability.tracing"):
+        setup_tracing(settings_no_endpoint)
+
+    first_call_warnings = [
+        r.message for r in caplog.records if r.levelno == logging.WARNING
+    ]
+
+    caplog.clear()
+
+    # Second call: sentinel is now False, must not re-warn.
+    with caplog.at_level(logging.WARNING, logger="kosmos.observability.tracing"):
+        setup_tracing(settings_no_endpoint)
+
+    second_call_warnings = [
+        r.message
+        for r in caplog.records
+        if r.levelno == logging.WARNING and "OTEL_EXPORTER_OTLP_ENDPOINT" in r.message
+    ]
+
+    assert len(second_call_warnings) == 0, (
+        "Subsequent call must not re-emit the endpoint warning; "
+        f"got: {second_call_warnings}"
+    )

--- a/tests/observability/test_tracing_init.py
+++ b/tests/observability/test_tracing_init.py
@@ -13,11 +13,9 @@ from __future__ import annotations
 import logging
 
 import pytest
-
-from opentelemetry.trace import NoOpTracerProvider
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
-
+from opentelemetry.trace import NoOpTracerProvider
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -42,13 +40,13 @@ def test_setup_tracing_disabled_returns_noop(monkeypatch: pytest.MonkeyPatch) ->
     monkeypatch.delenv("OTEL_EXPORTER_OTLP_ENDPOINT", raising=False)
     _reset_warn_sentinel()
 
-    from kosmos.observability.tracing import setup_tracing, TracingSettings
+    from kosmos.observability.tracing import TracingSettings, setup_tracing
 
     settings = TracingSettings(disabled=True)
     provider = setup_tracing(settings)
 
     assert isinstance(provider, NoOpTracerProvider), (
-        "Expected NoOpTracerProvider when disabled=True, got %s" % type(provider)
+        f"Expected NoOpTracerProvider when disabled=True, got {type(provider)}"
     )
 
     # Spans from a NoOp provider must be non-recording.
@@ -85,7 +83,7 @@ def test_setup_tracing_with_endpoint_returns_real_provider(
     monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
     _reset_warn_sentinel()
 
-    from kosmos.observability.tracing import setup_tracing, TracingSettings
+    from kosmos.observability.tracing import TracingSettings, setup_tracing
 
     # Do not pass headers to avoid SDK header-parsing ValueError in test env.
     settings = TracingSettings(
@@ -97,7 +95,7 @@ def test_setup_tracing_with_endpoint_returns_real_provider(
     provider = setup_tracing(settings)
 
     assert isinstance(provider, TracerProvider), (
-        "Expected SDK TracerProvider when endpoint is set, got %s" % type(provider)
+        f"Expected SDK TracerProvider when endpoint is set, got {type(provider)}"
     )
 
     # Verify that a BatchSpanProcessor is registered on the provider.
@@ -127,7 +125,7 @@ def test_setup_tracing_real_provider_has_batch_processor(
     """Directly construct settings and assert BatchSpanProcessor is attached."""
     _reset_warn_sentinel()
 
-    from kosmos.observability.tracing import setup_tracing, TracingSettings
+    from kosmos.observability.tracing import TracingSettings, setup_tracing
 
     settings = TracingSettings(
         endpoint="http://localhost:4318",
@@ -147,10 +145,9 @@ def test_setup_tracing_real_provider_has_batch_processor(
             if isinstance(proc, BatchSpanProcessor):
                 found_batch = True
                 break
-        if not found_batch:
+        if not found_batch and isinstance(sp, BatchSpanProcessor):
             # Some SDK versions wrap in a single-processor structure
-            if isinstance(sp, BatchSpanProcessor):
-                found_batch = True
+            found_batch = True
     assert found_batch, "Expected at least one BatchSpanProcessor registered on provider"
 
 
@@ -168,7 +165,7 @@ def test_setup_tracing_missing_endpoint_warns_once(
     monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
     _reset_warn_sentinel()
 
-    from kosmos.observability.tracing import setup_tracing, TracingSettings
+    from kosmos.observability.tracing import TracingSettings, setup_tracing
 
     settings_no_endpoint = TracingSettings(endpoint=None, disabled=False)
 
@@ -196,18 +193,13 @@ def test_setup_tracing_missing_endpoint_no_repeat_warn(
     monkeypatch.setenv("OTEL_SDK_DISABLED", "false")
     _reset_warn_sentinel()
 
-    from kosmos.observability.tracing import setup_tracing, TracingSettings
-    import kosmos.observability.tracing as tracing_mod
+    from kosmos.observability.tracing import TracingSettings, setup_tracing
 
     settings_no_endpoint = TracingSettings(endpoint=None, disabled=False)
 
     # First call: emits the warning and flips the sentinel to False.
     with caplog.at_level(logging.WARNING, logger="kosmos.observability.tracing"):
         setup_tracing(settings_no_endpoint)
-
-    first_call_warnings = [
-        r.message for r in caplog.records if r.levelno == logging.WARNING
-    ]
 
     caplog.clear()
 

--- a/uv.lock
+++ b/uv.lock
@@ -309,6 +309,18 @@ wheels = [
 ]
 
 [[package]]
+name = "googleapis-common-protos"
+version = "1.74.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/20/18/a746c8344152d368a5aac738d4c857012f2c5d1fd2eac7e17b647a7861bd/googleapis_common_protos-1.74.0.tar.gz", hash = "sha256:57971e4eeeba6aad1163c1f0fc88543f965bb49129b8bb55b2b7b26ecab084f1", size = 151254, upload-time = "2026-04-02T21:23:26.679Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b6/b0/be5d3329badb9230b765de6eea66b73abd5944bdeb5afb3562ddcd80ae84/googleapis_common_protos-1.74.0-py3-none-any.whl", hash = "sha256:702216f78610bb510e3f12ac3cafd281b7ac45cc5d86e90ad87e4d301a3426b5", size = 300743, upload-time = "2026-04-02T21:22:49.108Z" },
+]
+
+[[package]]
 name = "h11"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
@@ -376,6 +388,18 @@ wheels = [
 ]
 
 [[package]]
+name = "importlib-metadata"
+version = "8.7.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "zipp" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f3/49/3b30cad09e7771a4982d9975a8cbf64f00d4a1ececb53297f1d9a7be1b10/importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb", size = 57107, upload-time = "2025-12-21T10:00:19.278Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/5e/f8e9a1d23b9c20a551a8a02ea3637b4642e22c2626e3a13a9a29cdea99eb/importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151", size = 27865, upload-time = "2025-12-21T10:00:18.329Z" },
+]
+
+[[package]]
 name = "iniconfig"
 version = "2.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -390,6 +414,9 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },
+    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-sdk" },
+    { name = "opentelemetry-semantic-conventions" },
     { name = "prompt-toolkit" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
@@ -419,6 +446,9 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.27" },
     { name = "hypothesis", extras = ["pydantic"], marker = "extra == 'dev'", specifier = ">=6.100" },
     { name = "mypy", marker = "extra == 'dev'", specifier = ">=1.20.0" },
+    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.25" },
+    { name = "opentelemetry-sdk", specifier = ">=1.25" },
+    { name = "opentelemetry-semantic-conventions", specifier = ">=0.46b0" },
     { name = "pip-audit", marker = "extra == 'dev'", specifier = ">=2.10.0" },
     { name = "pip-licenses", marker = "extra == 'dev'", specifier = ">=5.0" },
     { name = "pre-commit", marker = "extra == 'dev'", specifier = ">=3.7" },
@@ -637,6 +667,88 @@ wheels = [
 ]
 
 [[package]]
+name = "opentelemetry-api"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "importlib-metadata" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/47/8e/3778a7e87801d994869a9396b9fc2a289e5f9be91ff54a27d41eace494b0/opentelemetry_api-1.41.0.tar.gz", hash = "sha256:9421d911326ec12dee8bc933f7839090cad7a3f13fcfb0f9e82f8174dc003c09", size = 71416, upload-time = "2026-04-09T14:38:34.544Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/ee/99ab786653b3bda9c37ade7e24a7b607a1b1f696063172768417539d876d/opentelemetry_api-1.41.0-py3-none-any.whl", hash = "sha256:0e77c806e6a89c9e4f8d372034622f3e1418a11bdbe1c80a50b3d3397ad0fa4f", size = 69007, upload-time = "2026-04-09T14:38:11.833Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-common"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-proto" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/8c/28/e8eca94966fe9a1465f6094dc5ddc5398473682180279c94020bc23b4906/opentelemetry_exporter_otlp_proto_common-1.41.0.tar.gz", hash = "sha256:966bbce537e9edb166154779a7c4f8ab6b8654a03a28024aeaf1a3eacb07d6ee", size = 20411, upload-time = "2026-04-09T14:38:36.572Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/26/c4/78b9bf2d9c1d5e494f44932988d9d91c51a66b9a7b48adf99b62f7c65318/opentelemetry_exporter_otlp_proto_common-1.41.0-py3-none-any.whl", hash = "sha256:7a99177bf61f85f4f9ed2072f54d676364719c066f6d11f515acc6c745c7acf0", size = 18366, upload-time = "2026-04-09T14:38:15.135Z" },
+]
+
+[[package]]
+name = "opentelemetry-exporter-otlp-proto-http"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "googleapis-common-protos" },
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
+    { name = "opentelemetry-proto" },
+    { name = "opentelemetry-sdk" },
+    { name = "requests" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/19/63/d9f43cd75f3fabb7e01148c89cfa9491fc18f6580a6764c554ff7c953c46/opentelemetry_exporter_otlp_proto_http-1.41.0.tar.gz", hash = "sha256:dcd6e0686f56277db4eecbadd5262124e8f2cc739cadbc3fae3d08a12c976cf5", size = 24139, upload-time = "2026-04-09T14:38:38.128Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/64/b5/a214cd907eedc17699d1c2d602288ae17cb775526df04db3a3b3585329d2/opentelemetry_exporter_otlp_proto_http-1.41.0-py3-none-any.whl", hash = "sha256:a9c4ee69cce9c3f4d7ee736ad1b44e3c9654002c0816900abbafd9f3cf289751", size = 22673, upload-time = "2026-04-09T14:38:18.349Z" },
+]
+
+[[package]]
+name = "opentelemetry-proto"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "protobuf" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/d9/08e3dc6156878713e8c811682bc76151f5fe1a3cb7f3abda3966fd56e71e/opentelemetry_proto-1.41.0.tar.gz", hash = "sha256:95d2e576f9fb1800473a3e4cfcca054295d06bdb869fda4dc9f4f779dc68f7b6", size = 45669, upload-time = "2026-04-09T14:38:45.978Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/8c/65ef7a9383a363864772022e822b5d5c6988e6f9dabeebb9278f5b86ebc3/opentelemetry_proto-1.41.0-py3-none-any.whl", hash = "sha256:b970ab537309f9eed296be482c3e7cca05d8aca8165346e929f658dbe153b247", size = 72074, upload-time = "2026-04-09T14:38:29.38Z" },
+]
+
+[[package]]
+name = "opentelemetry-sdk"
+version = "1.41.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "opentelemetry-semantic-conventions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/f8/0e/a586df1186f9f56b5a0879d52653effc40357b8e88fc50fe300038c3c08b/opentelemetry_sdk-1.41.0.tar.gz", hash = "sha256:7bddf3961131b318fc2d158947971a8e37e38b1cd23470cfb72b624e7cc108bd", size = 230181, upload-time = "2026-04-09T14:38:47.225Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2c/13/a7825118208cb32e6a4edcd0a99f925cbef81e77b3b0aedfd9125583c543/opentelemetry_sdk-1.41.0-py3-none-any.whl", hash = "sha256:a596f5687964a3e0d7f8edfdcf5b79cbca9c93c7025ebf5fb00f398a9443b0bd", size = 180214, upload-time = "2026-04-09T14:38:30.657Z" },
+]
+
+[[package]]
+name = "opentelemetry-semantic-conventions"
+version = "0.62b0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "opentelemetry-api" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a3/b0/c14f723e86c049b7bf8ff431160d982519b97a7be2857ed2247377397a24/opentelemetry_semantic_conventions-0.62b0.tar.gz", hash = "sha256:cbfb3c8fc259575cf68a6e1b94083cc35adc4a6b06e8cf431efa0d62606c0097", size = 145753, upload-time = "2026-04-09T14:38:48.274Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/58/6c/5e86fa1759a525ef91c2d8b79d668574760ff3f900d114297765eb8786cb/opentelemetry_semantic_conventions-0.62b0-py3-none-any.whl", hash = "sha256:0ddac1ce59eaf1a827d9987ab60d9315fb27aea23304144242d1fcad9e16b489", size = 231619, upload-time = "2026-04-09T14:38:32.394Z" },
+]
+
+[[package]]
 name = "packageurl-python"
 version = "0.17.6"
 source = { registry = "https://pypi.org/simple" }
@@ -786,6 +898,21 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/a1/96/06e01a7b38dce6fe1db213e061a4602dd6032a8a97ef6c1a862537732421/prompt_toolkit-3.0.52.tar.gz", hash = "sha256:28cde192929c8e7321de85de1ddbe736f1375148b02f2e17edd840042b1be855", size = 434198, upload-time = "2025-08-27T15:24:02.057Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/84/03/0d3ce49e2505ae70cf43bc5bb3033955d2fc9f932163e84dc0779cc47f48/prompt_toolkit-3.0.52-py3-none-any.whl", hash = "sha256:9aac639a3bbd33284347de5ad8d68ecc044b91a762dc39b7c21095fcd6a19955", size = 391431, upload-time = "2025-08-27T15:23:59.498Z" },
+]
+
+[[package]]
+name = "protobuf"
+version = "6.33.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/66/70/e908e9c5e52ef7c3a6c7902c9dfbb34c7e29c25d2f81ade3856445fd5c94/protobuf-6.33.6.tar.gz", hash = "sha256:a6768d25248312c297558af96a9f9c929e8c4cee0659cb07e780731095f38135", size = 444531, upload-time = "2026-03-18T19:05:00.988Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/9f/2f509339e89cfa6f6a4c4ff50438db9ca488dec341f7e454adad60150b00/protobuf-6.33.6-cp310-abi3-win32.whl", hash = "sha256:7d29d9b65f8afef196f8334e80d6bc1d5d4adedb449971fefd3723824e6e77d3", size = 425739, upload-time = "2026-03-18T19:04:48.373Z" },
+    { url = "https://files.pythonhosted.org/packages/76/5d/683efcd4798e0030c1bab27374fd13a89f7c2515fb1f3123efdfaa5eab57/protobuf-6.33.6-cp310-abi3-win_amd64.whl", hash = "sha256:0cd27b587afca21b7cfa59a74dcbd48a50f0a6400cfb59391340ad729d91d326", size = 437089, upload-time = "2026-03-18T19:04:50.381Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/01/a3c3ed5cd186f39e7880f8303cc51385a198a81469d53d0fdecf1f64d929/protobuf-6.33.6-cp39-abi3-macosx_10_9_universal2.whl", hash = "sha256:9720e6961b251bde64edfdab7d500725a2af5280f3f4c87e57c0208376aa8c3a", size = 427737, upload-time = "2026-03-18T19:04:51.866Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/90/b3c01fdec7d2f627b3a6884243ba328c1217ed2d978def5c12dc50d328a3/protobuf-6.33.6-cp39-abi3-manylinux2014_aarch64.whl", hash = "sha256:e2afbae9b8e1825e3529f88d514754e094278bb95eadc0e199751cdd9a2e82a2", size = 324610, upload-time = "2026-03-18T19:04:53.096Z" },
+    { url = "https://files.pythonhosted.org/packages/9b/ca/25afc144934014700c52e05103c2421997482d561f3101ff352e1292fb81/protobuf-6.33.6-cp39-abi3-manylinux2014_s390x.whl", hash = "sha256:c96c37eec15086b79762ed265d59ab204dabc53056e3443e702d2681f4b39ce3", size = 339381, upload-time = "2026-03-18T19:04:54.616Z" },
+    { url = "https://files.pythonhosted.org/packages/16/92/d1e32e3e0d894fe00b15ce28ad4944ab692713f2e7f0a99787405e43533a/protobuf-6.33.6-cp39-abi3-manylinux2014_x86_64.whl", hash = "sha256:e9db7e292e0ab79dd108d7f1a94fe31601ce1ee3f7b79e0692043423020b0593", size = 323436, upload-time = "2026-03-18T19:04:55.768Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/72/02445137af02769918a93807b2b7890047c32bfb9f90371cbc12688819eb/protobuf-6.33.6-py3-none-any.whl", hash = "sha256:77179e006c476e69bf8e8ce866640091ec42e1beb80b213c3900006ecfba6901", size = 170656, upload-time = "2026-03-18T19:04:59.826Z" },
 ]
 
 [[package]]
@@ -1281,4 +1408,13 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/35/a2/8e3becb46433538a38726c948d3399905a4c7cabd0df578ede5dc51f0ec2/wcwidth-0.6.0.tar.gz", hash = "sha256:cdc4e4262d6ef9a1a57e018384cbeb1208d8abbc64176027e2c2455c81313159", size = 159684, upload-time = "2026-02-06T19:19:40.919Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/68/5a/199c59e0a824a3db2b89c5d2dade7ab5f9624dbf6448dc291b46d5ec94d3/wcwidth-0.6.0-py3-none-any.whl", hash = "sha256:1a3a1e510b553315f8e146c54764f4fb6264ffad731b3d78088cdb1478ffbdad", size = 94189, upload-time = "2026-02-06T19:19:39.646Z" },
+]
+
+[[package]]
+name = "zipp"
+version = "3.23.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964ded15ab726fad40f25fd3d788fd741cc1c5a17d78ee8/zipp-3.23.1.tar.gz", hash = "sha256:32120e378d32cd9714ad503c1d024619063ec28aad2248dc6672ad13edfa5110", size = 25965, upload-time = "2026-04-13T23:21:46.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]


### PR DESCRIPTION
## Summary

- Adds OTel GenAI semconv v1.40 manual span authoring at 3 attach points (`invoke_agent` / `chat` / `execute_tool`), wired to Langfuse v3 via OTLP http/protobuf.
- Bridges to existing `MetricsCollector`/`ObservabilityEventLogger` without touching public APIs or the `_ALLOWED_METADATA_KEYS` PII whitelist.
- Ships `docker-compose.dev.yml` for local Langfuse v3 + CI-wide `OTEL_SDK_DISABLED=true` no-op enforcement.

## Test plan

- [x] `OTEL_SDK_DISABLED=true uv run pytest tests/` → 1529 passed, 33 skipped
- [x] `uv run pytest tests/` (unset) → 1529 passed, 33 skipped
- [x] Runtime deps: exactly 3 new `opentelemetry-*` entries (no instrumentors)
- [x] PII audit across `engine/query.py`, `llm/client.py`, `tools/executor.py` — only whitelist-approved span attributes
- [x] Streaming usage aggregation write-once invariant verified (T021)
- [x] 429 retry counter pre-stream + mid-stream increments (T022)
- [ ] Manual: `docker compose -f docker-compose.dev.yml up -d` + CLI query → single trace with 3 span kinds in Langfuse UI

Closes #463