### PR TITLE
fix(tools): resolve MEDIUM+ code review issues across MVP tool layer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ markers = [
 ]
 filterwarnings = [
     "error",
-    "ignore::pytest.PytestUnraisableExceptionWarning",
     "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ markers = [
 ]
 filterwarnings = [
     "error",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
     "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 

--- a/src/kosmos/tools/envelope.py
+++ b/src/kosmos/tools/envelope.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import TypeAdapter, ValidationError
 
@@ -29,6 +29,17 @@ from kosmos.tools.models import (
     LookupMeta,
     LookupOutput,
 )
+
+LookupErrorReason = Literal[
+    "auth_required",
+    "stale_data",
+    "timeout",
+    "upstream_unavailable",
+    "unknown_tool",
+    "invalid_params",
+    "out_of_domain",
+    "empty_registry",
+]
 
 if TYPE_CHECKING:
     from kosmos.tools.models import GovAPITool
@@ -99,7 +110,7 @@ def normalize(
 
 def make_error_envelope(
     tool_id: str,
-    reason: str,
+    reason: LookupErrorReason,
     message: str,
     request_id: str,
     elapsed_ms: int,
@@ -121,7 +132,7 @@ def make_error_envelope(
     )
     return LookupErrorModel(
         kind="error",
-        reason=reason,  # type: ignore[arg-type]
+        reason=reason,
         message=message,
         retryable=retryable,
         upstream_code=upstream_code,

--- a/src/kosmos/tools/envelope.py
+++ b/src/kosmos/tools/envelope.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pydantic import TypeAdapter, ValidationError
 
-from kosmos.tools.errors import EnvelopeNormalizationError
+from kosmos.tools.errors import EnvelopeNormalizationError, LookupErrorReason
 from kosmos.tools.models import (
     LookupError as LookupErrorModel,
 )
@@ -29,17 +29,6 @@ from kosmos.tools.models import (
     LookupMeta,
     LookupOutput,
 )
-
-LookupErrorReason = Literal[
-    "auth_required",
-    "stale_data",
-    "timeout",
-    "upstream_unavailable",
-    "unknown_tool",
-    "invalid_params",
-    "out_of_domain",
-    "empty_registry",
-]
 
 if TYPE_CHECKING:
     from kosmos.tools.models import GovAPITool

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -26,8 +26,8 @@ from kosmos.observability import (
     GEN_AI_TOOL_TYPE,
     filter_metadata,
 )
-from kosmos.tools.envelope import LookupErrorReason, make_error_envelope
-from kosmos.tools.errors import ToolNotFoundError
+from kosmos.tools.envelope import make_error_envelope
+from kosmos.tools.errors import LookupErrorReason, ToolNotFoundError
 from kosmos.tools.models import ToolResult
 from kosmos.tools.registry import ToolRegistry
 
@@ -50,12 +50,12 @@ def _classify_adapter_exception(exc: Exception) -> tuple[LookupErrorReason, bool
     from kosmos.tools.kma.projection import KMADomainError  # noqa: PLC0415
 
     if isinstance(exc, (ValueError, TypeError, KMADomainError)):
-        return ("invalid_params", False)
+        return (LookupErrorReason.invalid_params, False)
     if isinstance(exc, httpx.TimeoutException):
-        return ("timeout", True)
+        return (LookupErrorReason.timeout, True)
     if isinstance(exc, (httpx.HTTPStatusError, httpx.RequestError)):
-        return ("upstream_unavailable", True)
-    return ("upstream_unavailable", True)
+        return (LookupErrorReason.upstream_unavailable, True)
+    return (LookupErrorReason.upstream_unavailable, True)
 
 
 class ToolExecutor:
@@ -159,7 +159,7 @@ class ToolExecutor:
             logger.warning("invoke: tool not found: %s", tool_id)
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="unknown_tool",
+                reason=LookupErrorReason.unknown_tool,
                 message=f"No tool registered with id {tool_id!r}.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -174,7 +174,7 @@ class ToolExecutor:
             )
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="auth_required",
+                reason=LookupErrorReason.auth_required,
                 message=(
                     f"Tool {tool_id!r} requires authentication. "
                     "Provide a session identity to proceed."
@@ -190,7 +190,7 @@ class ToolExecutor:
             logger.warning("invoke: no adapter registered for tool: %s", tool_id)
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="unknown_tool",
+                reason=LookupErrorReason.unknown_tool,
                 message=f"No adapter registered for tool {tool_id!r}.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -201,10 +201,16 @@ class ToolExecutor:
         try:
             validated_input = tool.input_schema.model_validate(params)
         except ValidationError as exc:
-            logger.warning("invoke: input validation failed for %s: %s", tool_id, exc)
+            field_paths = [".".join(str(p) for p in e["loc"]) for e in exc.errors()]
+            logger.warning(
+                "invoke: input validation failed for %s (%d errors, fields: %s)",
+                tool_id,
+                exc.error_count(),
+                ", ".join(field_paths),
+            )
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="invalid_params",
+                reason=LookupErrorReason.invalid_params,
                 message="Invalid parameters for tool.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -215,7 +221,12 @@ class ToolExecutor:
         try:
             raw_output = await adapter(validated_input)
         except Exception as exc:
-            logger.warning("invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc)
+            logger.warning(
+                "invoke: adapter %s raised %s",
+                tool_id,
+                type(exc).__name__,
+                exc_info=True,
+            )
             reason, retryable = _classify_adapter_exception(exc)
             return make_error_envelope(
                 tool_id=tool_id,
@@ -238,7 +249,7 @@ class ToolExecutor:
             logger.error("invoke: envelope normalisation failed for %s: %s", tool_id, exc)
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="upstream_unavailable",
+                reason=LookupErrorReason.upstream_unavailable,
                 message="Response processing failed.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -294,7 +305,7 @@ class ToolExecutor:
                 # dispatch() has no session_identity parameter, so the auth gate in
                 # invoke() can never fire here — flag this for operational visibility.
                 if tool.requires_auth:
-                    logger.warning(
+                    logger.debug(
                         "dispatch() called for auth-required tool %r without auth gate",
                         tool_name,
                     )
@@ -383,10 +394,10 @@ class ToolExecutor:
                         result_dict = await adapter(validated_input)
                     except Exception as exc:
                         logger.warning(
-                            "Adapter %s raised %s: %s",
+                            "Adapter %s raised %s",
                             tool_name,
                             type(exc).__name__,
-                            exc,
+                            exc_info=True,
                         )
                         self._metrics_increment("tool.error_count", tool_name)
                         self._metrics_observe_duration(

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -215,9 +215,7 @@ class ToolExecutor:
         try:
             raw_output = await adapter(validated_input)
         except Exception as exc:
-            logger.warning(
-                "invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc
-            )
+            logger.warning("invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc)
             reason, retryable = _classify_adapter_exception(exc)
             return make_error_envelope(
                 tool_id=tool_id,
@@ -237,9 +235,7 @@ class ToolExecutor:
                 elapsed_ms=_elapsed(),
             )
         except EnvelopeNormalizationError as exc:
-            logger.error(
-                "invoke: envelope normalisation failed for %s: %s", tool_id, exc
-            )
+            logger.error("invoke: envelope normalisation failed for %s: %s", tool_id, exc)
             return make_error_envelope(
                 tool_id=tool_id,
                 reason="upstream_unavailable",

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -205,7 +205,7 @@ class ToolExecutor:
             return make_error_envelope(
                 tool_id=tool_id,
                 reason="invalid_params",
-                message=str(exc),
+                message="Invalid parameters for tool.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
                 retryable=False,
@@ -215,12 +215,14 @@ class ToolExecutor:
         try:
             raw_output = await adapter(validated_input)
         except Exception as exc:
-            logger.exception("invoke: adapter raised exception for %s: %s", tool_id, exc)
+            logger.warning(
+                "invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc
+            )
             reason, retryable = _classify_adapter_exception(exc)
             return make_error_envelope(
                 tool_id=tool_id,
                 reason=reason,
-                message=str(exc),
+                message="Tool execution failed.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
                 retryable=retryable,
@@ -235,11 +237,13 @@ class ToolExecutor:
                 elapsed_ms=_elapsed(),
             )
         except EnvelopeNormalizationError as exc:
-            logger.error("invoke: envelope normalisation failed for %s: %s", tool_id, exc)
+            logger.error(
+                "invoke: envelope normalisation failed for %s: %s", tool_id, exc
+            )
             return make_error_envelope(
                 tool_id=tool_id,
                 reason="upstream_unavailable",
-                message=str(exc),
+                message="Response processing failed.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
                 retryable=False,
@@ -289,6 +293,15 @@ class ToolExecutor:
                         error_type="not_found",
                     )
                     return _final_result
+
+                # Warn when the legacy dispatch() path is used for auth-required tools.
+                # dispatch() has no session_identity parameter, so the auth gate in
+                # invoke() can never fire here — flag this for operational visibility.
+                if tool.requires_auth:
+                    logger.warning(
+                        "dispatch() called for auth-required tool %r without auth gate",
+                        tool_name,
+                    )
 
                 # Step 2: Parse and validate input
                 try:
@@ -373,7 +386,12 @@ class ToolExecutor:
                     try:
                         result_dict = await adapter(validated_input)
                     except Exception as exc:
-                        logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)
+                        logger.warning(
+                            "Adapter %s raised %s: %s",
+                            tool_name,
+                            type(exc).__name__,
+                            exc,
+                        )
                         self._metrics_increment("tool.error_count", tool_name)
                         self._metrics_observe_duration(
                             "tool.duration_ms",
@@ -383,7 +401,7 @@ class ToolExecutor:
                         _final_result = ToolResult(
                             tool_id=tool_name,
                             success=False,
-                            error=str(exc),
+                            error="Tool execution failed.",
                             error_type="execution",
                         )
                         return _final_result
@@ -451,12 +469,14 @@ class ToolExecutor:
 
     def _handle_unexpected_error(self, tool_name: str, exc: BaseException) -> ToolResult:
         """Convert an unexpected exception to a ToolResult (never raises)."""
-        logger.exception("Unexpected error during dispatch of tool %s: %s", tool_name, exc)
+        logger.error(
+            "Unexpected error during dispatch of tool %s: %s", tool_name, exc, exc_info=True
+        )
         self._metrics_increment("tool.error_count", tool_name)
         return ToolResult(
             tool_id=tool_name,
             success=False,
-            error=f"Internal error: {exc}",
+            error="Internal error occurred.",
             error_type="execution",
         )
 

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -26,7 +26,7 @@ from kosmos.observability import (
     GEN_AI_TOOL_TYPE,
     filter_metadata,
 )
-from kosmos.tools.envelope import make_error_envelope
+from kosmos.tools.envelope import LookupErrorReason, make_error_envelope
 from kosmos.tools.errors import ToolNotFoundError
 from kosmos.tools.models import ToolResult
 from kosmos.tools.registry import ToolRegistry
@@ -43,7 +43,7 @@ _tracer = trace.get_tracer(__name__)
 AdapterFn = Callable[[BaseModel], Awaitable[dict[str, Any]]]
 
 
-def _classify_adapter_exception(exc: Exception) -> tuple[str, bool]:
+def _classify_adapter_exception(exc: Exception) -> tuple[LookupErrorReason, bool]:
     """Map adapter exceptions to (reason, retryable) for the error envelope."""
     import httpx  # noqa: PLC0415
 

--- a/src/kosmos/tools/geocoding/juso.py
+++ b/src/kosmos/tools/geocoding/juso.py
@@ -90,7 +90,7 @@ async def lookup_adm_cd(
         }
 
     except Exception as exc:
-        logger.debug("juso.lookup_adm_cd failed for %r: %s", query, exc)
+        logger.warning("juso.lookup_adm_cd failed for %r: %s", query, exc)
         return None
 
     finally:

--- a/src/kosmos/tools/geocoding/juso.py
+++ b/src/kosmos/tools/geocoding/juso.py
@@ -90,7 +90,12 @@ async def lookup_adm_cd(
         }
 
     except Exception as exc:
-        logger.warning("juso.lookup_adm_cd failed for %r: %s", query, exc)
+        logger.warning(
+            "juso.lookup_adm_cd failed (query_len=%d): %s",
+            len(query),
+            type(exc).__name__,
+            exc_info=True,
+        )
         return None
 
     finally:

--- a/src/kosmos/tools/geocoding/sgis.py
+++ b/src/kosmos/tools/geocoding/sgis.py
@@ -115,7 +115,7 @@ async def lookup_adm_cd_by_coords(
         }
 
     except Exception as exc:
-        logger.debug("sgis.lookup_adm_cd_by_coords failed for (%s, %s): %s", lat, lon, exc)
+        logger.warning("sgis.lookup_adm_cd_by_coords failed for (%s, %s): %s", lat, lon, exc)
         return None
 
     finally:

--- a/src/kosmos/tools/geocoding/sgis.py
+++ b/src/kosmos/tools/geocoding/sgis.py
@@ -115,7 +115,11 @@ async def lookup_adm_cd_by_coords(
         }
 
     except Exception as exc:
-        logger.warning("sgis.lookup_adm_cd_by_coords failed for (%s, %s): %s", lat, lon, exc)
+        logger.warning(
+            "sgis.lookup_adm_cd_by_coords failed (coords_provided=True): %s",
+            type(exc).__name__,
+            exc_info=True,
+        )
         return None
 
     finally:

--- a/src/kosmos/tools/hira/hospital_search.py
+++ b/src/kosmos/tools/hira/hospital_search.py
@@ -24,7 +24,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from kosmos.tools.errors import _require_env
+from kosmos.tools.errors import ToolExecutionError, _require_env
 from kosmos.tools.models import GovAPITool
 
 logger = logging.getLogger(__name__)
@@ -144,10 +144,11 @@ async def handle(
 
         content_type = response.headers.get("content-type", "")
         if "xml" in content_type.lower() and "json" not in content_type.lower():
-            raise RuntimeError(
+            raise ToolExecutionError(
+                "hira_hospital_search",
                 f"HIRA API returned XML instead of JSON "
                 f"(Content-Type: {content_type!r}). "
-                "Append '&type=json' to the request or check the serviceKey."
+                "Append '&type=json' to the request or check the serviceKey.",
             )
 
         raw: dict[str, Any] = response.json()
@@ -170,7 +171,10 @@ async def handle(
         }
 
     if result_code != "00":
-        raise RuntimeError(f"HIRA API error: resultCode={result_code!r} resultMsg={result_msg!r}")
+        raise ToolExecutionError(
+            "hira_hospital_search",
+            f"HIRA API error: resultCode={result_code!r} resultMsg={result_msg!r}",
+        )
 
     body = response_body.get("body", {})
     total_count = int(body.get("totalCount", 0))

--- a/src/kosmos/tools/kma/forecast_fetch.py
+++ b/src/kosmos/tools/kma/forecast_fetch.py
@@ -188,7 +188,7 @@ async def _fetch(
     if inp.base_time not in _VALID_BASE_TIMES:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.invalid_params.value,
+            reason=LookupErrorReason.invalid_params,
             message=(
                 f"base_time {inp.base_time!r} is not a valid KMA forecast base time. "
                 f"Must be one of: {', '.join(sorted(_VALID_BASE_TIMES))}."
@@ -201,7 +201,7 @@ async def _fetch(
     except KMADomainError as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.out_of_domain.value,
+            reason=LookupErrorReason.out_of_domain,
             message=str(exc),
         )
 
@@ -243,7 +243,7 @@ async def _fetch(
         if "xml" in content_type.lower() and "json" not in content_type.lower():
             return LookupError(
                 kind="error",
-                reason=LookupErrorReason.upstream_unavailable.value,
+                reason=LookupErrorReason.upstream_unavailable,
                 message=(
                     f"KMA API returned XML instead of JSON "
                     f"(content-type={content_type!r}). "
@@ -256,13 +256,13 @@ async def _fetch(
     except httpx.HTTPStatusError as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.upstream_unavailable.value,
+            reason=LookupErrorReason.upstream_unavailable,
             message=f"HTTP error from KMA forecast API: {exc.response.status_code}",
         )
     except httpx.RequestError as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.timeout.value,
+            reason=LookupErrorReason.timeout,
             message=f"Network error reaching KMA forecast API: {exc}",
             retryable=True,
         )
@@ -279,14 +279,14 @@ async def _fetch(
     except (KeyError, TypeError) as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.upstream_unavailable.value,
+            reason=LookupErrorReason.upstream_unavailable,
             message=f"Unexpected KMA response structure: {exc}",
         )
 
     if result_code != "00":
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.upstream_unavailable.value,
+            reason=LookupErrorReason.upstream_unavailable,
             message=f"KMA API error: resultCode={result_code!r} resultMsg={result_msg!r}",
             upstream_code=result_code,
             upstream_message=result_msg,

--- a/src/kosmos/tools/kma/forecast_fetch.py
+++ b/src/kosmos/tools/kma/forecast_fetch.py
@@ -38,7 +38,7 @@ from kosmos.tools.models import GovAPITool, LookupError, LookupTimeseries  # noq
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
+_BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
 
 _VALID_BASE_TIMES: frozenset[str] = frozenset(
     {"0200", "0500", "0800", "1100", "1400", "1700", "2000", "2300"}

--- a/src/kosmos/tools/kma/grid_coords.py
+++ b/src/kosmos/tools/kma/grid_coords.py
@@ -10,7 +10,7 @@ Reference: KMA VilageFcstInfoService_2.0 API technical guide.
 
 from __future__ import annotations
 
-import math
+from kosmos.tools.kma.projection import latlon_to_lcc
 
 # REGION_TO_GRID: maps region name strings to (nx, ny) KMA grid tuples.
 # Keys include both Korean and common Romanized names for broad matching.
@@ -152,40 +152,4 @@ def latlon_to_grid(lat: float, lon: float) -> tuple[int, int]:
     Returns:
         A ``(nx, ny)`` tuple of integer KMA grid coordinates.
     """
-    # KMA Lambert Conformal Conic projection constants (official KMA parameters)
-    earth_radius_km = 6371.00877  # Earth radius [km]
-    grid_km = 5.0  # Grid resolution [km]
-    slat1_deg = 30.0  # Standard latitude 1 [degrees]
-    slat2_deg = 60.0  # Standard latitude 2 [degrees]
-    olon_deg = 126.0  # Reference (true) longitude [degrees]
-    olat_deg = 38.0  # Reference latitude [degrees]
-    xo = 43.0  # Grid x-origin offset
-    yo = 136.0  # Grid y-origin offset
-
-    degrad = math.pi / 180.0
-
-    re = earth_radius_km / grid_km
-    slat1 = slat1_deg * degrad
-    slat2 = slat2_deg * degrad
-    olon = olon_deg * degrad
-    olat = olat_deg * degrad
-
-    sn = math.tan(math.pi * 0.25 + slat2 * 0.5) / math.tan(math.pi * 0.25 + slat1 * 0.5)
-    sn = math.log(math.cos(slat1) / math.cos(slat2)) / math.log(sn)
-    sf = math.tan(math.pi * 0.25 + slat1 * 0.5)
-    sf = (sf**sn) * math.cos(slat1) / sn
-    ro = math.tan(math.pi * 0.25 + olat * 0.5)
-    ro = re * sf / (ro**sn)
-
-    ra = math.tan(math.pi * 0.25 + lat * degrad * 0.5)
-    ra = re * sf / (ra**sn)
-    theta = lon * degrad - olon
-    if theta > math.pi:
-        theta -= 2.0 * math.pi
-    if theta < -math.pi:
-        theta += 2.0 * math.pi
-    theta *= sn
-
-    nx = int(ra * math.sin(theta) + xo + 1.5)
-    ny = int(ro - ra * math.cos(theta) + yo + 1.5)
-    return nx, ny
+    return latlon_to_lcc(lat, lon)

--- a/src/kosmos/tools/kma/kma_pre_warning.py
+++ b/src/kosmos/tools/kma/kma_pre_warning.py
@@ -29,7 +29,7 @@ from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/WthrWrnInfoService/getWthrPwnList"
+_BASE_URL = "https://apis.data.go.kr/1360000/WthrWrnInfoService/getWthrPwnList"
 
 # ---------------------------------------------------------------------------
 # Input / Output models

--- a/src/kosmos/tools/kma/kma_short_term_forecast.py
+++ b/src/kosmos/tools/kma/kma_short_term_forecast.py
@@ -30,7 +30,7 @@ from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
+_BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
 
 # Valid base times for the short-term forecast service (KST)
 _VALID_BASE_TIMES = frozenset({"0200", "0500", "0800", "1100", "1400", "1700", "2000", "2300"})

--- a/src/kosmos/tools/kma/kma_ultra_short_term_forecast.py
+++ b/src/kosmos/tools/kma/kma_ultra_short_term_forecast.py
@@ -34,7 +34,7 @@ from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst"
+_BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst"
 
 # ---------------------------------------------------------------------------
 # Input model (output reuses ForecastItem / KmaShortTermForecastOutput)

--- a/src/kosmos/tools/kma/kma_weather_alert_status.py
+++ b/src/kosmos/tools/kma/kma_weather_alert_status.py
@@ -22,7 +22,9 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from kosmos.tools.errors import ConfigurationError, ToolExecutionError, _require_env  # noqa: F401
+from kosmos.tools.executor import ToolExecutor
 from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -319,22 +321,17 @@ KMA_WEATHER_ALERT_STATUS_TOOL = GovAPITool(
 )
 
 
-def register(registry: object, executor: object) -> None:
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
     """Register KMA weather alert status tool and its adapter.
 
     Args:
-        registry: A ToolRegistry instance.
-        executor: A ToolExecutor instance.
+        registry: The central ``ToolRegistry`` to add the tool to.
+        executor: The ``ToolExecutor`` to bind the adapter function to.
     """
-    from kosmos.tools.executor import ToolExecutor
-    from kosmos.tools.registry import ToolRegistry
+    from typing import cast
 
-    assert isinstance(registry, ToolRegistry)
-    assert isinstance(executor, ToolExecutor)
+    from kosmos.tools.executor import AdapterFn
 
     registry.register(KMA_WEATHER_ALERT_STATUS_TOOL)
-    executor.register_adapter(
-        "kma_weather_alert_status",
-        lambda inp: _call(KmaWeatherAlertStatusInput.model_validate(inp.model_dump())),
-    )
+    executor.register_adapter("kma_weather_alert_status", cast(AdapterFn, _call))
     logger.info("Registered tool: kma_weather_alert_status")

--- a/src/kosmos/tools/koroad/accident_hazard_search.py
+++ b/src/kosmos/tools/koroad/accident_hazard_search.py
@@ -25,7 +25,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from kosmos.tools.errors import _require_env
+from kosmos.tools.errors import ToolExecutionError, _require_env
 from kosmos.tools.models import GovAPITool
 
 logger = logging.getLogger(__name__)
@@ -786,8 +786,9 @@ async def handle(
 
         content_type = response.headers.get("content-type", "")
         if "xml" in content_type.lower() and "json" not in content_type.lower():
-            raise RuntimeError(
-                f"KOROAD API returned XML instead of JSON (Content-Type: {content_type!r})."
+            raise ToolExecutionError(
+                "koroad_accident_hazard_search",
+                f"KOROAD API returned XML instead of JSON (Content-Type: {content_type!r}).",
             )
 
         raw: dict[str, Any] = response.json()
@@ -807,7 +808,10 @@ async def handle(
         }
 
     if result_code != "00":
-        raise RuntimeError(f"KOROAD API error: code={result_code!r} msg={result_msg!r}")
+        raise ToolExecutionError(
+            "koroad_accident_hazard_search",
+            f"KOROAD API error: code={result_code!r} msg={result_msg!r}",
+        )
 
     total_count = int(raw.get("totalCount", 0))
     raw_items = raw.get("items", {})

--- a/src/kosmos/tools/koroad/koroad_accident_search.py
+++ b/src/kosmos/tools/koroad/koroad_accident_search.py
@@ -107,7 +107,7 @@ class KoroadAccidentSearchInput(BaseModel):
     si_do: SidoCode = Field(
         description=(
             "Province/city code (siDo wire parameter). "
-            "MUST be derived from a prior address_to_region geocoding tool call "
+            "MUST be derived from a prior resolve_location geocoding tool call "
             "on the user-provided location string — never fill this from model memory. "
             "Empirical counter-example: a Korean-domain LLM produced gu_gun=110 (Jongno) "
             "instead of gu_gun=680 (Gangnam) for a '강남역' query because it guessed from "
@@ -120,7 +120,7 @@ class KoroadAccidentSearchInput(BaseModel):
     gu_gun: GugunCode = Field(
         description=(
             "District/county code (guGun wire parameter). Required by the KOROAD API. "
-            "MUST be derived from a prior address_to_region geocoding tool call "
+            "MUST be derived from a prior resolve_location geocoding tool call "
             "on the user-provided location string — never fill this from model memory. "
             "Empirical counter-example: a Korean-domain LLM produced gu_gun=110 (Jongno) "
             "instead of gu_gun=680 (Gangnam) for a '강남역' query because it guessed from "
@@ -352,7 +352,7 @@ KOROAD_ACCIDENT_SEARCH_TOOL = GovAPITool(
     llm_description=(
         "Query the authoritative KOROAD accident-prone hotspot dataset for a "
         "Korean municipality. To call this tool correctly: first invoke "
-        "`address_to_region` with the citizen's place name to obtain the "
+        "`resolve_location` with the citizen's place name to obtain the "
         "accurate si_do and gu_gun codes, then pass those codes here. "
         "This is the canonical source for Korean accident hotspot data — "
         "use it whenever the citizen asks about traffic accidents, dangerous "

--- a/src/kosmos/tools/lookup.py
+++ b/src/kosmos/tools/lookup.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import uuid
 
+from kosmos.tools.errors import LookupErrorReason
 from kosmos.tools.models import (
     LookupCollection,
     LookupError,  # noqa: A004
@@ -137,7 +138,7 @@ async def _lookup_fetch(
     if executor is None or not isinstance(executor, ToolExecutor):
         return LookupError(
             kind="error",
-            reason="unknown_tool",
+            reason=LookupErrorReason.unknown_tool,
             message=f"No executor available to invoke tool {inp.tool_id!r}.",
             retryable=False,
         )

--- a/src/kosmos/tools/lookup.py
+++ b/src/kosmos/tools/lookup.py
@@ -32,6 +32,7 @@ async def lookup(
     *,
     registry: object | None = None,
     executor: object | None = None,
+    session_identity: str | None = None,
 ) -> LookupSearchResult | LookupRecord | LookupCollection | LookupTimeseries | LookupError:
     """Dispatch a lookup call by mode.
 
@@ -39,6 +40,8 @@ async def lookup(
         inp: Validated LookupSearchInput or LookupFetchInput.
         registry: ToolRegistry instance (required for search mode).
         executor: ToolExecutor instance (required for fetch mode).
+        session_identity: Caller identity token.  None = unauthenticated.
+            Forwarded to executor.invoke() to enable the Layer 3 auth gate.
 
     Returns:
         One of the 5 LookupOutput variants.
@@ -46,7 +49,7 @@ async def lookup(
     if isinstance(inp, LookupSearchInput):
         return await _lookup_search(inp, registry=registry)
     else:
-        return await _lookup_fetch(inp, executor=executor)
+        return await _lookup_fetch(inp, executor=executor, session_identity=session_identity)
 
 
 async def _lookup_search(
@@ -122,6 +125,7 @@ async def _lookup_fetch(
     inp: LookupFetchInput,
     *,
     executor: object | None = None,
+    session_identity: str | None = None,
 ) -> LookupRecord | LookupCollection | LookupTimeseries | LookupError:
     """Handle fetch mode: typed adapter invocation via executor.
 
@@ -144,6 +148,7 @@ async def _lookup_fetch(
         tool_id=inp.tool_id,
         params=inp.params,
         request_id=request_id,
+        session_identity=session_identity,
     )
 
     # executor.invoke() always returns a LookupOutput variant — pass through

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -9,6 +9,8 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from kosmos.tools.errors import LookupErrorReason
+
 
 class GovAPITool(BaseModel):
     """Government API tool definition with fail-closed security defaults.
@@ -513,16 +515,7 @@ class LookupError(BaseModel):  # noqa: A001
     model_config = ConfigDict(extra="forbid")
 
     kind: Literal["error"]
-    reason: Literal[
-        "auth_required",
-        "stale_data",
-        "timeout",
-        "upstream_unavailable",
-        "unknown_tool",
-        "invalid_params",
-        "out_of_domain",
-        "empty_registry",
-    ]
+    reason: LookupErrorReason
     message: str
     upstream_code: str | None = None
     upstream_message: str | None = None

--- a/src/kosmos/tools/resolve_location.py
+++ b/src/kosmos/tools/resolve_location.py
@@ -360,9 +360,7 @@ async def resolve_location(  # noqa: C901
                         # Overwrite coords_bundle with fresh values from this call
                         # so all "all"-mode data shares the same source response.
                         total = kakao_result.meta.total_count
-                        confidence = (
-                            "high" if total == 1 else ("medium" if total <= 3 else "low")
-                        )
+                        confidence = "high" if total == 1 else ("medium" if total <= 3 else "low")
                         coords_bundle = CoordResult(
                             kind="coords",
                             lat=lat,
@@ -386,12 +384,8 @@ async def resolve_location(  # noqa: C901
                             road_address=(
                                 doc.road_address.address_name if doc.road_address else None
                             ),
-                            jibun_address=(
-                                doc.address.address_name if doc.address else None
-                            ),
-                            postal_code=(
-                                doc.road_address.zone_no if doc.road_address else None
-                            ),
+                            jibun_address=(doc.address.address_name if doc.address else None),
+                            postal_code=(doc.road_address.zone_no if doc.road_address else None),
                             source="kakao",
                         )
             except Exception:

--- a/src/kosmos/tools/resolve_location.py
+++ b/src/kosmos/tools/resolve_location.py
@@ -16,7 +16,6 @@ FR-036: ``ResolveBundle`` carries per-backend provenance.
 from __future__ import annotations
 
 import logging
-import re
 
 import httpx
 
@@ -31,20 +30,6 @@ from kosmos.tools.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Regex patterns for input classification (FR-004 dispatch rules §4.4)
-_COORD_RE = re.compile(r"^-?\d+\.?\d*\s*,\s*-?\d+\.?\d*$")
-_ROAD_ADDR_RE = re.compile(r"[로길]\s*\d+")
-
-
-def _classify_query(query: str) -> str:
-    """Classify a query as 'coord', 'address', or 'place'."""
-    stripped = query.strip()
-    if _COORD_RE.match(stripped):
-        return "coord"
-    if _ROAD_ADDR_RE.search(stripped):
-        return "address"
-    return "place"
 
 
 async def _kakao_geocode(
@@ -291,13 +276,16 @@ async def resolve_location(  # noqa: C901
                 reason="not_found",
                 message=f"Could not resolve address for query {query!r}.",
             )
-        # Convert juso result to AddressResult (juso returns road address in admCd call)
-        return AddressResult(
-            kind="address",
-            road_address=adm.name,
-            jibun_address=None,
-            postal_code=None,
-            source="juso",
+        # adm.name is an administrative area name (e.g. "서울특별시 강남구"), not a
+        # specific road or jibun address.  Returning it in road_address would
+        # mislead callers, so we surface an honest not_found error instead.
+        return ResolveError(
+            kind="error",
+            reason="not_found",
+            message=(
+                f"JUSO resolved only an administrative area ({adm.name!r}) for"
+                f" query {query!r}, not a specific road or jibun address."
+            ),
         )
 
     # --- poi path ---
@@ -315,10 +303,10 @@ async def resolve_location(  # noqa: C901
                     lat = lon = None  # type: ignore[assignment]
 
                 if lat is not None and lon is not None:
-                    addr_block = doc.road_address or doc.address
-                    category = ""
-                    if addr_block:
-                        category = getattr(addr_block, "region_1depth_name", "")
+                    # address_type gives "REGION"|"ROAD"|"REGION_ADDR"|"ROAD_ADDR"
+                    # which is a more meaningful category than the province name
+                    # that region_1depth_name would return.
+                    category = getattr(doc, "address_type", "")
 
                     return POIResult(
                         kind="poi",
@@ -353,17 +341,15 @@ async def resolve_location(  # noqa: C901
             adm_bundle = await _sgis_adm_cd(query, coords=coords_bundle, client=client)
 
         if want == "all":
-            # Also resolve address and POI
-            geo = await _kakao_geocode(query, client=client)
-            if isinstance(geo, AddressResult):
-                address_result = geo
-
+            # Single Kakao call to extract address, coords, and POI together,
+            # avoiding the three separate calls (_kakao_geocode, _kakao_coords,
+            # search_address) that would hit the same endpoint with the same query.
             try:
                 from kosmos.tools.geocoding.kakao_client import search_address
 
-                result = await search_address(query, client=client)
-                if result.documents:
-                    doc = result.documents[0]
+                kakao_result = await search_address(query, client=client)
+                if kakao_result.documents:
+                    doc = kakao_result.documents[0]
                     try:
                         lat = float(doc.y)
                         lon = float(doc.x)
@@ -371,16 +357,49 @@ async def resolve_location(  # noqa: C901
                         lat = lon = None  # type: ignore[assignment]
 
                     if lat is not None and lon is not None:
+                        # Overwrite coords_bundle with fresh values from this call
+                        # so all "all"-mode data shares the same source response.
+                        total = kakao_result.meta.total_count
+                        confidence = (
+                            "high" if total == 1 else ("medium" if total <= 3 else "low")
+                        )
+                        coords_bundle = CoordResult(
+                            kind="coords",
+                            lat=lat,
+                            lon=lon,
+                            confidence=confidence,  # type: ignore[arg-type]
+                            source="kakao",
+                        )
+
                         poi_result = POIResult(
                             kind="poi",
                             name=doc.address_name,
-                            category="",
+                            category=getattr(doc, "address_type", ""),
                             lat=lat,
                             lon=lon,
                             source="kakao",
                         )
+
+                    if doc.road_address or doc.address:
+                        address_result = AddressResult(
+                            kind="address",
+                            road_address=(
+                                doc.road_address.address_name if doc.road_address else None
+                            ),
+                            jibun_address=(
+                                doc.address.address_name if doc.address else None
+                            ),
+                            postal_code=(
+                                doc.road_address.zone_no if doc.road_address else None
+                            ),
+                            source="kakao",
+                        )
             except Exception:
-                logger.debug("POI extraction failed; continuing without POI result", exc_info=True)
+                logger.debug(
+                    "Kakao resolution failed for %r; continuing without address/POI",
+                    query,
+                    exc_info=True,
+                )
 
         if coords_bundle is None and adm_bundle is None:
             return ResolveError(

--- a/src/kosmos/tools/resolve_location.py
+++ b/src/kosmos/tools/resolve_location.py
@@ -332,18 +332,9 @@ async def resolve_location(  # noqa: C901
         address_result: AddressResult | None = None
         poi_result: POIResult | None = None
 
-        # Resolve coordinates via kakao
-        coords_bundle = await _kakao_coords(query, client=client)
-
-        # Resolve adm_cd via juso (preferred) or sgis (fallback)
-        adm_bundle = await _juso_adm_cd(query, client=client)
-        if adm_bundle is None:
-            adm_bundle = await _sgis_adm_cd(query, coords=coords_bundle, client=client)
-
         if want == "all":
-            # Single Kakao call to extract address, coords, and POI together,
-            # avoiding the three separate calls (_kakao_geocode, _kakao_coords,
-            # search_address) that would hit the same endpoint with the same query.
+            # Single Kakao call for coords, address, and POI — avoids the
+            # redundant _kakao_coords() + search_address() double-call.
             try:
                 from kosmos.tools.geocoding.kakao_client import search_address
 
@@ -357,8 +348,6 @@ async def resolve_location(  # noqa: C901
                         lat = lon = None  # type: ignore[assignment]
 
                     if lat is not None and lon is not None:
-                        # Overwrite coords_bundle with fresh values from this call
-                        # so all "all"-mode data shares the same source response.
                         total = kakao_result.meta.total_count
                         confidence = "high" if total == 1 else ("medium" if total <= 3 else "low")
                         coords_bundle = CoordResult(
@@ -390,10 +379,16 @@ async def resolve_location(  # noqa: C901
                         )
             except Exception:
                 logger.debug(
-                    "Kakao resolution failed for %r; continuing without address/POI",
-                    query,
+                    "Kakao resolution failed; continuing without address/POI",
                     exc_info=True,
                 )
+        else:
+            coords_bundle = await _kakao_coords(query, client=client)
+
+        # Resolve adm_cd via juso (preferred) or sgis (fallback)
+        adm_bundle = await _juso_adm_cd(query, client=client)
+        if adm_bundle is None:
+            adm_bundle = await _sgis_adm_cd(query, coords=coords_bundle, client=client)
 
         if coords_bundle is None and adm_bundle is None:
             return ResolveError(

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -48,7 +48,7 @@ def sample_tool_factory():
         name_ko: str = "날씨예보",
         provider: str = "기상청",
         category: list[str] | None = None,
-        endpoint: str = "http://apis.data.go.kr/test",
+        endpoint: str = "https://apis.data.go.kr/test",
         auth_type: str = "api_key",
         search_hint: str = "날씨 예보 weather forecast 기상청",
         **overrides,
@@ -114,7 +114,7 @@ def populated_registry(sample_tool_factory) -> ToolRegistry:
         name_ko="교통사고통계",
         provider="도로교통공단",
         category=["교통", "사고"],
-        endpoint="http://apis.data.go.kr/koroad/accident",
+        endpoint="https://apis.data.go.kr/koroad/accident",
         search_hint="교통사고 통계 traffic accident road safety",
     )
 
@@ -124,7 +124,7 @@ def populated_registry(sample_tool_factory) -> ToolRegistry:
         name_ko="병원정보조회",
         provider="건강보험심사평가원",
         category=["의료", "병원"],
-        endpoint="http://apis.data.go.kr/hira/hospital",
+        endpoint="https://apis.data.go.kr/hira/hospital",
         search_hint="병원 의원 의료기관 hospital clinic HIRA",
     )
 
@@ -134,7 +134,7 @@ def populated_registry(sample_tool_factory) -> ToolRegistry:
         name_ko="사업자등록정보조회",
         provider="국세청",
         category=["사업자", "세금"],
-        endpoint="http://apis.data.go.kr/nts/business",
+        endpoint="https://apis.data.go.kr/nts/business",
         search_hint="사업자등록 법인 business registration NTS tax",
     )
 

--- a/tests/tools/koroad/test_koroad_accident_search.py
+++ b/tests/tools/koroad/test_koroad_accident_search.py
@@ -373,15 +373,15 @@ class TestSchemaContract:
         """Return the Python-level Field(description=...) value."""
         return str(KoroadAccidentSearchInput.model_fields[field_name].description or "")
 
-    def test_si_do_description_contains_address_to_region(self) -> None:
-        """si_do schema description must reference the address_to_region geocoding tool."""
+    def test_si_do_description_contains_resolve_location(self) -> None:
+        """si_do schema description must reference the resolve_location geocoding tool."""
         prop_desc = self._property_description("si_do")
         field_desc = self._field_description("si_do")
         combined = prop_desc + field_desc
-        assert "address_to_region" in combined, (
-            "'address_to_region' not found in si_do field description. "
+        assert "resolve_location" in combined, (
+            "'resolve_location' not found in si_do field description. "
             "The si_do description must instruct the LLM to derive the value "
-            "from a prior address_to_region geocoding call. "
+            "from a prior resolve_location geocoding call. "
             f"schema property description: {prop_desc!r} | field description: {field_desc!r}"
         )
 
@@ -410,15 +410,15 @@ class TestSchemaContract:
             f"Full schema keys: {list(schema.get('$defs', {}).keys())}"
         )
 
-    def test_gu_gun_description_contains_address_to_region(self) -> None:
-        """gu_gun schema description must reference the address_to_region geocoding tool."""
+    def test_gu_gun_description_contains_resolve_location(self) -> None:
+        """gu_gun schema description must reference the resolve_location geocoding tool."""
         prop_desc = self._property_description("gu_gun")
         field_desc = self._field_description("gu_gun")
         combined = prop_desc + field_desc
-        assert "address_to_region" in combined, (
-            "'address_to_region' not found in gu_gun field description. "
+        assert "resolve_location" in combined, (
+            "'resolve_location' not found in gu_gun field description. "
             "The gu_gun description must instruct the LLM to derive the value "
-            "from a prior address_to_region geocoding call. "
+            "from a prior resolve_location geocoding call. "
             f"schema property description: {prop_desc!r} | field description: {field_desc!r}"
         )
 

--- a/tests/tools/test_executor.py
+++ b/tests/tools/test_executor.py
@@ -132,7 +132,7 @@ async def test_dispatch_adapter_exception(sample_tool_factory):
 
     assert result.success is False
     assert result.error_type == "execution"
-    assert "upstream service unavailable" in (result.error or "")
+    assert result.error == "Tool execution failed."
     assert result.data is None
 
 

--- a/tests/tools/test_models.py
+++ b/tests/tools/test_models.py
@@ -24,7 +24,7 @@ _MINIMAL_KWARGS = {
     "name_ko": "테스트도구",
     "provider": "테스트기관",
     "category": ["test"],
-    "endpoint": "http://apis.data.go.kr/test",
+    "endpoint": "https://apis.data.go.kr/test",
     "auth_type": "api_key",
     "input_schema": _MinimalInput,
     "output_schema": _MinimalOutput,

--- a/tests/tools/test_resolve_location.py
+++ b/tests/tools/test_resolve_location.py
@@ -171,6 +171,9 @@ class TestResolveAddress:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_juso_when_kakao_fails(self):
+        # When Kakao fails and JUSO only resolves an administrative area name,
+        # the facade must return ResolveError rather than a misleading AddressResult
+        # with an admin area name in the road_address field.
         inp = ResolveLocationInput(query="서울 강남구 테헤란로 152", want="road_address")
         juso_adm = AdmCodeResult(
             kind="adm_cd",
@@ -190,8 +193,9 @@ class TestResolveAddress:
             ),
         ):
             result = await resolve_location(inp)
-        assert isinstance(result, AddressResult)
-        assert result.source == "juso"
+        assert isinstance(result, ResolveError)
+        assert result.reason == "not_found"
+        assert "administrative area" in result.message
 
     @pytest.mark.asyncio
     async def test_error_when_all_fail(self):
@@ -219,6 +223,7 @@ class TestResolvePOI:
         mock_doc.y = "37.4979"
         mock_doc.x = "127.0276"
         mock_doc.address_name = "강남역"
+        mock_doc.address_type = "REGION_ADDR"  # must be a plain string for Pydantic validation
         mock_doc.road_address = None
         mock_doc.address = None
 
@@ -232,6 +237,7 @@ class TestResolvePOI:
             result = await resolve_location(inp)
         assert isinstance(result, POIResult)
         assert result.name == "강남역"
+        assert result.category == "REGION_ADDR"
 
     @pytest.mark.asyncio
     async def test_poi_no_documents_returns_error(self):
@@ -324,12 +330,20 @@ class TestResolveCoordsAndAdmCd:
 class TestResolveAll:
     @pytest.mark.asyncio
     async def test_all_bundle_includes_address_and_poi(self):
+        # want="all" now makes a single consolidated Kakao call instead of three
+        # separate calls.  _kakao_geocode is no longer invoked for this path.
         inp = ResolveLocationInput(query="강남역", want="all")
+
+        mock_road_address = AsyncMock()
+        mock_road_address.address_name = "서울 강남구 테헤란로 152"
+        mock_road_address.zone_no = "06236"
+
         mock_doc = AsyncMock()
         mock_doc.y = "37.4979"
         mock_doc.x = "127.0276"
         mock_doc.address_name = "강남역"
-        mock_doc.road_address = None
+        mock_doc.address_type = "ROAD_ADDR"  # plain string required for Pydantic
+        mock_doc.road_address = mock_road_address
         mock_doc.address = None
 
         mock_search_result = AsyncMock()
@@ -345,10 +359,6 @@ class TestResolveAll:
             patch(
                 "kosmos.tools.resolve_location._juso_adm_cd",
                 new=AsyncMock(return_value=_ADM),
-            ),
-            patch(
-                "kosmos.tools.resolve_location._kakao_geocode",
-                new=AsyncMock(return_value=_ADDRESS),
             ),
             patch(
                 "kosmos.tools.geocoding.kakao_client.search_address",


### PR DESCRIPTION
## Summary

Fixes all MEDIUM and above severity issues identified by 5 parallel code reviews of #587 (MVP Main-Tool). 20 files changed across 4 parallel Agent Teams.

### Security & Auth (BLOCKER/HIGH)
- **HTTP → HTTPS**: All `data.go.kr` API endpoints upgraded to TLS (4 KMA adapters + test fixtures)
- **session_identity threading**: `lookup()` → `_lookup_fetch()` → `executor.invoke()` now passes identity so the auth gate is actually reachable
- **Error sanitization**: `str(exc)` in executor no longer leaks ValidationError traces, upstream API messages, or internal exceptions to callers

### Bug Fixes (HIGH)
- **JUSO fallback**: No longer returns admin area name (e.g. "서울특별시 강남구") in `road_address` field — returns `ResolveError` instead
- **POI category**: Uses `doc.address_type` ("REGION"|"ROAD"|"ROAD_ADDR") instead of province name
- **Stale tool refs**: `address_to_region` → `resolve_location` in KOROAD adapter Field descriptions + tests

### Performance & Deduplication (MEDIUM)
- **Kakao call consolidation**: `want="all"` in resolve_location makes 1 API call instead of 3
- **LCC projection dedup**: `grid_coords.latlon_to_grid` delegates to authoritative `projection.latlon_to_lcc`

### Code Quality (MEDIUM)
- **Typed reason**: `make_error_envelope(reason: str)` → `reason: LookupErrorReason` (Literal), removed `type: ignore`
- **Typed register()**: `kma_weather_alert_status.register()` uses proper types instead of `object` + `assert isinstance`
- **ToolExecutionError**: KOROAD/HIRA adapters use structured error instead of bare `RuntimeError`
- **Dead code removed**: `_classify_query()`, `_COORD_RE`, `_ROAD_ADDR_RE` in resolve_location.py
- **Logging upgrade**: Geocoding catch-all exceptions logged at `warning` instead of `debug`

## Test plan

- [x] `uv run pytest` — 1694 passed, 30 skipped, 0 failed
- [x] T043 LCC parity test still passes after grid_coords delegation
- [x] Test assertions co-updated for address_to_region → resolve_location rename
- [x] test_resolve_location tests updated for JUSO fallback behavior change
- [x] test_executor sanitized error message assertion updated