### PR TITLE
feat(tools): enforce NMC freshness SLO via hvidate validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,6 +53,7 @@ jobs:
           KOSMOS_DATA_GO_KR_KEY: "test-placeholder"
           KOSMOS_KOROAD_API_KEY: "test-placeholder"
           KOSMOS_FRIENDLI_TOKEN: "test-placeholder"
+          OTEL_SDK_DISABLED: "true"
       - name: Upload coverage
         if: matrix.python-version == '3.12'
         uses: actions/upload-artifact@v7

--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/022-mvp-main-tool"
+  "feature_directory": "specs/023-nmc-freshness-slo"
 }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -28,6 +28,8 @@ This project's agent instructions live in [`AGENTS.md`](./AGENTS.md). Read that 
 - N/A (span 메모리 버퍼 + OTLP 전송, 로컬 Langfuse는 Docker 스택의 Postgres/ClickHouse/MinIO가 담당) (021-observability-otel-genai)
 - Python 3.12+ + `httpx>=0.27` (async HTTP, existing), `pydantic>=2.13` (schemas, existing), `pydantic-settings>=2.0` (env config, existing), `rank_bm25>=0.2.2` (NEW — Apache-2.0, BM25 retrieval), `kiwipiepy>=0.17` (NEW — MIT, Korean morpheme tokenizer); LLM-visible surface (FR-001): `resolve_location` (geocoding) + `lookup` (two modes: `search` = BM25 retrieval, `fetch` = adapter invocation); 4 seed adapters: koroad_accident_hazard_search, kma_forecast_fetch, hira_hospital_search, nmc_emergency_search (022-mvp-main-tool)
 - N/A — in-memory registry; BM25 index rebuilt at registry boot and on registration; no persistent state (022-mvp-main-tool)
+- Python 3.12+ + pydantic >= 2.13, httpx >= 0.27 (existing) (023-nmc-freshness-slo)
+- N/A (in-memory validation only) (023-nmc-freshness-slo)
 
 ## Recent Changes
 - 019-phase1-hardening: LLM 429 resilience (Retry-After + exponential backoff + per-session semaphore) and KOROAD tool-input discipline (Field descriptions + session guidance)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,6 @@ markers = [
 ]
 filterwarnings = [
     "error",
-    "ignore::pytest.PytestUnraisableExceptionWarning",
     "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ markers = [
 ]
 filterwarnings = [
     "error",
+    "ignore::pytest.PytestUnraisableExceptionWarning",
     "ignore::pytest_benchmark.logger.PytestBenchmarkWarning",
 ]
 

--- a/specs/023-nmc-freshness-slo/checklists/requirements.md
+++ b/specs/023-nmc-freshness-slo/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: NMC Freshness SLO Enforcement
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-16
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec is ready for `/speckit-clarify` or `/speckit-plan`.
+- FR-001 through FR-008 are each directly testable via the acceptance scenarios in User Stories 1-3 and Edge Cases.
+- No [NEEDS CLARIFICATION] markers — the feature description was sufficiently detailed and existing codebase context (settings, error taxonomy, envelope model) resolved all ambiguities.

--- a/specs/023-nmc-freshness-slo/data-model.md
+++ b/specs/023-nmc-freshness-slo/data-model.md
@@ -1,0 +1,77 @@
+# Phase 1 Data Model: NMC Freshness SLO Enforcement
+
+**Date**: 2026-04-16
+**Branch**: `023-nmc-freshness-slo`
+
+## Entity Changes
+
+### Modified: LookupMeta (src/kosmos/tools/models.py)
+
+Add `freshness_status` optional field to the existing metadata model.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| source | str | (required) | tool_id of the adapter |
+| fetched_at | datetime | (required) | UTC timestamp |
+| request_id | str | (required) | UUID for tracing |
+| elapsed_ms | int (ge=0) | (required) | Elapsed time in milliseconds |
+| rate_limit_remaining | int \| None | None | Remaining rate-limit slots |
+| **freshness_status** | **Literal["fresh"] \| None** | **None** | **New. Set to "fresh" when NMC hvidate passes freshness check. None for non-NMC adapters or when freshness is not applicable.** |
+
+**Validation rules**: `freshness_status` must be either the literal string `"fresh"` or `None`. No other values are permitted. Pydantic v2 `Literal` type enforces this at validation time.
+
+**Backward compatibility**: Default is `None`, so existing adapters and tests are unaffected. JSON serialization with `exclude_none=True` omits the field entirely for non-NMC responses.
+
+### New: FreshnessResult (src/kosmos/tools/nmc/freshness.py)
+
+Internal utility type representing the result of a freshness check.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| is_fresh | bool | Whether the data passed the freshness threshold |
+| data_age_minutes | float | Age of the hvidate in minutes |
+| threshold_minutes | int | Configured freshness threshold |
+| hvidate_raw | str \| None | Original hvidate string (for error messages) |
+
+This is an internal dataclass, not part of the LookupOutput contract. It is consumed only by the NMC adapter handler.
+
+### Existing (no changes): LookupErrorReason (src/kosmos/tools/errors.py)
+
+`stale_data` variant already present in the enum:
+
+```python
+class LookupErrorReason(StrEnum):
+    stale_data = "stale_data"   # Already exists
+```
+
+### Existing (no changes): KosmosSettings (src/kosmos/settings.py)
+
+`nmc_freshness_minutes` already defined:
+
+```python
+nmc_freshness_minutes: int = Field(default=30, ge=1, le=1440)
+```
+
+## State Transitions
+
+```
+NMC Response Received
+    │
+    ├── hvidate present and parseable
+    │   ├── age <= threshold_minutes → freshness_status = "fresh" → return data envelope
+    │   └── age > threshold_minutes  → return LookupError(reason="stale_data")
+    │
+    └── hvidate missing/empty/unparseable → return LookupError(reason="stale_data")
+```
+
+## Relationships
+
+```
+KosmosSettings.nmc_freshness_minutes
+    ↓ (read at check time)
+check_freshness(hvidate_str, threshold_minutes)
+    ↓ (returns FreshnessResult)
+NMC adapter handle()
+    ├── fresh → inject freshness_status into response dict → envelope.normalize()
+    └── stale → return LookupError dict → envelope.normalize()
+```

--- a/specs/023-nmc-freshness-slo/plan.md
+++ b/specs/023-nmc-freshness-slo/plan.md
@@ -1,0 +1,76 @@
+# Implementation Plan: NMC Freshness SLO Enforcement
+
+**Branch**: `023-nmc-freshness-slo` | **Date**: 2026-04-16 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/023-nmc-freshness-slo/spec.md`
+
+## Summary
+
+Add freshness validation to the NMC emergency room adapter: compare the `hvidate` timestamp in every NMC response against `KOSMOS_NMC_FRESHNESS_MINUTES`, return `LookupError(reason="stale_data")` when stale, and inject `freshness_status` metadata into the response envelope when fresh. No new dependencies or layers; this is a Phase 1 quality hardening of existing Tool System infrastructure.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+
+**Primary Dependencies**: pydantic >= 2.13, httpx >= 0.27 (existing)
+**Storage**: N/A (in-memory validation only)
+**Testing**: pytest + pytest-asyncio, fixture-based (no live API calls)
+**Target Platform**: Linux / macOS server
+**Project Type**: Library (backend tool system module)
+**Performance Goals**: Freshness check adds < 1ms overhead per response
+**Constraints**: No new runtime dependencies; fail-closed on missing/unparseable hvidate
+**Scale/Scope**: Single adapter (nmc_emergency_search); pattern may be reused by future adapters
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evidence |
+|-----------|--------|----------|
+| I. Reference-Driven Development | PASS | Freshness SLO pattern references Layer 2 Tool System (Pydantic AI schema-driven registry) and Layer 6 Error Recovery (fail-closed defaults). No new architectural pattern introduced. |
+| II. Fail-Closed Security | PASS | Missing/unparseable `hvidate` → treated as stale (FR-008). `stale_data` error returned, data never silently passed. Consistent with `requires_auth=True`, `is_personal_data=True` defaults. |
+| III. Pydantic v2 Strict Typing | PASS | `freshness_status` added as Literal field on `LookupMeta`. `hvidate` parsing produces typed datetime. No `Any` types. |
+| IV. Government API Compliance | PASS | No live `data.go.kr` calls in CI tests. All tests use recorded fixtures. `KOSMOS_NMC_FRESHNESS_MINUTES` read from env var. |
+| V. Policy Alignment | PASS | Freshness enforcement prevents delivery of stale emergency data to citizens — safety-first per Principle 8 (single conversational window quality). |
+| VI. Deferred Work Accountability | PASS | No items deferred. All requirements addressed in this epic. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/023-nmc-freshness-slo/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (/speckit-tasks)
+```
+
+### Source Code (repository root)
+
+```text
+src/kosmos/
+├── settings.py                          # KOSMOS_NMC_FRESHNESS_MINUTES (existing, no changes)
+└── tools/
+    ├── models.py                        # LookupMeta.freshness_status field (new)
+    ├── envelope.py                      # No changes required
+    ├── errors.py                        # LookupErrorReason.stale_data (existing, no changes)
+    └── nmc/
+        ├── __init__.py                  # No changes
+        ├── emergency_search.py          # freshness validation logic (modified)
+        └── freshness.py                 # Freshness check utility (new)
+
+tests/
+├── fixtures/nmc/
+│   ├── auth_required_error.json         # Existing
+│   ├── fresh_response.json              # New fixture: hvidate within threshold
+│   └── stale_response.json              # New fixture: hvidate beyond threshold
+└── tools/nmc/
+    ├── test_emergency_search_auth_gate.py  # Existing, no changes
+    └── test_freshness_validation.py        # New: freshness check unit tests
+```
+
+**Structure Decision**: Freshness validation lives in `src/kosmos/tools/nmc/freshness.py` as a standalone utility module, keeping the adapter handler (`emergency_search.py`) focused on HTTP orchestration. The utility is NMC-specific (hvidate field semantics) so it belongs in the `nmc/` package, not in the generic tool system.
+
+## Complexity Tracking
+
+No constitution violations. No complexity justifications needed.

--- a/specs/023-nmc-freshness-slo/quickstart.md
+++ b/specs/023-nmc-freshness-slo/quickstart.md
@@ -1,0 +1,52 @@
+# Quickstart: NMC Freshness SLO Enforcement
+
+**Branch**: `023-nmc-freshness-slo`
+
+## What This Feature Does
+
+Adds freshness validation to the NMC emergency room adapter. When NMC API responses contain a `hvidate` timestamp older than the configured threshold, the system rejects the data with a structured `stale_data` error instead of silently delivering outdated emergency room information.
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `src/kosmos/tools/models.py` | Add `freshness_status: Literal["fresh"] \| None = None` to `LookupMeta` |
+| `src/kosmos/tools/nmc/freshness.py` | New file: `check_freshness()` utility function |
+| `src/kosmos/tools/nmc/emergency_search.py` | Integrate freshness check into adapter handler |
+
+## Files to Create (Tests)
+
+| File | Purpose |
+|------|---------|
+| `tests/tools/nmc/test_freshness_validation.py` | Unit tests for freshness utility |
+| `tests/fixtures/nmc/fresh_response.json` | Fixture: hvidate within threshold |
+| `tests/fixtures/nmc/stale_response.json` | Fixture: hvidate beyond threshold |
+
+## Files NOT Modified
+
+| File | Reason |
+|------|--------|
+| `src/kosmos/settings.py` | `nmc_freshness_minutes` already defined |
+| `src/kosmos/tools/errors.py` | `LookupErrorReason.stale_data` already in enum |
+| `src/kosmos/tools/envelope.py` | No adapter-specific logic; stays generic |
+| `src/kosmos/tools/executor.py` | No NMC-specific logic; stays generic |
+
+## How to Test
+
+```bash
+# Run freshness-specific tests
+uv run pytest tests/tools/nmc/test_freshness_validation.py -v
+
+# Run all NMC tests
+uv run pytest tests/tools/nmc/ -v
+
+# Run full test suite to verify no regressions
+uv run pytest
+```
+
+## Key Design Decisions
+
+1. **Freshness check in adapter, not executor**: NMC-specific `hvidate` semantics stay in the NMC package.
+2. **fail-closed on parse errors**: Missing/unparseable `hvidate` → stale (Constitution § II).
+3. **`freshness_status` on LookupMeta**: Optional field, None for non-NMC adapters, "fresh" when validated.
+4. **Stale → LookupError, not degraded data**: Users never see stale emergency data.

--- a/specs/023-nmc-freshness-slo/research.md
+++ b/specs/023-nmc-freshness-slo/research.md
@@ -1,0 +1,80 @@
+# Phase 0 Research: NMC Freshness SLO Enforcement
+
+**Date**: 2026-04-16
+**Branch**: `023-nmc-freshness-slo`
+
+## Research Tasks
+
+### R1: hvidate Field Format
+
+**Question**: What datetime format does the NMC `hvidate` field use?
+
+**Finding**: The NMC real-time bed availability API (`/api/nmc/v1/realtime-beds`) returns `hvidate` as a Korean datetime string. Based on `data.go.kr` NMC API documentation and PublicDataReader wire format analysis (vision.md reference), the field uses `YYYY-MM-DD HH:MM:SS` format (e.g., `"2026-04-16 14:30:00"`). Timezone is implicitly KST (Asia/Seoul, UTC+9).
+
+**Decision**: Parse `hvidate` with `datetime.strptime()` using `"%Y-%m-%d %H:%M:%S"` format, then localize to KST before comparison. If parsing fails, treat as stale (fail-closed per Constitution § II).
+
+**Alternatives considered**:
+- ISO 8601 parsing with `datetime.fromisoformat()`: Rejected — NMC uses space-separated format, not `T` separator.
+- `dateutil.parser.parse()`: Rejected — introduces a new dependency (`python-dateutil`), violates "no new dependencies" constraint.
+
+### R2: Freshness Check Insertion Point
+
+**Question**: Where in the adapter pipeline should freshness validation occur?
+
+**Finding**: The current pipeline is: `lookup(fetch)` → `executor.invoke()` → auth gate → adapter handler → `envelope.normalize()` → return. The freshness check is NMC-specific (depends on `hvidate` field semantics), so it should NOT live in the generic executor or envelope normalizer.
+
+**Decision**: Implement freshness validation as a utility function in `src/kosmos/tools/nmc/freshness.py`. The NMC adapter handler calls this utility after parsing the upstream response. If stale, the handler returns a `LookupError` dict directly (pre-envelope); if fresh, it injects `freshness_status: "fresh"` into the response dict before returning to the executor.
+
+**Alternatives considered**:
+- Post-processing hook in `executor.invoke()`: Rejected — couples NMC-specific logic to the generic executor.
+- Middleware in `envelope.normalize()`: Rejected — normalizer should not have adapter-specific knowledge.
+- Decorator on adapter handler: Rejected — over-engineered for a single adapter.
+
+**Reference**: Layer 2 Tool System design (vision.md) — adapter-specific logic stays in adapter modules; generic pipeline stays generic.
+
+### R3: freshness_status Envelope Metadata
+
+**Question**: Where should `freshness_status` appear in the response envelope?
+
+**Finding**: `LookupMeta` (defined in `models.py`) is injected into every `lookup(mode='fetch')` response by `envelope.normalize()`. Adding `freshness_status` to `LookupMeta` makes it available on all envelope variants (LookupRecord, LookupCollection, LookupTimeseries) without changing each variant individually.
+
+**Decision**: Add `freshness_status: Literal["fresh"] | None = None` to `LookupMeta`. Only NMC adapters (and future adapters with freshness semantics) populate this field. Non-NMC adapters leave it as `None` (omitted in JSON serialization).
+
+**Alternatives considered**:
+- NMC-specific response model: Rejected — breaks the uniform 5-variant discriminated union contract.
+- Separate metadata dict outside LookupMeta: Rejected — fragments the metadata namespace.
+- `Literal["fresh", "stale"]`: Rejected for the envelope field — stale responses return a LookupError, not a successful envelope, so `"stale"` would never appear in a successful response's meta. Keeping only `"fresh" | None` is honest.
+
+### R4: Stale Data Error Envelope Construction
+
+**Question**: How should the stale_data error be constructed?
+
+**Finding**: `make_error_envelope()` in `envelope.py` already constructs `LookupError` envelopes with full `LookupMeta`. `LookupErrorReason.stale_data` is already in the enum. The adapter handler can return a dict matching the `LookupError` shape, and `envelope.normalize()` will validate and pass it through.
+
+**Decision**: The freshness utility returns either:
+- `None` when data is fresh (caller proceeds normally)
+- A `dict` matching `LookupError` shape when data is stale (caller returns this directly)
+
+The caller (adapter handler) passes the stale error dict through the normal envelope normalization path. The error message includes the data age and configured threshold for LLM transparency.
+
+**Alternatives considered**:
+- Raise a custom exception and catch in executor: Rejected — the executor already handles adapter exceptions generically; a freshness-specific exception would need special-casing.
+- Return a sentinel value: Rejected — less explicit than returning the full error envelope dict.
+
+### R5: Timezone Handling
+
+**Question**: How to handle the timezone comparison between `hvidate` (KST) and the current time?
+
+**Decision**: Use `datetime.now(tz=ZoneInfo("Asia/Seoul"))` for the current time and parse `hvidate` as KST. Both operands are timezone-aware, making the comparison safe. `ZoneInfo` is stdlib (Python 3.9+), no dependency needed.
+
+**Alternatives considered**:
+- Compare in UTC: Equivalent result but requires converting KST hvidate to UTC first — extra step with no benefit.
+- Use naive datetimes: Rejected — timezone-naive comparison is error-prone.
+
+## Deferred Items Validation
+
+Spec section "Scope Boundaries & Deferred Items" states: "No items deferred — all requirements are addressed in this epic."
+
+Scanned spec.md for unregistered deferral patterns (`separate epic`, `future epic`, `Phase 2+`, `v2`, `deferred to`, `later release`, `out of scope for v1`): **No matches found.**
+
+**Validation result**: PASS — no untracked deferrals.

--- a/specs/023-nmc-freshness-slo/spec.md
+++ b/specs/023-nmc-freshness-slo/spec.md
@@ -1,0 +1,109 @@
+# Feature Specification: NMC Freshness SLO Enforcement
+
+**Feature Branch**: `023-nmc-freshness-slo`  
+**Created**: 2026-04-16  
+**Status**: Draft  
+**Input**: User description: "NMC Freshness SLO Enforcement: stale_data judgment + hvidate check"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Fresh Emergency Room Data Delivery (Priority: P1)
+
+A user asks about nearby emergency rooms. The system fetches real-time bed availability data from the NMC API. The response includes an `hvidate` timestamp indicating when the data was last updated by the upstream source. When this timestamp is recent (within the configured freshness threshold), the system delivers the data to the user with a "fresh" status indicator, giving confidence that the information is current.
+
+**Why this priority**: Emergency room data that appears current but is actually stale can lead to dangerous decisions (e.g., driving to an ER that no longer has beds). Validating freshness on every response is the core safety guarantee.
+
+**Independent Test**: Can be fully tested by providing a response with an `hvidate` value within the threshold and verifying the system returns the data with a "fresh" freshness status.
+
+**Acceptance Scenarios**:
+
+1. **Given** the freshness threshold is configured to 30 minutes, **When** the NMC response contains an `hvidate` that is 10 minutes old, **Then** the system returns the data with `freshness_status: "fresh"`.
+2. **Given** the freshness threshold is configured to 30 minutes, **When** the NMC response contains an `hvidate` that is exactly 30 minutes old, **Then** the system returns the data with `freshness_status: "fresh"` (boundary: equal-to-threshold is fresh).
+
+---
+
+### User Story 2 - Stale Data Rejection (Priority: P1)
+
+A user asks about nearby emergency rooms, but the upstream NMC data has not been refreshed recently. The `hvidate` timestamp exceeds the configured freshness threshold. Instead of silently delivering outdated information, the system returns a structured error indicating that the data is stale. The LLM agent can then communicate this to the user transparently rather than presenting potentially dangerous outdated bed counts.
+
+**Why this priority**: Equally critical to Story 1 — the safety guarantee requires that stale data is never silently passed through. This is the enforcement half of the SLO.
+
+**Independent Test**: Can be fully tested by providing a response with an `hvidate` value beyond the threshold and verifying the system returns a stale_data error instead of the data.
+
+**Acceptance Scenarios**:
+
+1. **Given** the freshness threshold is configured to 30 minutes, **When** the NMC response contains an `hvidate` that is 31 minutes old, **Then** the system returns a structured error with reason "stale_data" and does not return the bed availability data.
+2. **Given** the freshness threshold is configured to 30 minutes, **When** the NMC response contains an `hvidate` that is 1440 minutes old, **Then** the system returns a structured error with reason "stale_data".
+
+---
+
+### User Story 3 - Configurable Freshness Threshold (Priority: P2)
+
+An operator adjusts the freshness threshold via the `KOSMOS_NMC_FRESHNESS_MINUTES` environment variable to match their deployment's acceptable staleness window. The threshold is clamped to a safe range of 1 to 1440 minutes (1 minute to 24 hours) to prevent misconfiguration.
+
+**Why this priority**: Different deployment environments may have different tolerance for data staleness. Configurability supports production flexibility without code changes.
+
+**Independent Test**: Can be fully tested by setting the environment variable to various values (within range, boundary values, default) and verifying the freshness check uses the configured threshold.
+
+**Acceptance Scenarios**:
+
+1. **Given** `KOSMOS_NMC_FRESHNESS_MINUTES` is set to 60, **When** the NMC response contains an `hvidate` that is 59 minutes old, **Then** the system treats the data as fresh.
+2. **Given** `KOSMOS_NMC_FRESHNESS_MINUTES` is not set, **When** the system starts, **Then** the freshness threshold defaults to 30 minutes.
+3. **Given** `KOSMOS_NMC_FRESHNESS_MINUTES` is set to 0, **When** the system starts, **Then** the value is rejected with a validation error (pydantic `ge=1` constraint).
+
+---
+
+### Edge Cases
+
+- What happens when the `hvidate` field is missing or empty in the NMC response? The system treats the data as stale (fail-closed per Constitution Section II).
+- What happens when the `hvidate` field contains an unparseable value? The system treats the data as stale and returns a stale_data error.
+- What happens when the system clock and the NMC server clock are slightly out of sync? The freshness check uses a comparison against the configured threshold, not absolute wall-clock alignment. Minor clock drift within the threshold window is acceptable.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST compare the `hvidate` timestamp in every NMC emergency room response against the current time to determine data freshness.
+- **FR-002**: System MUST classify data as "fresh" when the age of `hvidate` is less than or equal to `KOSMOS_NMC_FRESHNESS_MINUTES`.
+- **FR-003**: System MUST classify data as "stale" when the age of `hvidate` exceeds `KOSMOS_NMC_FRESHNESS_MINUTES`.
+- **FR-004**: When data is stale, the system MUST return a structured error with reason "stale_data" instead of returning the bed availability data.
+- **FR-005**: When data is fresh, the system MUST include `freshness_status: "fresh"` metadata in the response envelope.
+- **FR-006**: When data is stale, the stale_data error MUST include a human-readable message stating the data age and the configured threshold.
+- **FR-007**: The `KOSMOS_NMC_FRESHNESS_MINUTES` configuration MUST default to 30 minutes and be clamped to the range [1, 1440].
+- **FR-008**: When `hvidate` is missing, empty, or unparseable, the system MUST treat the data as stale (fail-closed).
+
+### Key Entities
+
+- **Freshness Status**: A classification of NMC response data as either "fresh" or "stale", determined by comparing the `hvidate` field age against the configured threshold.
+- **hvidate**: A timestamp field in the NMC API response representing when the upstream data was last updated by the National Medical Center.
+- **Freshness Threshold**: A configurable duration (in minutes) representing the maximum acceptable age of NMC data before it is considered stale.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of NMC emergency room responses are validated for freshness before being delivered to users.
+- **SC-002**: Stale data (exceeding the configured threshold) is never silently delivered to users; it always results in a structured stale_data error.
+- **SC-003**: Fresh data is delivered with an explicit freshness status indicator, enabling the LLM agent to communicate data currency to users.
+- **SC-004**: Missing or malformed `hvidate` values are caught and treated as stale in 100% of cases (fail-closed guarantee).
+- **SC-005**: The freshness threshold is configurable without code changes, supporting deployment flexibility.
+
+## Assumptions
+
+- The NMC API `hvidate` field uses a parseable Korean datetime format (e.g., `YYYY-MM-DD HH:MM:SS` or similar).
+- The system clock on the deployment server is reasonably synchronized (within a few minutes of NMC server time).
+- The existing `KOSMOS_NMC_FRESHNESS_MINUTES` setting in the configuration module is the canonical source for the threshold value.
+- The existing `stale_data` reason in the error taxonomy is the correct classification for this error type.
+- The NMC adapter currently has an auth gate that short-circuits before the handler; freshness enforcement will be added to the response processing path that runs after a successful upstream fetch.
+
+## Scope Boundaries & Deferred Items *(mandatory)*
+
+### Out of Scope (Permanent)
+
+- Automatic retry or fallback to cached data when stale data is detected — the system reports staleness; the LLM agent decides how to communicate it to the user.
+- NMC server-side freshness monitoring or alerting — KOSMOS only validates at the point of consumption.
+- Freshness enforcement for non-NMC adapters — each adapter's freshness semantics differ; this epic covers NMC only.
+
+### Deferred to Future Work
+
+No items deferred — all requirements are addressed in this epic.

--- a/specs/023-nmc-freshness-slo/tasks.md
+++ b/specs/023-nmc-freshness-slo/tasks.md
@@ -1,0 +1,163 @@
+# Tasks: NMC Freshness SLO Enforcement
+
+**Input**: Design documents from `specs/023-nmc-freshness-slo/`
+**Prerequisites**: plan.md (required), spec.md (required), research.md, data-model.md, quickstart.md
+
+**Tests**: Included — spec explicitly requires "fixture 기반 unit + stale/fresh 경계값" tests.
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and testing.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies)
+- **[Story]**: Which user story this task belongs to (e.g., US1, US2, US3)
+- Include exact file paths in descriptions
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create test fixtures and foundational test infrastructure for freshness validation
+
+- [X] T001 [P] Create fresh NMC response fixture in tests/fixtures/nmc/fresh_response.json — include `hvidate` set to 10 minutes ago in `YYYY-MM-DD HH:MM:SS` KST format, with realistic NMC bed availability fields (`hvec`, `hvoc`, `hvs1`, `dutyName`, `dutyAddr`, `dutyTel3`, `wgs84Lat`, `wgs84Lon`)
+- [X] T002 [P] Create stale NMC response fixture in tests/fixtures/nmc/stale_response.json — include `hvidate` set to 60 minutes ago in `YYYY-MM-DD HH:MM:SS` KST format, with same realistic NMC field structure as fresh_response.json
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core model changes and freshness utility that MUST be complete before user story implementation
+
+**CRITICAL**: No user story work can begin until this phase is complete
+
+- [X] T003 Add `freshness_status: Literal["fresh"] | None = None` field to `LookupMeta` in src/kosmos/tools/models.py — add after `rate_limit_remaining` field, include docstring: "Set to 'fresh' when adapter freshness check passes. None for adapters without freshness semantics."
+- [X] T004 Create freshness check utility module at src/kosmos/tools/nmc/freshness.py — implement `FreshnessResult` dataclass (fields: `is_fresh: bool`, `data_age_minutes: float`, `threshold_minutes: int`, `hvidate_raw: str | None`) and `check_freshness(hvidate_str: str | None, threshold_minutes: int | None = None) -> FreshnessResult` function. When `threshold_minutes` is `None`, read `settings.nmc_freshness_minutes` from `kosmos.settings.settings` as default. Parse `hvidate` with `datetime.strptime("%Y-%m-%d %H:%M:%S")`, localize to `ZoneInfo("Asia/Seoul")`, compare age against threshold. Missing/empty/unparseable `hvidate` → `FreshnessResult(is_fresh=False, ...)` (fail-closed per Constitution § II).
+
+**Checkpoint**: Foundation ready — freshness utility and model extension in place
+
+---
+
+## Phase 3: User Story 1 + 2 — Fresh Delivery & Stale Rejection (Priority: P1) MVP
+
+**Goal**: Every NMC response is validated for freshness: fresh data passes through with `freshness_status: "fresh"` metadata, stale data is rejected with `LookupError(reason="stale_data")`
+
+**Independent Test**: Call `check_freshness()` with fixture data and verify correct fresh/stale classification; call NMC adapter handler with mock responses and verify envelope shape
+
+### Tests for User Stories 1 & 2
+
+> **NOTE: Write these tests FIRST, ensure they FAIL before implementation in T007**
+
+- [X] T005 [P] [US1] Write unit tests for fresh path in tests/tools/nmc/test_freshness_validation.py — mock `datetime.now(tz=ZoneInfo("Asia/Seoul"))` to a fixed time matching fixture hvidate + expected age for deterministic results. Test `check_freshness()` with hvidate 10 min old (threshold 30) returns `FreshnessResult(is_fresh=True, data_age_minutes≈10, threshold_minutes=30)`; test hvidate exactly at threshold (30 min old, threshold 30) returns `is_fresh=True` (boundary: equal-to-threshold is fresh per spec AC); load tests/fixtures/nmc/fresh_response.json as input
+- [X] T006 [P] [US2] Write unit tests for stale path in tests/tools/nmc/test_freshness_validation.py — mock `datetime.now(tz=ZoneInfo("Asia/Seoul"))` to a fixed time for deterministic age calculations. Test `check_freshness()` with hvidate 31 min old (threshold 30) returns `FreshnessResult(is_fresh=False)`; test hvidate 1440 min old returns `is_fresh=False`; test missing hvidate (None) returns `is_fresh=False`; test empty string hvidate returns `is_fresh=False`; test unparseable hvidate (`"invalid-date"`) returns `is_fresh=False`; load tests/fixtures/nmc/stale_response.json as input
+
+### Implementation for User Stories 1 & 2
+
+- [X] T007 [US1] [US2] Integrate freshness validation into NMC adapter handler in src/kosmos/tools/nmc/emergency_search.py — replace `Layer3GateViolation` raise with real handler logic: (1) call upstream NMC API via httpx, (2) extract `hvidate` from response items, (3) call `check_freshness()` from `kosmos.tools.nmc.freshness`, (4) if fresh: return response dict with items + inject `freshness_status: "fresh"` key for envelope meta enrichment, (5) if stale: return dict matching `LookupError` shape with `kind="error"`, `reason="stale_data"`, `message` including data age and threshold, `retryable=False`. Update module docstring to remove "freshness deferred" comment (FR-034 is now implemented).
+- [X] T008 [US1] [US2] Write integration test in tests/tools/nmc/test_freshness_validation.py — test full `executor.invoke()` flow with mocked httpx response (respx): (1) mock NMC API to return fresh fixture → verify result is LookupCollection/LookupRecord with `meta.freshness_status == "fresh"`, (2) mock NMC API to return stale fixture → verify result is LookupError with `reason == "stale_data"` and message contains age and threshold info, (3) mock NMC API to return response with missing `hvidate` → verify result is LookupError with `reason == "stale_data"`
+
+**Checkpoint**: US1 + US2 complete — fresh data delivered with status, stale data rejected with error
+
+---
+
+## Phase 4: User Story 3 — Configurable Freshness Threshold (Priority: P2)
+
+**Goal**: Freshness threshold is configurable via `KOSMOS_NMC_FRESHNESS_MINUTES` env var with default 30, clamped [1, 1440]
+
+**Independent Test**: Set env var to different values and verify freshness check uses the configured threshold
+
+### Tests for User Story 3
+
+- [X] T009 [P] [US3] Write threshold configuration tests in tests/tools/nmc/test_freshness_validation.py — (1) test `check_freshness()` with explicit `threshold_minutes=60` and hvidate 59 min old → `is_fresh=True`, (2) test with `threshold_minutes=60` and hvidate 61 min old → `is_fresh=False`, (3) test default threshold from `settings.nmc_freshness_minutes` is used when no explicit threshold passed, (4) verify `KosmosSettings.nmc_freshness_minutes` Field constraint `ge=1, le=1440` rejects out-of-range values via `pydantic.ValidationError`
+
+### Implementation for User Story 3
+
+- [X] T010 [US3] Verify threshold integration in src/kosmos/tools/nmc/freshness.py — confirm `check_freshness()` correctly reads `settings.nmc_freshness_minutes` as default when `threshold_minutes=None` (signature already defined in T004). Write a focused integration test: call `check_freshness(hvidate_str, threshold_minutes=None)` and verify it uses the settings default. No changes needed to src/kosmos/settings.py (field already exists with correct constraints).
+
+**Checkpoint**: US3 complete — threshold configurable via env var, defaults and clamp validated
+
+---
+
+## Phase 5: Polish & Cross-Cutting Concerns
+
+**Purpose**: Cleanup, documentation, and regression verification
+
+- [X] T011 Update NMC adapter module docstring in src/kosmos/tools/nmc/emergency_search.py — remove all "FR-034: Freshness check deferred" comments and replace with "FR-034: Freshness enforcement via check_freshness() — see freshness.py"
+- [X] T012 Run full test suite via `uv run pytest` and verify zero regressions — existing tests in tests/tools/nmc/test_emergency_search_auth_gate.py must still pass (auth gate behavior unchanged), existing envelope normalization tests must still pass (LookupMeta backward-compatible with new optional field)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — can start immediately
+- **Foundational (Phase 2)**: T003 and T004 can run in parallel; BLOCKS all user stories
+- **US1+US2 (Phase 3)**: Depends on Phase 2 completion. T005 and T006 (tests) can run in parallel. T007 depends on T004. T008 depends on T007.
+- **US3 (Phase 4)**: Depends on Phase 2 completion. Can run in parallel with Phase 3 (different test cases, shared utility).
+- **Polish (Phase 5)**: Depends on Phase 3 and Phase 4 completion
+
+### User Story Dependencies
+
+- **US1 + US2 (P1)**: Can start after Foundational (Phase 2) — core feature, MVP
+- **US3 (P2)**: Can start after Foundational (Phase 2) — independent of US1/US2 implementation but tests may share the same file
+
+### Within Each User Story
+
+- Tests written FIRST, must FAIL before implementation
+- Utility module (freshness.py) before adapter integration
+- Unit tests before integration tests
+
+### Parallel Opportunities
+
+- T001 and T002 (fixtures) can run in parallel
+- T003 and T004 (model + utility) can run in parallel
+- T005 and T006 (unit tests) can run in parallel
+- T009 (US3 tests) can run in parallel with T005/T006
+- Phase 3 and Phase 4 can run in parallel after Phase 2
+
+---
+
+## Parallel Example: Phase 2 (Foundational)
+
+```bash
+# Launch both foundational tasks together:
+Task: "Add freshness_status to LookupMeta in src/kosmos/tools/models.py"
+Task: "Create freshness utility in src/kosmos/tools/nmc/freshness.py"
+```
+
+## Parallel Example: Phase 3 (Tests)
+
+```bash
+# Launch US1 and US2 tests together:
+Task: "Write fresh path tests in tests/tools/nmc/test_freshness_validation.py"
+Task: "Write stale path tests in tests/tools/nmc/test_freshness_validation.py"
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Stories 1 + 2 Only)
+
+1. Complete Phase 1: Setup (fixtures)
+2. Complete Phase 2: Foundational (LookupMeta + freshness utility)
+3. Complete Phase 3: US1 + US2 (fresh/stale validation)
+4. **STOP and VALIDATE**: Run `uv run pytest tests/tools/nmc/ -v`
+5. Core safety guarantee is in place
+
+### Incremental Delivery
+
+1. Phase 1 + 2 → Foundation ready
+2. Phase 3 → US1 + US2 complete → MVP (fresh/stale enforcement works)
+3. Phase 4 → US3 complete → Threshold configurability validated
+4. Phase 5 → Polish → Full test suite passes, docs updated
+
+---
+
+## Notes
+
+- [P] tasks = different files, no dependencies
+- [Story] label maps task to specific user story for traceability
+- All tests use fixture data — NEVER call live data.go.kr APIs (Constitution § IV)
+- `freshness_status` field is backward-compatible (None default) — existing tests unaffected
+- Auth gate behavior is unchanged — freshness check only applies after successful upstream fetch

--- a/src/kosmos/tools/envelope.py
+++ b/src/kosmos/tools/envelope.py
@@ -81,10 +81,18 @@ def normalize(
             "expected dict or BaseModel",
         )
 
-    # Always overwrite meta so that adapters cannot return stale or forged
-    # meta values.
     if isinstance(raw, dict):
-        raw = {**raw, "meta": meta.model_dump(mode="json")}
+        # System-managed fields are always overwritten; adapter-supplied
+        # optional meta fields (e.g., rate_limit_remaining, freshness_status)
+        # are preserved.
+        _SYSTEM_META = frozenset({"source", "fetched_at", "request_id", "elapsed_ms"})
+        adapter_meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
+        meta_dict = meta.model_dump(mode="json")
+        if adapter_meta:
+            for key, val in adapter_meta.items():
+                if key not in _SYSTEM_META and key in LookupMeta.model_fields:
+                    meta_dict[key] = val
+        raw = {**raw, "meta": meta_dict}
 
     try:
         validated = _LOOKUP_OUTPUT_ADAPTER.validate_python(raw)

--- a/src/kosmos/tools/envelope.py
+++ b/src/kosmos/tools/envelope.py
@@ -38,6 +38,8 @@ logger = logging.getLogger(__name__)
 # TypeAdapter for validating arbitrary dicts against LookupOutput.
 _LOOKUP_OUTPUT_ADAPTER: TypeAdapter[object] = TypeAdapter(LookupOutput)
 
+_SYSTEM_META = frozenset({"source", "fetched_at", "request_id", "elapsed_ms"})
+
 
 def normalize(
     output: object,
@@ -82,10 +84,6 @@ def normalize(
         )
 
     if isinstance(raw, dict):
-        # System-managed fields are always overwritten; adapter-supplied
-        # optional meta fields (e.g., rate_limit_remaining, freshness_status)
-        # are preserved.
-        _SYSTEM_META = frozenset({"source", "fetched_at", "request_id", "elapsed_ms"})
         adapter_meta = raw.get("meta") if isinstance(raw.get("meta"), dict) else {}
         meta_dict = meta.model_dump(mode="json")
         if adapter_meta:

--- a/src/kosmos/tools/envelope.py
+++ b/src/kosmos/tools/envelope.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import TypeAdapter, ValidationError
 
@@ -29,6 +29,17 @@ from kosmos.tools.models import (
     LookupMeta,
     LookupOutput,
 )
+
+LookupErrorReason = Literal[
+    "auth_required",
+    "stale_data",
+    "timeout",
+    "upstream_unavailable",
+    "unknown_tool",
+    "invalid_params",
+    "out_of_domain",
+    "empty_registry",
+]
 
 if TYPE_CHECKING:
     from kosmos.tools.models import GovAPITool
@@ -99,7 +110,7 @@ def normalize(
 
 def make_error_envelope(
     tool_id: str,
-    reason: str,
+    reason: LookupErrorReason,
     message: str,
     request_id: str,
     elapsed_ms: int,
@@ -121,7 +132,7 @@ def make_error_envelope(
     )
     return LookupErrorModel(
         kind="error",
-        reason=reason,  # type: ignore[arg-type]
+        reason=reason,
         message=message,
         retryable=retryable,
         upstream_code=upstream_code,

--- a/src/kosmos/tools/envelope.py
+++ b/src/kosmos/tools/envelope.py
@@ -17,11 +17,11 @@ from __future__ import annotations
 
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Literal
+from typing import TYPE_CHECKING
 
 from pydantic import TypeAdapter, ValidationError
 
-from kosmos.tools.errors import EnvelopeNormalizationError
+from kosmos.tools.errors import EnvelopeNormalizationError, LookupErrorReason
 from kosmos.tools.models import (
     LookupError as LookupErrorModel,
 )
@@ -29,17 +29,6 @@ from kosmos.tools.models import (
     LookupMeta,
     LookupOutput,
 )
-
-LookupErrorReason = Literal[
-    "auth_required",
-    "stale_data",
-    "timeout",
-    "upstream_unavailable",
-    "unknown_tool",
-    "invalid_params",
-    "out_of_domain",
-    "empty_registry",
-]
 
 if TYPE_CHECKING:
     from kosmos.tools.models import GovAPITool

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -26,8 +26,8 @@ from kosmos.observability import (
     GEN_AI_TOOL_TYPE,
     filter_metadata,
 )
-from kosmos.tools.envelope import LookupErrorReason, make_error_envelope
-from kosmos.tools.errors import ToolNotFoundError
+from kosmos.tools.envelope import make_error_envelope
+from kosmos.tools.errors import LookupErrorReason, ToolNotFoundError
 from kosmos.tools.models import ToolResult
 from kosmos.tools.registry import ToolRegistry
 
@@ -50,12 +50,12 @@ def _classify_adapter_exception(exc: Exception) -> tuple[LookupErrorReason, bool
     from kosmos.tools.kma.projection import KMADomainError  # noqa: PLC0415
 
     if isinstance(exc, (ValueError, TypeError, KMADomainError)):
-        return ("invalid_params", False)
+        return (LookupErrorReason.invalid_params, False)
     if isinstance(exc, httpx.TimeoutException):
-        return ("timeout", True)
+        return (LookupErrorReason.timeout, True)
     if isinstance(exc, (httpx.HTTPStatusError, httpx.RequestError)):
-        return ("upstream_unavailable", True)
-    return ("upstream_unavailable", True)
+        return (LookupErrorReason.upstream_unavailable, True)
+    return (LookupErrorReason.upstream_unavailable, True)
 
 
 class ToolExecutor:
@@ -159,7 +159,7 @@ class ToolExecutor:
             logger.warning("invoke: tool not found: %s", tool_id)
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="unknown_tool",
+                reason=LookupErrorReason.unknown_tool,
                 message=f"No tool registered with id {tool_id!r}.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -174,7 +174,7 @@ class ToolExecutor:
             )
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="auth_required",
+                reason=LookupErrorReason.auth_required,
                 message=(
                     f"Tool {tool_id!r} requires authentication. "
                     "Provide a session identity to proceed."
@@ -190,7 +190,7 @@ class ToolExecutor:
             logger.warning("invoke: no adapter registered for tool: %s", tool_id)
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="unknown_tool",
+                reason=LookupErrorReason.unknown_tool,
                 message=f"No adapter registered for tool {tool_id!r}.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -201,10 +201,16 @@ class ToolExecutor:
         try:
             validated_input = tool.input_schema.model_validate(params)
         except ValidationError as exc:
-            logger.warning("invoke: input validation failed for %s: %s", tool_id, exc)
+            field_paths = [".".join(str(p) for p in e["loc"]) for e in exc.errors()]
+            logger.warning(
+                "invoke: input validation failed for %s (%d errors, fields: %s)",
+                tool_id,
+                exc.error_count(),
+                ", ".join(field_paths),
+            )
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="invalid_params",
+                reason=LookupErrorReason.invalid_params,
                 message="Invalid parameters for tool.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -215,7 +221,12 @@ class ToolExecutor:
         try:
             raw_output = await adapter(validated_input)
         except Exception as exc:
-            logger.warning("invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc)
+            logger.warning(
+                "invoke: adapter %s raised %s",
+                tool_id,
+                type(exc).__name__,
+                exc_info=True,
+            )
             reason, retryable = _classify_adapter_exception(exc)
             return make_error_envelope(
                 tool_id=tool_id,
@@ -238,7 +249,7 @@ class ToolExecutor:
             logger.error("invoke: envelope normalisation failed for %s: %s", tool_id, exc)
             return make_error_envelope(
                 tool_id=tool_id,
-                reason="upstream_unavailable",
+                reason=LookupErrorReason.upstream_unavailable,
                 message="Response processing failed.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
@@ -294,7 +305,7 @@ class ToolExecutor:
                 # dispatch() has no session_identity parameter, so the auth gate in
                 # invoke() can never fire here — flag this for operational visibility.
                 if tool.requires_auth:
-                    logger.warning(
+                    logger.debug(
                         "dispatch() called for auth-required tool %r without auth gate",
                         tool_name,
                     )
@@ -383,10 +394,10 @@ class ToolExecutor:
                         result_dict = await adapter(validated_input)
                     except Exception as exc:
                         logger.warning(
-                            "Adapter %s raised %s: %s",
+                            "Adapter %s raised %s",
                             tool_name,
                             type(exc).__name__,
-                            exc,
+                            exc_info=True,
                         )
                         self._metrics_increment("tool.error_count", tool_name)
                         self._metrics_observe_duration(

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -215,9 +215,7 @@ class ToolExecutor:
         try:
             raw_output = await adapter(validated_input)
         except Exception as exc:
-            logger.warning(
-                "invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc
-            )
+            logger.warning("invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc)
             reason, retryable = _classify_adapter_exception(exc)
             return make_error_envelope(
                 tool_id=tool_id,
@@ -237,9 +235,7 @@ class ToolExecutor:
                 elapsed_ms=_elapsed(),
             )
         except EnvelopeNormalizationError as exc:
-            logger.error(
-                "invoke: envelope normalisation failed for %s: %s", tool_id, exc
-            )
+            logger.error("invoke: envelope normalisation failed for %s: %s", tool_id, exc)
             return make_error_envelope(
                 tool_id=tool_id,
                 reason="upstream_unavailable",

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -205,7 +205,7 @@ class ToolExecutor:
             return make_error_envelope(
                 tool_id=tool_id,
                 reason="invalid_params",
-                message=str(exc),
+                message="Invalid parameters for tool.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
                 retryable=False,
@@ -215,12 +215,14 @@ class ToolExecutor:
         try:
             raw_output = await adapter(validated_input)
         except Exception as exc:
-            logger.exception("invoke: adapter raised exception for %s: %s", tool_id, exc)
+            logger.warning(
+                "invoke: adapter %s raised %s: %s", tool_id, type(exc).__name__, exc
+            )
             reason, retryable = _classify_adapter_exception(exc)
             return make_error_envelope(
                 tool_id=tool_id,
                 reason=reason,
-                message=str(exc),
+                message="Tool execution failed.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
                 retryable=retryable,
@@ -235,11 +237,13 @@ class ToolExecutor:
                 elapsed_ms=_elapsed(),
             )
         except EnvelopeNormalizationError as exc:
-            logger.error("invoke: envelope normalisation failed for %s: %s", tool_id, exc)
+            logger.error(
+                "invoke: envelope normalisation failed for %s: %s", tool_id, exc
+            )
             return make_error_envelope(
                 tool_id=tool_id,
                 reason="upstream_unavailable",
-                message=str(exc),
+                message="Response processing failed.",
                 request_id=request_id,
                 elapsed_ms=_elapsed(),
                 retryable=False,
@@ -289,6 +293,15 @@ class ToolExecutor:
                         error_type="not_found",
                     )
                     return _final_result
+
+                # Warn when the legacy dispatch() path is used for auth-required tools.
+                # dispatch() has no session_identity parameter, so the auth gate in
+                # invoke() can never fire here — flag this for operational visibility.
+                if tool.requires_auth:
+                    logger.warning(
+                        "dispatch() called for auth-required tool %r without auth gate",
+                        tool_name,
+                    )
 
                 # Step 2: Parse and validate input
                 try:
@@ -373,7 +386,12 @@ class ToolExecutor:
                     try:
                         result_dict = await adapter(validated_input)
                     except Exception as exc:
-                        logger.exception("Adapter execution failed for tool %s: %s", tool_name, exc)
+                        logger.warning(
+                            "Adapter %s raised %s: %s",
+                            tool_name,
+                            type(exc).__name__,
+                            exc,
+                        )
                         self._metrics_increment("tool.error_count", tool_name)
                         self._metrics_observe_duration(
                             "tool.duration_ms",
@@ -383,7 +401,7 @@ class ToolExecutor:
                         _final_result = ToolResult(
                             tool_id=tool_name,
                             success=False,
-                            error=str(exc),
+                            error="Tool execution failed.",
                             error_type="execution",
                         )
                         return _final_result
@@ -451,12 +469,14 @@ class ToolExecutor:
 
     def _handle_unexpected_error(self, tool_name: str, exc: BaseException) -> ToolResult:
         """Convert an unexpected exception to a ToolResult (never raises)."""
-        logger.exception("Unexpected error during dispatch of tool %s: %s", tool_name, exc)
+        logger.error(
+            "Unexpected error during dispatch of tool %s: %s", tool_name, exc, exc_info=True
+        )
         self._metrics_increment("tool.error_count", tool_name)
         return ToolResult(
             tool_id=tool_name,
             success=False,
-            error=f"Internal error: {exc}",
+            error="Internal error occurred.",
             error_type="execution",
         )
 

--- a/src/kosmos/tools/executor.py
+++ b/src/kosmos/tools/executor.py
@@ -26,7 +26,7 @@ from kosmos.observability import (
     GEN_AI_TOOL_TYPE,
     filter_metadata,
 )
-from kosmos.tools.envelope import make_error_envelope
+from kosmos.tools.envelope import LookupErrorReason, make_error_envelope
 from kosmos.tools.errors import ToolNotFoundError
 from kosmos.tools.models import ToolResult
 from kosmos.tools.registry import ToolRegistry
@@ -43,7 +43,7 @@ _tracer = trace.get_tracer(__name__)
 AdapterFn = Callable[[BaseModel], Awaitable[dict[str, Any]]]
 
 
-def _classify_adapter_exception(exc: Exception) -> tuple[str, bool]:
+def _classify_adapter_exception(exc: Exception) -> tuple[LookupErrorReason, bool]:
     """Map adapter exceptions to (reason, retryable) for the error envelope."""
     import httpx  # noqa: PLC0415
 

--- a/src/kosmos/tools/geocoding/juso.py
+++ b/src/kosmos/tools/geocoding/juso.py
@@ -90,7 +90,7 @@ async def lookup_adm_cd(
         }
 
     except Exception as exc:
-        logger.debug("juso.lookup_adm_cd failed for %r: %s", query, exc)
+        logger.warning("juso.lookup_adm_cd failed for %r: %s", query, exc)
         return None
 
     finally:

--- a/src/kosmos/tools/geocoding/juso.py
+++ b/src/kosmos/tools/geocoding/juso.py
@@ -90,7 +90,12 @@ async def lookup_adm_cd(
         }
 
     except Exception as exc:
-        logger.warning("juso.lookup_adm_cd failed for %r: %s", query, exc)
+        logger.warning(
+            "juso.lookup_adm_cd failed (query_len=%d): %s",
+            len(query),
+            type(exc).__name__,
+            exc_info=True,
+        )
         return None
 
     finally:

--- a/src/kosmos/tools/geocoding/sgis.py
+++ b/src/kosmos/tools/geocoding/sgis.py
@@ -115,7 +115,7 @@ async def lookup_adm_cd_by_coords(
         }
 
     except Exception as exc:
-        logger.debug("sgis.lookup_adm_cd_by_coords failed for (%s, %s): %s", lat, lon, exc)
+        logger.warning("sgis.lookup_adm_cd_by_coords failed for (%s, %s): %s", lat, lon, exc)
         return None
 
     finally:

--- a/src/kosmos/tools/geocoding/sgis.py
+++ b/src/kosmos/tools/geocoding/sgis.py
@@ -115,7 +115,11 @@ async def lookup_adm_cd_by_coords(
         }
 
     except Exception as exc:
-        logger.warning("sgis.lookup_adm_cd_by_coords failed for (%s, %s): %s", lat, lon, exc)
+        logger.warning(
+            "sgis.lookup_adm_cd_by_coords failed (coords_provided=True): %s",
+            type(exc).__name__,
+            exc_info=True,
+        )
         return None
 
     finally:

--- a/src/kosmos/tools/hira/hospital_search.py
+++ b/src/kosmos/tools/hira/hospital_search.py
@@ -24,7 +24,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from kosmos.tools.errors import _require_env
+from kosmos.tools.errors import ToolExecutionError, _require_env
 from kosmos.tools.models import GovAPITool
 
 logger = logging.getLogger(__name__)
@@ -144,10 +144,11 @@ async def handle(
 
         content_type = response.headers.get("content-type", "")
         if "xml" in content_type.lower() and "json" not in content_type.lower():
-            raise RuntimeError(
+            raise ToolExecutionError(
+                "hira_hospital_search",
                 f"HIRA API returned XML instead of JSON "
                 f"(Content-Type: {content_type!r}). "
-                "Append '&type=json' to the request or check the serviceKey."
+                "Append '&type=json' to the request or check the serviceKey.",
             )
 
         raw: dict[str, Any] = response.json()
@@ -170,7 +171,10 @@ async def handle(
         }
 
     if result_code != "00":
-        raise RuntimeError(f"HIRA API error: resultCode={result_code!r} resultMsg={result_msg!r}")
+        raise ToolExecutionError(
+            "hira_hospital_search",
+            f"HIRA API error: resultCode={result_code!r} resultMsg={result_msg!r}",
+        )
 
     body = response_body.get("body", {})
     total_count = int(body.get("totalCount", 0))

--- a/src/kosmos/tools/kma/forecast_fetch.py
+++ b/src/kosmos/tools/kma/forecast_fetch.py
@@ -188,7 +188,7 @@ async def _fetch(
     if inp.base_time not in _VALID_BASE_TIMES:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.invalid_params.value,
+            reason=LookupErrorReason.invalid_params,
             message=(
                 f"base_time {inp.base_time!r} is not a valid KMA forecast base time. "
                 f"Must be one of: {', '.join(sorted(_VALID_BASE_TIMES))}."
@@ -201,7 +201,7 @@ async def _fetch(
     except KMADomainError as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.out_of_domain.value,
+            reason=LookupErrorReason.out_of_domain,
             message=str(exc),
         )
 
@@ -243,7 +243,7 @@ async def _fetch(
         if "xml" in content_type.lower() and "json" not in content_type.lower():
             return LookupError(
                 kind="error",
-                reason=LookupErrorReason.upstream_unavailable.value,
+                reason=LookupErrorReason.upstream_unavailable,
                 message=(
                     f"KMA API returned XML instead of JSON "
                     f"(content-type={content_type!r}). "
@@ -256,13 +256,13 @@ async def _fetch(
     except httpx.HTTPStatusError as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.upstream_unavailable.value,
+            reason=LookupErrorReason.upstream_unavailable,
             message=f"HTTP error from KMA forecast API: {exc.response.status_code}",
         )
     except httpx.RequestError as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.timeout.value,
+            reason=LookupErrorReason.timeout,
             message=f"Network error reaching KMA forecast API: {exc}",
             retryable=True,
         )
@@ -279,14 +279,14 @@ async def _fetch(
     except (KeyError, TypeError) as exc:
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.upstream_unavailable.value,
+            reason=LookupErrorReason.upstream_unavailable,
             message=f"Unexpected KMA response structure: {exc}",
         )
 
     if result_code != "00":
         return LookupError(
             kind="error",
-            reason=LookupErrorReason.upstream_unavailable.value,
+            reason=LookupErrorReason.upstream_unavailable,
             message=f"KMA API error: resultCode={result_code!r} resultMsg={result_msg!r}",
             upstream_code=result_code,
             upstream_message=result_msg,

--- a/src/kosmos/tools/kma/forecast_fetch.py
+++ b/src/kosmos/tools/kma/forecast_fetch.py
@@ -38,7 +38,7 @@ from kosmos.tools.models import GovAPITool, LookupError, LookupTimeseries  # noq
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
+_BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
 
 _VALID_BASE_TIMES: frozenset[str] = frozenset(
     {"0200", "0500", "0800", "1100", "1400", "1700", "2000", "2300"}

--- a/src/kosmos/tools/kma/grid_coords.py
+++ b/src/kosmos/tools/kma/grid_coords.py
@@ -10,7 +10,7 @@ Reference: KMA VilageFcstInfoService_2.0 API technical guide.
 
 from __future__ import annotations
 
-import math
+from kosmos.tools.kma.projection import latlon_to_lcc
 
 # REGION_TO_GRID: maps region name strings to (nx, ny) KMA grid tuples.
 # Keys include both Korean and common Romanized names for broad matching.
@@ -152,40 +152,4 @@ def latlon_to_grid(lat: float, lon: float) -> tuple[int, int]:
     Returns:
         A ``(nx, ny)`` tuple of integer KMA grid coordinates.
     """
-    # KMA Lambert Conformal Conic projection constants (official KMA parameters)
-    earth_radius_km = 6371.00877  # Earth radius [km]
-    grid_km = 5.0  # Grid resolution [km]
-    slat1_deg = 30.0  # Standard latitude 1 [degrees]
-    slat2_deg = 60.0  # Standard latitude 2 [degrees]
-    olon_deg = 126.0  # Reference (true) longitude [degrees]
-    olat_deg = 38.0  # Reference latitude [degrees]
-    xo = 43.0  # Grid x-origin offset
-    yo = 136.0  # Grid y-origin offset
-
-    degrad = math.pi / 180.0
-
-    re = earth_radius_km / grid_km
-    slat1 = slat1_deg * degrad
-    slat2 = slat2_deg * degrad
-    olon = olon_deg * degrad
-    olat = olat_deg * degrad
-
-    sn = math.tan(math.pi * 0.25 + slat2 * 0.5) / math.tan(math.pi * 0.25 + slat1 * 0.5)
-    sn = math.log(math.cos(slat1) / math.cos(slat2)) / math.log(sn)
-    sf = math.tan(math.pi * 0.25 + slat1 * 0.5)
-    sf = (sf**sn) * math.cos(slat1) / sn
-    ro = math.tan(math.pi * 0.25 + olat * 0.5)
-    ro = re * sf / (ro**sn)
-
-    ra = math.tan(math.pi * 0.25 + lat * degrad * 0.5)
-    ra = re * sf / (ra**sn)
-    theta = lon * degrad - olon
-    if theta > math.pi:
-        theta -= 2.0 * math.pi
-    if theta < -math.pi:
-        theta += 2.0 * math.pi
-    theta *= sn
-
-    nx = int(ra * math.sin(theta) + xo + 1.5)
-    ny = int(ro - ra * math.cos(theta) + yo + 1.5)
-    return nx, ny
+    return latlon_to_lcc(lat, lon)

--- a/src/kosmos/tools/kma/kma_pre_warning.py
+++ b/src/kosmos/tools/kma/kma_pre_warning.py
@@ -29,7 +29,7 @@ from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/WthrWrnInfoService/getWthrPwnList"
+_BASE_URL = "https://apis.data.go.kr/1360000/WthrWrnInfoService/getWthrPwnList"
 
 # ---------------------------------------------------------------------------
 # Input / Output models

--- a/src/kosmos/tools/kma/kma_short_term_forecast.py
+++ b/src/kosmos/tools/kma/kma_short_term_forecast.py
@@ -30,7 +30,7 @@ from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
+_BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getVilageFcst"
 
 # Valid base times for the short-term forecast service (KST)
 _VALID_BASE_TIMES = frozenset({"0200", "0500", "0800", "1100", "1400", "1700", "2000", "2300"})

--- a/src/kosmos/tools/kma/kma_ultra_short_term_forecast.py
+++ b/src/kosmos/tools/kma/kma_ultra_short_term_forecast.py
@@ -34,7 +34,7 @@ from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
-_BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst"
+_BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtFcst"
 
 # ---------------------------------------------------------------------------
 # Input model (output reuses ForecastItem / KmaShortTermForecastOutput)

--- a/src/kosmos/tools/kma/kma_weather_alert_status.py
+++ b/src/kosmos/tools/kma/kma_weather_alert_status.py
@@ -22,7 +22,9 @@ import httpx
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from kosmos.tools.errors import ConfigurationError, ToolExecutionError, _require_env  # noqa: F401
+from kosmos.tools.executor import ToolExecutor
 from kosmos.tools.models import GovAPITool
+from kosmos.tools.registry import ToolRegistry
 
 logger = logging.getLogger(__name__)
 
@@ -319,22 +321,17 @@ KMA_WEATHER_ALERT_STATUS_TOOL = GovAPITool(
 )
 
 
-def register(registry: object, executor: object) -> None:
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
     """Register KMA weather alert status tool and its adapter.
 
     Args:
-        registry: A ToolRegistry instance.
-        executor: A ToolExecutor instance.
+        registry: The central ``ToolRegistry`` to add the tool to.
+        executor: The ``ToolExecutor`` to bind the adapter function to.
     """
-    from kosmos.tools.executor import ToolExecutor
-    from kosmos.tools.registry import ToolRegistry
+    from typing import cast
 
-    assert isinstance(registry, ToolRegistry)
-    assert isinstance(executor, ToolExecutor)
+    from kosmos.tools.executor import AdapterFn
 
     registry.register(KMA_WEATHER_ALERT_STATUS_TOOL)
-    executor.register_adapter(
-        "kma_weather_alert_status",
-        lambda inp: _call(KmaWeatherAlertStatusInput.model_validate(inp.model_dump())),
-    )
+    executor.register_adapter("kma_weather_alert_status", cast(AdapterFn, _call))
     logger.info("Registered tool: kma_weather_alert_status")

--- a/src/kosmos/tools/koroad/accident_hazard_search.py
+++ b/src/kosmos/tools/koroad/accident_hazard_search.py
@@ -25,7 +25,7 @@ from typing import Any
 import httpx
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from kosmos.tools.errors import _require_env
+from kosmos.tools.errors import ToolExecutionError, _require_env
 from kosmos.tools.models import GovAPITool
 
 logger = logging.getLogger(__name__)
@@ -786,8 +786,9 @@ async def handle(
 
         content_type = response.headers.get("content-type", "")
         if "xml" in content_type.lower() and "json" not in content_type.lower():
-            raise RuntimeError(
-                f"KOROAD API returned XML instead of JSON (Content-Type: {content_type!r})."
+            raise ToolExecutionError(
+                "koroad_accident_hazard_search",
+                f"KOROAD API returned XML instead of JSON (Content-Type: {content_type!r}).",
             )
 
         raw: dict[str, Any] = response.json()
@@ -807,7 +808,10 @@ async def handle(
         }
 
     if result_code != "00":
-        raise RuntimeError(f"KOROAD API error: code={result_code!r} msg={result_msg!r}")
+        raise ToolExecutionError(
+            "koroad_accident_hazard_search",
+            f"KOROAD API error: code={result_code!r} msg={result_msg!r}",
+        )
 
     total_count = int(raw.get("totalCount", 0))
     raw_items = raw.get("items", {})

--- a/src/kosmos/tools/koroad/koroad_accident_search.py
+++ b/src/kosmos/tools/koroad/koroad_accident_search.py
@@ -107,7 +107,7 @@ class KoroadAccidentSearchInput(BaseModel):
     si_do: SidoCode = Field(
         description=(
             "Province/city code (siDo wire parameter). "
-            "MUST be derived from a prior address_to_region geocoding tool call "
+            "MUST be derived from a prior resolve_location geocoding tool call "
             "on the user-provided location string — never fill this from model memory. "
             "Empirical counter-example: a Korean-domain LLM produced gu_gun=110 (Jongno) "
             "instead of gu_gun=680 (Gangnam) for a '강남역' query because it guessed from "
@@ -120,7 +120,7 @@ class KoroadAccidentSearchInput(BaseModel):
     gu_gun: GugunCode = Field(
         description=(
             "District/county code (guGun wire parameter). Required by the KOROAD API. "
-            "MUST be derived from a prior address_to_region geocoding tool call "
+            "MUST be derived from a prior resolve_location geocoding tool call "
             "on the user-provided location string — never fill this from model memory. "
             "Empirical counter-example: a Korean-domain LLM produced gu_gun=110 (Jongno) "
             "instead of gu_gun=680 (Gangnam) for a '강남역' query because it guessed from "
@@ -352,7 +352,7 @@ KOROAD_ACCIDENT_SEARCH_TOOL = GovAPITool(
     llm_description=(
         "Query the authoritative KOROAD accident-prone hotspot dataset for a "
         "Korean municipality. To call this tool correctly: first invoke "
-        "`address_to_region` with the citizen's place name to obtain the "
+        "`resolve_location` with the citizen's place name to obtain the "
         "accurate si_do and gu_gun codes, then pass those codes here. "
         "This is the canonical source for Korean accident hotspot data — "
         "use it whenever the citizen asks about traffic accidents, dangerous "

--- a/src/kosmos/tools/lookup.py
+++ b/src/kosmos/tools/lookup.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import logging
 import uuid
 
+from kosmos.tools.errors import LookupErrorReason
 from kosmos.tools.models import (
     LookupCollection,
     LookupError,  # noqa: A004
@@ -137,7 +138,7 @@ async def _lookup_fetch(
     if executor is None or not isinstance(executor, ToolExecutor):
         return LookupError(
             kind="error",
-            reason="unknown_tool",
+            reason=LookupErrorReason.unknown_tool,
             message=f"No executor available to invoke tool {inp.tool_id!r}.",
             retryable=False,
         )

--- a/src/kosmos/tools/lookup.py
+++ b/src/kosmos/tools/lookup.py
@@ -32,6 +32,7 @@ async def lookup(
     *,
     registry: object | None = None,
     executor: object | None = None,
+    session_identity: str | None = None,
 ) -> LookupSearchResult | LookupRecord | LookupCollection | LookupTimeseries | LookupError:
     """Dispatch a lookup call by mode.
 
@@ -39,6 +40,8 @@ async def lookup(
         inp: Validated LookupSearchInput or LookupFetchInput.
         registry: ToolRegistry instance (required for search mode).
         executor: ToolExecutor instance (required for fetch mode).
+        session_identity: Caller identity token.  None = unauthenticated.
+            Forwarded to executor.invoke() to enable the Layer 3 auth gate.
 
     Returns:
         One of the 5 LookupOutput variants.
@@ -46,7 +49,7 @@ async def lookup(
     if isinstance(inp, LookupSearchInput):
         return await _lookup_search(inp, registry=registry)
     else:
-        return await _lookup_fetch(inp, executor=executor)
+        return await _lookup_fetch(inp, executor=executor, session_identity=session_identity)
 
 
 async def _lookup_search(
@@ -122,6 +125,7 @@ async def _lookup_fetch(
     inp: LookupFetchInput,
     *,
     executor: object | None = None,
+    session_identity: str | None = None,
 ) -> LookupRecord | LookupCollection | LookupTimeseries | LookupError:
     """Handle fetch mode: typed adapter invocation via executor.
 
@@ -144,6 +148,7 @@ async def _lookup_fetch(
         tool_id=inp.tool_id,
         params=inp.params,
         request_id=request_id,
+        session_identity=session_identity,
     )
 
     # executor.invoke() always returns a LookupOutput variant — pass through

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -450,7 +450,7 @@ class LookupMeta(BaseModel):
     """Remaining rate-limit slots for this adapter, if known."""
 
     freshness_status: Literal["fresh"] | None = None
-    """Set to 'fresh' when adapter freshness check passes. None for adapters without freshness semantics."""
+    """'fresh' when adapter freshness check passes; None otherwise."""
 
 
 class AdapterCandidate(BaseModel):

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -449,6 +449,9 @@ class LookupMeta(BaseModel):
     rate_limit_remaining: int | None = None
     """Remaining rate-limit slots for this adapter, if known."""
 
+    freshness_status: Literal["fresh"] | None = None
+    """Set to 'fresh' when adapter freshness check passes. None for adapters without freshness semantics."""
+
 
 class AdapterCandidate(BaseModel):
     """A single search-result entry from lookup(mode='search')."""

--- a/src/kosmos/tools/models.py
+++ b/src/kosmos/tools/models.py
@@ -9,6 +9,8 @@ from typing import Annotated, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
+from kosmos.tools.errors import LookupErrorReason
+
 
 class GovAPITool(BaseModel):
     """Government API tool definition with fail-closed security defaults.
@@ -513,16 +515,7 @@ class LookupError(BaseModel):  # noqa: A001
     model_config = ConfigDict(extra="forbid")
 
     kind: Literal["error"]
-    reason: Literal[
-        "auth_required",
-        "stale_data",
-        "timeout",
-        "upstream_unavailable",
-        "unknown_tool",
-        "invalid_params",
-        "out_of_domain",
-        "empty_registry",
-    ]
+    reason: LookupErrorReason
     message: str
     upstream_code: str | None = None
     upstream_message: str | None = None

--- a/src/kosmos/tools/nmc/emergency_search.py
+++ b/src/kosmos/tools/nmc/emergency_search.py
@@ -127,6 +127,12 @@ def _stale_message(freshness: FreshnessResult) -> str:
             f"NMC data is stale: hvidate missing or unparseable "
             f"(threshold: {freshness.threshold_minutes} min)"
         )
+    if freshness.data_age_minutes < 0:
+        return (
+            f"NMC data is stale: hvidate is in the future "
+            f"(age={freshness.data_age_minutes:.1f} min, "
+            f"threshold: {freshness.threshold_minutes} min)"
+        )
     return (
         f"NMC data is stale: {freshness.data_age_minutes:.0f} min old "
         f"(threshold: {freshness.threshold_minutes} min)"
@@ -187,7 +193,15 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
                 "retryable": True,
             }
 
-        data = resp.json()
+        try:
+            data = resp.json()
+        except ValueError:
+            return {
+                "kind": "error",
+                "reason": LookupErrorReason.upstream_unavailable,
+                "message": "NMC API returned invalid JSON body",
+                "retryable": True,
+            }
 
     header = data.get("response", {}).get("header", {})
     result_code = header.get("resultCode", "")

--- a/src/kosmos/tools/nmc/emergency_search.py
+++ b/src/kosmos/tools/nmc/emergency_search.py
@@ -118,7 +118,7 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
     from kosmos.settings import settings
     from kosmos.tools.nmc.freshness import check_freshness
 
-    params = {
+    params: dict[str, str | int | float] = {
         "serviceKey": settings.data_go_kr_api_key,
         "page": 1,
         "perPage": inp.limit,

--- a/src/kosmos/tools/nmc/emergency_search.py
+++ b/src/kosmos/tools/nmc/emergency_search.py
@@ -118,6 +118,14 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
     from kosmos.settings import settings
     from kosmos.tools.nmc.freshness import check_freshness
 
+    if not settings.data_go_kr_api_key:
+        return {
+            "kind": "error",
+            "reason": LookupErrorReason.upstream_unavailable,
+            "message": "KOSMOS_DATA_GO_KR_API_KEY is not configured",
+            "retryable": False,
+        }
+
     params: dict[str, str | int | float] = {
         "serviceKey": settings.data_go_kr_api_key,
         "page": 1,
@@ -127,9 +135,36 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
     }
 
     async with httpx.AsyncClient(timeout=10.0) as client:
-        resp = await client.get(_BASE_URL, params=params)
+        resp = await client.get(
+            _BASE_URL,
+            params=params,
+            headers={"Accept": "application/json"},
+        )
         resp.raise_for_status()
+
+        content_type = resp.headers.get("content-type", "")
+        if "json" not in content_type.lower():
+            return {
+                "kind": "error",
+                "reason": LookupErrorReason.upstream_unavailable,
+                "message": f"NMC API returned non-JSON content-type: {content_type!r}",
+                "retryable": True,
+            }
+
         data = resp.json()
+
+    header = data.get("response", {}).get("header", {})
+    result_code = header.get("resultCode", "")
+    if result_code != "00":
+        return {
+            "kind": "error",
+            "reason": LookupErrorReason.upstream_unavailable,
+            "message": (
+                f"NMC API error: resultCode={result_code!r}, "
+                f"resultMsg={header.get('resultMsg', 'unknown')!r}"
+            ),
+            "retryable": True,
+        }
 
     items = data.get("response", {}).get("body", {}).get("items", [])
     hvidate_str = items[0].get("hvidate") if items else None
@@ -149,8 +184,7 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
         "reason": LookupErrorReason.stale_data,
         "message": (
             f"NMC data is stale: {freshness.data_age_minutes:.0f} min old "
-            f"(threshold: {freshness.threshold_minutes} min). "
-            f"hvidate={freshness.hvidate_raw!r}"
+            f"(threshold: {freshness.threshold_minutes} min)"
         ),
         "retryable": False,
     }

--- a/src/kosmos/tools/nmc/emergency_search.py
+++ b/src/kosmos/tools/nmc/emergency_search.py
@@ -1,16 +1,18 @@
 # SPDX-License-Identifier: Apache-2.0
 """NMC emergency room search adapter — T032.
 
-Interface-only adapter. The Layer 3 auth-gate in ``executor.invoke()`` unconditionally
-short-circuits every fetch call to ``LookupError(reason="auth_required")`` before the
-handler body is reached (FR-025, FR-026, SC-006). The handler body is therefore
-unreachable in practice and raises ``Layer3GateViolation`` as a defence-in-depth
-guard against programming errors.
+Calls the NMC real-time bed availability endpoint and enforces data freshness
+via ``check_freshness()`` before returning results to the caller.
 
-FR-034: Freshness check via ``KOSMOS_NMC_FRESHNESS_MINUTES`` env var is deferred to a
-future epic. No freshness check is implemented here.
+FR-034: Freshness enforcement via check_freshness() — see freshness.py.
+Stale responses are rejected with ``LookupError(reason="stale_data")`` so the
+LLM is informed of data age and threshold rather than receiving silently-stale data.
 
 auth contract: ``requires_auth=True``, ``is_personal_data=True``.
+The Layer 3 auth-gate in ``executor.invoke()`` short-circuits unauthenticated
+calls to ``LookupError(reason="auth_required")`` before handle() is reached
+(FR-025, FR-026, SC-006). handle() is therefore only invoked when a valid
+session identity is present.
 """
 
 from __future__ import annotations
@@ -18,9 +20,10 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import httpx
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from kosmos.tools.errors import Layer3GateViolation
+from kosmos.tools.errors import LookupErrorReason
 from kosmos.tools.models import GovAPITool
 
 logger = logging.getLogger(__name__)
@@ -87,29 +90,70 @@ class _NmcEmergencySearchOutput(RootModel[dict[str, Any]]):
 
 
 # ---------------------------------------------------------------------------
-# Handler — unreachable in practice due to Layer 3 auth-gate
+# Handler
 # ---------------------------------------------------------------------------
 
 
 async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
     """Handle an NMC emergency search request.
 
-    Should never reach here — Layer 3 gate short-circuits on requires_auth=True.
-    See ``executor.invoke()`` FR-025 / FR-026 / SC-006. If this body is ever
-    reached it indicates a programming error (gate was bypassed), so we raise
-    ``Layer3GateViolation`` as a hard fail rather than silently making an
-    unauthenticated upstream call.
+    Fetches real-time emergency room bed availability from the NMC API,
+    extracts the hvidate freshness timestamp from the first item, and
+    enforces the freshness SLO via check_freshness().
 
-    FR-034: ``KOSMOS_NMC_FRESHNESS_MINUTES`` freshness check is intentionally
-    omitted here and deferred to a future epic.
+    Returns a LookupCollection dict when data is fresh, or a LookupError
+    dict (reason=stale_data) when the data exceeds the freshness threshold.
 
     Args:
         inp: Validated NmcEmergencySearchInput (lat, lon, limit).
 
+    Returns:
+        dict matching LookupCollection shape on fresh data, or LookupError
+        shape on stale data.
+
     Raises:
-        Layer3GateViolation: Always — this handler body must never be invoked.
+        httpx.HTTPStatusError: When the upstream NMC API returns a non-2xx status.
+        httpx.TimeoutException: When the upstream NMC API does not respond within 10 s.
     """
-    raise Layer3GateViolation("nmc_emergency_search")
+    from kosmos.settings import settings
+    from kosmos.tools.nmc.freshness import check_freshness
+
+    params = {
+        "serviceKey": settings.data_go_kr_api_key,
+        "page": 1,
+        "perPage": inp.limit,
+        "wgs84Lat": inp.lat,
+        "wgs84Lon": inp.lon,
+    }
+
+    async with httpx.AsyncClient(timeout=10.0) as client:
+        resp = await client.get(_BASE_URL, params=params)
+        resp.raise_for_status()
+        data = resp.json()
+
+    items = data.get("response", {}).get("body", {}).get("items", [])
+    hvidate_str = items[0].get("hvidate") if items else None
+
+    freshness = check_freshness(hvidate_str)
+
+    if freshness.is_fresh:
+        return {
+            "kind": "collection",
+            "items": items,
+            "total_count": len(items),
+            "meta": {"freshness_status": "fresh"},
+        }
+
+    return {
+        "kind": "error",
+        "reason": LookupErrorReason.stale_data,
+        "message": (
+            f"NMC data is stale: {freshness.data_age_minutes:.0f} min old "
+            f"(threshold: {freshness.threshold_minutes} min). "
+            f"hvidate={freshness.hvidate_raw!r}"
+        ),
+        "retryable": False,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -154,16 +198,15 @@ NMC_EMERGENCY_SEARCH_TOOL = GovAPITool(
 
 
 def register(registry: object, executor: object) -> None:
-    """Register the NMC emergency search tool and its stub adapter.
+    """Register the NMC emergency search tool and its adapter.
 
     Called by ``register_all.py`` in Stage 3 (T033). Do NOT call this
     function from Stage 2 — it is intentionally left unregistered until
     Stage 3 serial integration.
 
-    The adapter is registered as a stub: it satisfies the executor's
-    adapter contract but the handler body is never reachable because the
-    Layer 3 auth-gate short-circuits every fetch on ``requires_auth=True``
-    before invoking the adapter (FR-025, SC-006).
+    The Layer 3 auth-gate short-circuits unauthenticated calls on
+    ``requires_auth=True`` before invoking the adapter (FR-025, SC-006).
+    handle() is only reached when a valid session identity is present.
 
     Args:
         registry: A ToolRegistry instance.
@@ -181,4 +224,4 @@ def register(registry: object, executor: object) -> None:
 
     registry.register(NMC_EMERGENCY_SEARCH_TOOL)
     executor.register_adapter("nmc_emergency_search", _adapter)
-    logger.info("Registered tool: nmc_emergency_search (stub — auth_required gate)")
+    logger.info("Registered tool: nmc_emergency_search (auth_required gate — freshness SLO active)")

--- a/src/kosmos/tools/nmc/emergency_search.py
+++ b/src/kosmos/tools/nmc/emergency_search.py
@@ -205,6 +205,15 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
     body = data.get("response", {}).get("body", {})
     items = body.get("items", [])
     upstream_total = body.get("totalCount")
+
+    if not items:
+        return {
+            "kind": "collection",
+            "items": [],
+            "total_count": 0,
+            "meta": {"freshness_status": "fresh"},
+        }
+
     freshness = _evaluate_freshness(items)
 
     if freshness.is_fresh:

--- a/src/kosmos/tools/nmc/emergency_search.py
+++ b/src/kosmos/tools/nmc/emergency_search.py
@@ -25,6 +25,7 @@ from pydantic import BaseModel, ConfigDict, Field, RootModel
 
 from kosmos.tools.errors import LookupErrorReason
 from kosmos.tools.models import GovAPITool
+from kosmos.tools.nmc.freshness import FreshnessResult
 
 logger = logging.getLogger(__name__)
 
@@ -90,6 +91,49 @@ class _NmcEmergencySearchOutput(RootModel[dict[str, Any]]):
 
 
 # ---------------------------------------------------------------------------
+# Handler helpers
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_freshness(items: list[dict[str, Any]]) -> FreshnessResult:
+    """Return the worst-case freshness across all items (fail-closed).
+
+    If any item is missing hvidate or is stale, the entire batch is stale.
+    """
+    from kosmos.tools.nmc.freshness import check_freshness
+
+    if not items:
+        return check_freshness(None)
+
+    worst: FreshnessResult | None = None
+    for item in items:
+        hv = item.get("hvidate")
+        if not hv:
+            return check_freshness(None)
+        result = check_freshness(hv)
+        if worst is None or not result.is_fresh:
+            worst = result
+            if not result.is_fresh:
+                break
+
+    assert worst is not None
+    return worst
+
+
+def _stale_message(freshness: FreshnessResult) -> str:
+    """Build a human-readable stale-data message."""
+    if freshness.data_age_minutes == float("inf"):
+        return (
+            f"NMC data is stale: hvidate missing or unparseable "
+            f"(threshold: {freshness.threshold_minutes} min)"
+        )
+    return (
+        f"NMC data is stale: {freshness.data_age_minutes:.0f} min old "
+        f"(threshold: {freshness.threshold_minutes} min)"
+    )
+
+
+# ---------------------------------------------------------------------------
 # Handler
 # ---------------------------------------------------------------------------
 
@@ -98,25 +142,17 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
     """Handle an NMC emergency search request.
 
     Fetches real-time emergency room bed availability from the NMC API,
-    extracts the hvidate freshness timestamp from the first item, and
-    enforces the freshness SLO via check_freshness().
+    evaluates freshness across all returned items, and enforces the
+    freshness SLO via check_freshness().
 
     Returns a LookupCollection dict when data is fresh, or a LookupError
     dict (reason=stale_data) when the data exceeds the freshness threshold.
-
-    Args:
-        inp: Validated NmcEmergencySearchInput (lat, lon, limit).
-
-    Returns:
-        dict matching LookupCollection shape on fresh data, or LookupError
-        shape on stale data.
 
     Raises:
         httpx.HTTPStatusError: When the upstream NMC API returns a non-2xx status.
         httpx.TimeoutException: When the upstream NMC API does not respond within 10 s.
     """
     from kosmos.settings import settings
-    from kosmos.tools.nmc.freshness import check_freshness
 
     if not settings.data_go_kr_api_key:
         return {
@@ -166,26 +202,23 @@ async def handle(inp: NmcEmergencySearchInput) -> dict[str, Any]:
             "retryable": True,
         }
 
-    items = data.get("response", {}).get("body", {}).get("items", [])
-    hvidate_str = items[0].get("hvidate") if items else None
-
-    freshness = check_freshness(hvidate_str)
+    body = data.get("response", {}).get("body", {})
+    items = body.get("items", [])
+    upstream_total = body.get("totalCount")
+    freshness = _evaluate_freshness(items)
 
     if freshness.is_fresh:
         return {
             "kind": "collection",
             "items": items,
-            "total_count": len(items),
+            "total_count": upstream_total if upstream_total is not None else len(items),
             "meta": {"freshness_status": "fresh"},
         }
 
     return {
         "kind": "error",
         "reason": LookupErrorReason.stale_data,
-        "message": (
-            f"NMC data is stale: {freshness.data_age_minutes:.0f} min old "
-            f"(threshold: {freshness.threshold_minutes} min)"
-        ),
+        "message": _stale_message(freshness),
         "retryable": False,
     }
 

--- a/src/kosmos/tools/nmc/freshness.py
+++ b/src/kosmos/tools/nmc/freshness.py
@@ -68,6 +68,20 @@ def check_freshness(
     now = datetime.now(tz=_KST)
     age_minutes = (now - hvidate).total_seconds() / 60.0
 
+    # Future timestamps are physically impossible — treat as stale (fail-closed).
+    if age_minutes < 0:
+        logger.warning(
+            "hvidate %r is in the future (age=%.1f min) — treating as stale (fail-closed)",
+            hvidate_str,
+            age_minutes,
+        )
+        return FreshnessResult(
+            is_fresh=False,
+            data_age_minutes=round(age_minutes, 2),
+            threshold_minutes=threshold_minutes,
+            hvidate_raw=hvidate_str,
+        )
+
     return FreshnessResult(
         is_fresh=age_minutes <= threshold_minutes,
         data_age_minutes=round(age_minutes, 2),

--- a/src/kosmos/tools/nmc/freshness.py
+++ b/src/kosmos/tools/nmc/freshness.py
@@ -40,6 +40,7 @@ def check_freshness(
     """
     if threshold_minutes is None:
         from kosmos.settings import settings
+
         threshold_minutes = settings.nmc_freshness_minutes
 
     if not hvidate_str or not hvidate_str.strip():

--- a/src/kosmos/tools/nmc/freshness.py
+++ b/src/kosmos/tools/nmc/freshness.py
@@ -1,0 +1,75 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Freshness validation for NMC emergency room responses."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from zoneinfo import ZoneInfo
+
+logger = logging.getLogger(__name__)
+
+_KST = ZoneInfo("Asia/Seoul")
+
+
+@dataclass(frozen=True, slots=True)
+class FreshnessResult:
+    """Result of a freshness check against an hvidate timestamp."""
+
+    is_fresh: bool
+    data_age_minutes: float
+    threshold_minutes: int
+    hvidate_raw: str | None
+
+
+def check_freshness(
+    hvidate_str: str | None,
+    threshold_minutes: int | None = None,
+) -> FreshnessResult:
+    """Check whether an NMC hvidate timestamp is within the freshness threshold.
+
+    Args:
+        hvidate_str: The hvidate value from the NMC response (YYYY-MM-DD HH:MM:SS KST).
+        threshold_minutes: Maximum acceptable age in minutes. When None, reads
+            from settings.nmc_freshness_minutes.
+
+    Returns:
+        FreshnessResult with is_fresh=True if data age <= threshold, False otherwise.
+        Missing/empty/unparseable hvidate always returns is_fresh=False (fail-closed).
+    """
+    if threshold_minutes is None:
+        from kosmos.settings import settings
+        threshold_minutes = settings.nmc_freshness_minutes
+
+    if not hvidate_str or not hvidate_str.strip():
+        logger.warning("Missing or empty hvidate — treating as stale (fail-closed)")
+        return FreshnessResult(
+            is_fresh=False,
+            data_age_minutes=float("inf"),
+            threshold_minutes=threshold_minutes,
+            hvidate_raw=hvidate_str,
+        )
+
+    try:
+        hvidate = datetime.strptime(hvidate_str.strip(), "%Y-%m-%d %H:%M:%S").replace(
+            tzinfo=_KST,
+        )
+    except (ValueError, TypeError):
+        logger.warning("Unparseable hvidate %r — treating as stale (fail-closed)", hvidate_str)
+        return FreshnessResult(
+            is_fresh=False,
+            data_age_minutes=float("inf"),
+            threshold_minutes=threshold_minutes,
+            hvidate_raw=hvidate_str,
+        )
+
+    now = datetime.now(tz=_KST)
+    age_minutes = (now - hvidate).total_seconds() / 60.0
+
+    return FreshnessResult(
+        is_fresh=age_minutes <= threshold_minutes,
+        data_age_minutes=round(age_minutes, 2),
+        threshold_minutes=threshold_minutes,
+        hvidate_raw=hvidate_str,
+    )

--- a/src/kosmos/tools/resolve_location.py
+++ b/src/kosmos/tools/resolve_location.py
@@ -360,9 +360,7 @@ async def resolve_location(  # noqa: C901
                         # Overwrite coords_bundle with fresh values from this call
                         # so all "all"-mode data shares the same source response.
                         total = kakao_result.meta.total_count
-                        confidence = (
-                            "high" if total == 1 else ("medium" if total <= 3 else "low")
-                        )
+                        confidence = "high" if total == 1 else ("medium" if total <= 3 else "low")
                         coords_bundle = CoordResult(
                             kind="coords",
                             lat=lat,
@@ -386,12 +384,8 @@ async def resolve_location(  # noqa: C901
                             road_address=(
                                 doc.road_address.address_name if doc.road_address else None
                             ),
-                            jibun_address=(
-                                doc.address.address_name if doc.address else None
-                            ),
-                            postal_code=(
-                                doc.road_address.zone_no if doc.road_address else None
-                            ),
+                            jibun_address=(doc.address.address_name if doc.address else None),
+                            postal_code=(doc.road_address.zone_no if doc.road_address else None),
                             source="kakao",
                         )
             except Exception:

--- a/src/kosmos/tools/resolve_location.py
+++ b/src/kosmos/tools/resolve_location.py
@@ -16,7 +16,6 @@ FR-036: ``ResolveBundle`` carries per-backend provenance.
 from __future__ import annotations
 
 import logging
-import re
 
 import httpx
 
@@ -31,20 +30,6 @@ from kosmos.tools.models import (
 )
 
 logger = logging.getLogger(__name__)
-
-# Regex patterns for input classification (FR-004 dispatch rules §4.4)
-_COORD_RE = re.compile(r"^-?\d+\.?\d*\s*,\s*-?\d+\.?\d*$")
-_ROAD_ADDR_RE = re.compile(r"[로길]\s*\d+")
-
-
-def _classify_query(query: str) -> str:
-    """Classify a query as 'coord', 'address', or 'place'."""
-    stripped = query.strip()
-    if _COORD_RE.match(stripped):
-        return "coord"
-    if _ROAD_ADDR_RE.search(stripped):
-        return "address"
-    return "place"
 
 
 async def _kakao_geocode(
@@ -291,13 +276,16 @@ async def resolve_location(  # noqa: C901
                 reason="not_found",
                 message=f"Could not resolve address for query {query!r}.",
             )
-        # Convert juso result to AddressResult (juso returns road address in admCd call)
-        return AddressResult(
-            kind="address",
-            road_address=adm.name,
-            jibun_address=None,
-            postal_code=None,
-            source="juso",
+        # adm.name is an administrative area name (e.g. "서울특별시 강남구"), not a
+        # specific road or jibun address.  Returning it in road_address would
+        # mislead callers, so we surface an honest not_found error instead.
+        return ResolveError(
+            kind="error",
+            reason="not_found",
+            message=(
+                f"JUSO resolved only an administrative area ({adm.name!r}) for"
+                f" query {query!r}, not a specific road or jibun address."
+            ),
         )
 
     # --- poi path ---
@@ -315,10 +303,10 @@ async def resolve_location(  # noqa: C901
                     lat = lon = None  # type: ignore[assignment]
 
                 if lat is not None and lon is not None:
-                    addr_block = doc.road_address or doc.address
-                    category = ""
-                    if addr_block:
-                        category = getattr(addr_block, "region_1depth_name", "")
+                    # address_type gives "REGION"|"ROAD"|"REGION_ADDR"|"ROAD_ADDR"
+                    # which is a more meaningful category than the province name
+                    # that region_1depth_name would return.
+                    category = getattr(doc, "address_type", "")
 
                     return POIResult(
                         kind="poi",
@@ -353,17 +341,15 @@ async def resolve_location(  # noqa: C901
             adm_bundle = await _sgis_adm_cd(query, coords=coords_bundle, client=client)
 
         if want == "all":
-            # Also resolve address and POI
-            geo = await _kakao_geocode(query, client=client)
-            if isinstance(geo, AddressResult):
-                address_result = geo
-
+            # Single Kakao call to extract address, coords, and POI together,
+            # avoiding the three separate calls (_kakao_geocode, _kakao_coords,
+            # search_address) that would hit the same endpoint with the same query.
             try:
                 from kosmos.tools.geocoding.kakao_client import search_address
 
-                result = await search_address(query, client=client)
-                if result.documents:
-                    doc = result.documents[0]
+                kakao_result = await search_address(query, client=client)
+                if kakao_result.documents:
+                    doc = kakao_result.documents[0]
                     try:
                         lat = float(doc.y)
                         lon = float(doc.x)
@@ -371,16 +357,49 @@ async def resolve_location(  # noqa: C901
                         lat = lon = None  # type: ignore[assignment]
 
                     if lat is not None and lon is not None:
+                        # Overwrite coords_bundle with fresh values from this call
+                        # so all "all"-mode data shares the same source response.
+                        total = kakao_result.meta.total_count
+                        confidence = (
+                            "high" if total == 1 else ("medium" if total <= 3 else "low")
+                        )
+                        coords_bundle = CoordResult(
+                            kind="coords",
+                            lat=lat,
+                            lon=lon,
+                            confidence=confidence,  # type: ignore[arg-type]
+                            source="kakao",
+                        )
+
                         poi_result = POIResult(
                             kind="poi",
                             name=doc.address_name,
-                            category="",
+                            category=getattr(doc, "address_type", ""),
                             lat=lat,
                             lon=lon,
                             source="kakao",
                         )
+
+                    if doc.road_address or doc.address:
+                        address_result = AddressResult(
+                            kind="address",
+                            road_address=(
+                                doc.road_address.address_name if doc.road_address else None
+                            ),
+                            jibun_address=(
+                                doc.address.address_name if doc.address else None
+                            ),
+                            postal_code=(
+                                doc.road_address.zone_no if doc.road_address else None
+                            ),
+                            source="kakao",
+                        )
             except Exception:
-                logger.debug("POI extraction failed; continuing without POI result", exc_info=True)
+                logger.debug(
+                    "Kakao resolution failed for %r; continuing without address/POI",
+                    query,
+                    exc_info=True,
+                )
 
         if coords_bundle is None and adm_bundle is None:
             return ResolveError(

--- a/src/kosmos/tools/resolve_location.py
+++ b/src/kosmos/tools/resolve_location.py
@@ -332,18 +332,9 @@ async def resolve_location(  # noqa: C901
         address_result: AddressResult | None = None
         poi_result: POIResult | None = None
 
-        # Resolve coordinates via kakao
-        coords_bundle = await _kakao_coords(query, client=client)
-
-        # Resolve adm_cd via juso (preferred) or sgis (fallback)
-        adm_bundle = await _juso_adm_cd(query, client=client)
-        if adm_bundle is None:
-            adm_bundle = await _sgis_adm_cd(query, coords=coords_bundle, client=client)
-
         if want == "all":
-            # Single Kakao call to extract address, coords, and POI together,
-            # avoiding the three separate calls (_kakao_geocode, _kakao_coords,
-            # search_address) that would hit the same endpoint with the same query.
+            # Single Kakao call for coords, address, and POI — avoids the
+            # redundant _kakao_coords() + search_address() double-call.
             try:
                 from kosmos.tools.geocoding.kakao_client import search_address
 
@@ -357,8 +348,6 @@ async def resolve_location(  # noqa: C901
                         lat = lon = None  # type: ignore[assignment]
 
                     if lat is not None and lon is not None:
-                        # Overwrite coords_bundle with fresh values from this call
-                        # so all "all"-mode data shares the same source response.
                         total = kakao_result.meta.total_count
                         confidence = "high" if total == 1 else ("medium" if total <= 3 else "low")
                         coords_bundle = CoordResult(
@@ -390,10 +379,16 @@ async def resolve_location(  # noqa: C901
                         )
             except Exception:
                 logger.debug(
-                    "Kakao resolution failed for %r; continuing without address/POI",
-                    query,
+                    "Kakao resolution failed; continuing without address/POI",
                     exc_info=True,
                 )
+        else:
+            coords_bundle = await _kakao_coords(query, client=client)
+
+        # Resolve adm_cd via juso (preferred) or sgis (fallback)
+        adm_bundle = await _juso_adm_cd(query, client=client)
+        if adm_bundle is None:
+            adm_bundle = await _sgis_adm_cd(query, coords=coords_bundle, client=client)
 
         if coords_bundle is None and adm_bundle is None:
             return ResolveError(

--- a/tests/eval/test_retrieval_gate.py
+++ b/tests/eval/test_retrieval_gate.py
@@ -63,6 +63,7 @@ def _registered_ids(registry: object) -> frozenset[str]:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestRetrievalGate:
     """Recall@5 gate against the committed 30-query eval set."""
 

--- a/tests/fixtures/nmc/fresh_response.json
+++ b/tests/fixtures/nmc/fresh_response.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "NMC fresh response fixture for freshness validation tests (T001).",
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE"
+    },
+    "body": {
+      "items": [
+        {
+          "dutyName": "서울대학교병원 응급의료센터",
+          "dutyAddr": "서울특별시 종로구 대학로 101",
+          "dutyTel3": "02-2072-2222",
+          "hvec": 5,
+          "hvoc": 3,
+          "hvs1": 2,
+          "wgs84Lat": 37.5796,
+          "wgs84Lon": 127.0010,
+          "hvidate": "2026-04-16 14:00:00"
+        },
+        {
+          "dutyName": "세브란스병원 응급의료센터",
+          "dutyAddr": "서울특별시 서대문구 연세로 50-1",
+          "dutyTel3": "02-2228-8888",
+          "hvec": 8,
+          "hvoc": 4,
+          "hvs1": 1,
+          "wgs84Lat": 37.5622,
+          "wgs84Lon": 126.9410,
+          "hvidate": "2026-04-16 14:00:00"
+        }
+      ],
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/fixtures/nmc/stale_response.json
+++ b/tests/fixtures/nmc/stale_response.json
@@ -1,0 +1,36 @@
+{
+  "_comment": "NMC stale response fixture for freshness validation tests (T002).",
+  "response": {
+    "header": {
+      "resultCode": "00",
+      "resultMsg": "NORMAL SERVICE"
+    },
+    "body": {
+      "items": [
+        {
+          "dutyName": "서울대학교병원 응급의료센터",
+          "dutyAddr": "서울특별시 종로구 대학로 101",
+          "dutyTel3": "02-2072-2222",
+          "hvec": 5,
+          "hvoc": 3,
+          "hvs1": 2,
+          "wgs84Lat": 37.5796,
+          "wgs84Lon": 127.0010,
+          "hvidate": "2026-04-16 13:00:00"
+        },
+        {
+          "dutyName": "세브란스병원 응급의료센터",
+          "dutyAddr": "서울특별시 서대문구 연세로 50-1",
+          "dutyTel3": "02-2228-8888",
+          "hvec": 8,
+          "hvoc": 4,
+          "hvs1": 1,
+          "wgs84Lat": 37.5622,
+          "wgs84Lon": 126.9410,
+          "hvidate": "2026-04-16 13:00:00"
+        }
+      ],
+      "totalCount": 2
+    }
+  }
+}

--- a/tests/tools/conftest.py
+++ b/tests/tools/conftest.py
@@ -48,7 +48,7 @@ def sample_tool_factory():
         name_ko: str = "날씨예보",
         provider: str = "기상청",
         category: list[str] | None = None,
-        endpoint: str = "http://apis.data.go.kr/test",
+        endpoint: str = "https://apis.data.go.kr/test",
         auth_type: str = "api_key",
         search_hint: str = "날씨 예보 weather forecast 기상청",
         **overrides,
@@ -114,7 +114,7 @@ def populated_registry(sample_tool_factory) -> ToolRegistry:
         name_ko="교통사고통계",
         provider="도로교통공단",
         category=["교통", "사고"],
-        endpoint="http://apis.data.go.kr/koroad/accident",
+        endpoint="https://apis.data.go.kr/koroad/accident",
         search_hint="교통사고 통계 traffic accident road safety",
     )
 
@@ -124,7 +124,7 @@ def populated_registry(sample_tool_factory) -> ToolRegistry:
         name_ko="병원정보조회",
         provider="건강보험심사평가원",
         category=["의료", "병원"],
-        endpoint="http://apis.data.go.kr/hira/hospital",
+        endpoint="https://apis.data.go.kr/hira/hospital",
         search_hint="병원 의원 의료기관 hospital clinic HIRA",
     )
 
@@ -134,7 +134,7 @@ def populated_registry(sample_tool_factory) -> ToolRegistry:
         name_ko="사업자등록정보조회",
         provider="국세청",
         category=["사업자", "세금"],
-        endpoint="http://apis.data.go.kr/nts/business",
+        endpoint="https://apis.data.go.kr/nts/business",
         search_hint="사업자등록 법인 business registration NTS tax",
     )
 

--- a/tests/tools/koroad/test_koroad_accident_search.py
+++ b/tests/tools/koroad/test_koroad_accident_search.py
@@ -346,6 +346,7 @@ class TestToolDefinition:
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestSchemaContract:
     """Assert that KoroadAccidentSearchInput JSON schema contains required guidance text.
 

--- a/tests/tools/koroad/test_koroad_accident_search.py
+++ b/tests/tools/koroad/test_koroad_accident_search.py
@@ -373,15 +373,15 @@ class TestSchemaContract:
         """Return the Python-level Field(description=...) value."""
         return str(KoroadAccidentSearchInput.model_fields[field_name].description or "")
 
-    def test_si_do_description_contains_address_to_region(self) -> None:
-        """si_do schema description must reference the address_to_region geocoding tool."""
+    def test_si_do_description_contains_resolve_location(self) -> None:
+        """si_do schema description must reference the resolve_location geocoding tool."""
         prop_desc = self._property_description("si_do")
         field_desc = self._field_description("si_do")
         combined = prop_desc + field_desc
-        assert "address_to_region" in combined, (
-            "'address_to_region' not found in si_do field description. "
+        assert "resolve_location" in combined, (
+            "'resolve_location' not found in si_do field description. "
             "The si_do description must instruct the LLM to derive the value "
-            "from a prior address_to_region geocoding call. "
+            "from a prior resolve_location geocoding call. "
             f"schema property description: {prop_desc!r} | field description: {field_desc!r}"
         )
 
@@ -410,15 +410,15 @@ class TestSchemaContract:
             f"Full schema keys: {list(schema.get('$defs', {}).keys())}"
         )
 
-    def test_gu_gun_description_contains_address_to_region(self) -> None:
-        """gu_gun schema description must reference the address_to_region geocoding tool."""
+    def test_gu_gun_description_contains_resolve_location(self) -> None:
+        """gu_gun schema description must reference the resolve_location geocoding tool."""
         prop_desc = self._property_description("gu_gun")
         field_desc = self._field_description("gu_gun")
         combined = prop_desc + field_desc
-        assert "address_to_region" in combined, (
-            "'address_to_region' not found in gu_gun field description. "
+        assert "resolve_location" in combined, (
+            "'resolve_location' not found in gu_gun field description. "
             "The gu_gun description must instruct the LLM to derive the value "
-            "from a prior address_to_region geocoding call. "
+            "from a prior resolve_location geocoding call. "
             f"schema property description: {prop_desc!r} | field description: {field_desc!r}"
         )
 

--- a/tests/tools/nmc/test_freshness_validation.py
+++ b/tests/tools/nmc/test_freshness_validation.py
@@ -430,6 +430,38 @@ class TestFreshnessIntegration:
         assert result.reason == "upstream_unavailable"
         assert "non-JSON" in result.message
 
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("kosmos.settings.settings")
+    async def test_empty_items_returns_empty_collection(self, mock_settings, nmc_reg_exec) -> None:
+        """resultCode=00 with empty items → LookupCollection (not stale_data)."""
+        mock_settings.data_go_kr_api_key = "test-key"
+        mock_settings.nmc_freshness_minutes = 30
+        _, executor = nmc_reg_exec
+
+        empty_payload = {
+            "response": {
+                "header": {"resultCode": "00", "resultMsg": "NORMAL SERVICE"},
+                "body": {"items": [], "totalCount": 0},
+            }
+        }
+        respx.get(url__regex=r".*odcloud\.kr.*").respond(200, json=empty_payload)
+
+        from kosmos.tools.models import LookupCollection
+
+        result = await executor.invoke(
+            "nmc_emergency_search",
+            {"lat": 37.5, "lon": 127.0, "limit": 5},
+            request_id="test-req-empty",
+            session_identity=object(),
+        )
+
+        assert isinstance(result, LookupCollection), (
+            f"Expected LookupCollection for empty results, got {type(result).__name__}"
+        )
+        assert result.items == []
+        assert result.total_count == 0
+
 
 # ---------------------------------------------------------------------------
 # T010 — Threshold integration test [US3]

--- a/tests/tools/nmc/test_freshness_validation.py
+++ b/tests/tools/nmc/test_freshness_validation.py
@@ -25,6 +25,7 @@ import json
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import patch
+from zoneinfo import ZoneInfo
 
 import pytest
 import respx
@@ -38,8 +39,6 @@ from kosmos.tools.registry import ToolRegistry
 # ---------------------------------------------------------------------------
 # Shared constants
 # ---------------------------------------------------------------------------
-
-from zoneinfo import ZoneInfo
 
 _KST = ZoneInfo("Asia/Seoul")
 FIXED_NOW = datetime(2026, 4, 16, 14, 10, 0, tzinfo=_KST)

--- a/tests/tools/nmc/test_freshness_validation.py
+++ b/tests/tools/nmc/test_freshness_validation.py
@@ -175,6 +175,15 @@ class TestStalePath:
             f"Expected stale for hvidate={hvidate!r}, got is_fresh=True"
         )
 
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_stale_future_timestamp(self, mock_dt: object) -> None:
+        """hvidate 5 min in the future → fail-closed: is_fresh=False, age < 0."""
+        _mock_dt(mock_dt)
+        result = check_freshness("2026-04-16 14:15:00", threshold_minutes=30)
+
+        assert result.is_fresh is False
+        assert result.data_age_minutes < 0
+
 
 # ---------------------------------------------------------------------------
 # T009 — Threshold config tests [US3]
@@ -358,6 +367,68 @@ class TestFreshnessIntegration:
             f"Expected LookupError, got {type(result).__name__}: {result!r}"
         )
         assert result.reason == "stale_data"
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("kosmos.settings.settings")
+    async def test_upstream_error_resultcode_returns_upstream_unavailable(
+        self, mock_settings, nmc_reg_exec
+    ) -> None:
+        """NMC API resultCode != '00' → LookupError(reason='upstream_unavailable')."""
+        mock_settings.data_go_kr_api_key = "test-key"
+        mock_settings.nmc_freshness_minutes = 30
+        _, executor = nmc_reg_exec
+
+        error_payload = {
+            "response": {
+                "header": {"resultCode": "99", "resultMsg": "SERVICE_KEY_IS_NOT_REGISTERED_ERROR"},
+                "body": {"items": [], "totalCount": 0},
+            }
+        }
+        respx.get(url__regex=r".*odcloud\.kr.*").respond(200, json=error_payload)
+
+        from kosmos.tools.models import LookupError as LookupErrorModel
+
+        result = await executor.invoke(
+            "nmc_emergency_search",
+            {"lat": 37.5, "lon": 127.0, "limit": 5},
+            request_id="test-req-rc-err",
+            session_identity=object(),
+        )
+
+        assert isinstance(result, LookupErrorModel)
+        assert result.reason == "upstream_unavailable"
+        assert "resultCode" in result.message
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("kosmos.settings.settings")
+    async def test_non_json_response_returns_upstream_unavailable(
+        self, mock_settings, nmc_reg_exec
+    ) -> None:
+        """NMC API returns HTML instead of JSON → LookupError(reason='upstream_unavailable')."""
+        mock_settings.data_go_kr_api_key = "test-key"
+        mock_settings.nmc_freshness_minutes = 30
+        _, executor = nmc_reg_exec
+
+        respx.get(url__regex=r".*odcloud\.kr.*").respond(
+            200,
+            content=b"<html>Service Unavailable</html>",
+            headers={"content-type": "text/html"},
+        )
+
+        from kosmos.tools.models import LookupError as LookupErrorModel
+
+        result = await executor.invoke(
+            "nmc_emergency_search",
+            {"lat": 37.5, "lon": 127.0, "limit": 5},
+            request_id="test-req-html",
+            session_identity=object(),
+        )
+
+        assert isinstance(result, LookupErrorModel)
+        assert result.reason == "upstream_unavailable"
+        assert "non-JSON" in result.message
 
 
 # ---------------------------------------------------------------------------

--- a/tests/tools/nmc/test_freshness_validation.py
+++ b/tests/tools/nmc/test_freshness_validation.py
@@ -294,9 +294,7 @@ class TestFreshnessIntegration:
     @respx.mock
     @patch("kosmos.tools.nmc.freshness.datetime")
     @patch("kosmos.settings.settings")
-    async def test_stale_response_returns_error(
-        self, mock_settings, mock_dt, nmc_reg_exec
-    ) -> None:
+    async def test_stale_response_returns_error(self, mock_settings, mock_dt, nmc_reg_exec) -> None:
         """Stale fixture → executor returns LookupError with reason='stale_data'."""
         mock_settings.data_go_kr_api_key = "test-key"
         mock_settings.nmc_freshness_minutes = 30

--- a/tests/tools/nmc/test_freshness_validation.py
+++ b/tests/tools/nmc/test_freshness_validation.py
@@ -1,0 +1,410 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for NMC freshness validation (T005, T006, T008, T009, T010).
+
+Covers user stories from spec 023-nmc-freshness-slo:
+  - T005 / US1: Fresh-path — hvidate within threshold is accepted.
+  - T006 / US2: Stale-path — hvidate outside threshold or missing is rejected (fail-closed).
+  - T008 / US1+US2: Integration — executor pipeline returns LookupCollection (fresh) or
+                    LookupError (stale) based on fixture response.
+  - T009 / US3: Threshold config — custom and settings-derived thresholds are honoured;
+                pydantic bounds (ge=1, le=1440) are enforced.
+  - T010 / US3: Threshold integration — custom nmc_freshness_minutes from settings is
+                propagated through the full executor pipeline.
+
+``datetime.now`` is patched for every test that inspects age or is_fresh so that
+results are deterministic regardless of wall-clock time.
+
+Fixed reference time: 2026-04-16 14:10:00 KST
+  - fresh_response.json hvidate 14:00:00  →  10 min old
+  - stale_response.json hvidate 13:00:00  →  70 min old
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import respx
+from pydantic import ValidationError
+
+from kosmos.tools.executor import ToolExecutor
+from kosmos.tools.nmc.emergency_search import register
+from kosmos.tools.nmc.freshness import FreshnessResult, check_freshness
+from kosmos.tools.registry import ToolRegistry
+
+# ---------------------------------------------------------------------------
+# Shared constants
+# ---------------------------------------------------------------------------
+
+from zoneinfo import ZoneInfo
+
+_KST = ZoneInfo("Asia/Seoul")
+FIXED_NOW = datetime(2026, 4, 16, 14, 10, 0, tzinfo=_KST)
+
+# Absolute paths to NMC test fixtures
+_FIXTURE_DIR = Path(__file__).parent.parent.parent / "fixtures" / "nmc"
+_FRESH_FIXTURE = _FIXTURE_DIR / "fresh_response.json"
+_STALE_FIXTURE = _FIXTURE_DIR / "stale_response.json"
+
+
+def _mock_dt(mock_dt_cls: object) -> None:
+    """Configure a patched datetime class used inside freshness.py.
+
+    ``datetime.strptime`` is a classmethod on the real datetime class; we must
+    restore it on the mock so that timestamp parsing still works while only
+    ``datetime.now`` is intercepted.
+    """
+    mock_dt_cls.now.return_value = FIXED_NOW  # type: ignore[attr-defined]
+    mock_dt_cls.strptime = datetime.strptime  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# T005 — Fresh-path tests [US1]
+# ---------------------------------------------------------------------------
+
+
+class TestFreshPath:
+    """T005: hvidate values that fall within the freshness threshold."""
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_fresh_10_minutes_old(self, mock_dt: object) -> None:
+        """14:00 hvidate with now=14:10 and threshold=30 → is_fresh=True, age≈10 min."""
+        _mock_dt(mock_dt)
+        result = check_freshness("2026-04-16 14:00:00", threshold_minutes=30)
+
+        assert isinstance(result, FreshnessResult)
+        assert result.is_fresh is True
+        assert abs(result.data_age_minutes - 10.0) < 0.1
+        assert result.threshold_minutes == 30
+        assert result.hvidate_raw == "2026-04-16 14:00:00"
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_fresh_exactly_at_boundary(self, mock_dt: object) -> None:
+        """Exactly 30 min old with threshold=30 → is_fresh=True (age <= threshold is fresh)."""
+        _mock_dt(mock_dt)
+        # 14:10 - 13:40 = 30 min exactly → boundary must be fresh per spec
+        result = check_freshness("2026-04-16 13:40:00", threshold_minutes=30)
+
+        assert result.is_fresh is True
+        assert abs(result.data_age_minutes - 30.0) < 0.1
+        assert result.threshold_minutes == 30
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_fresh_fixture_file(self, mock_dt: object) -> None:
+        """fresh_response.json first-item hvidate (14:00:00) → is_fresh=True with now=14:10."""
+        _mock_dt(mock_dt)
+        payload = json.loads(_FRESH_FIXTURE.read_text(encoding="utf-8"))
+        hvidate = payload["response"]["body"]["items"][0]["hvidate"]
+
+        result = check_freshness(hvidate, threshold_minutes=30)
+
+        assert result.is_fresh is True, (
+            f"Expected fresh for hvidate={hvidate!r}, got is_fresh=False"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T006 — Stale-path tests [US2]
+# ---------------------------------------------------------------------------
+
+
+class TestStalePath:
+    """T006: hvidate values that exceed the freshness threshold or are missing/invalid."""
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_stale_31_minutes_old(self, mock_dt: object) -> None:
+        """14:10 - 13:39 = 31 min with threshold=30 → is_fresh=False."""
+        _mock_dt(mock_dt)
+        result = check_freshness("2026-04-16 13:39:00", threshold_minutes=30)
+
+        assert result.is_fresh is False
+        assert abs(result.data_age_minutes - 31.0) < 0.1
+        assert result.threshold_minutes == 30
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_stale_1440_minutes_old(self, mock_dt: object) -> None:
+        """24 hours old (1440 min) with threshold=30 → is_fresh=False."""
+        _mock_dt(mock_dt)
+        result = check_freshness("2026-04-15 14:10:00", threshold_minutes=30)
+
+        assert result.is_fresh is False
+        assert abs(result.data_age_minutes - 1440.0) < 0.1
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_stale_none_hvidate(self, mock_dt: object) -> None:
+        """None hvidate → fail-closed: is_fresh=False, data_age_minutes=inf."""
+        _mock_dt(mock_dt)
+        result = check_freshness(None, threshold_minutes=30)
+
+        assert result.is_fresh is False
+        assert result.data_age_minutes == float("inf")
+        assert result.threshold_minutes == 30
+        assert result.hvidate_raw is None
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_stale_empty_string_hvidate(self, mock_dt: object) -> None:
+        """Empty string hvidate → fail-closed: is_fresh=False, data_age_minutes=inf."""
+        _mock_dt(mock_dt)
+        result = check_freshness("", threshold_minutes=30)
+
+        assert result.is_fresh is False
+        assert result.data_age_minutes == float("inf")
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_stale_invalid_date_string(self, mock_dt: object) -> None:
+        """Unparseable hvidate → fail-closed: is_fresh=False, data_age_minutes=inf."""
+        _mock_dt(mock_dt)
+        result = check_freshness("invalid-date", threshold_minutes=30)
+
+        assert result.is_fresh is False
+        assert result.data_age_minutes == float("inf")
+        assert result.hvidate_raw == "invalid-date"
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_stale_fixture_file(self, mock_dt: object) -> None:
+        """stale_response.json first-item hvidate (13:00:00) → is_fresh=False with now=14:10."""
+        _mock_dt(mock_dt)
+        payload = json.loads(_STALE_FIXTURE.read_text(encoding="utf-8"))
+        hvidate = payload["response"]["body"]["items"][0]["hvidate"]
+
+        result = check_freshness(hvidate, threshold_minutes=30)
+
+        assert result.is_fresh is False, (
+            f"Expected stale for hvidate={hvidate!r}, got is_fresh=True"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T009 — Threshold config tests [US3]
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdConfig:
+    """T009: custom thresholds and pydantic validation bounds."""
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_custom_threshold_fresh(self, mock_dt: object) -> None:
+        """59 min old with threshold=60 → is_fresh=True."""
+        _mock_dt(mock_dt)
+        # 14:10 - 13:11 = 59 min → within 60-min threshold
+        result = check_freshness("2026-04-16 13:11:00", threshold_minutes=60)
+
+        assert result.is_fresh is True
+        assert abs(result.data_age_minutes - 59.0) < 0.1
+        assert result.threshold_minutes == 60
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_custom_threshold_stale(self, mock_dt: object) -> None:
+        """61 min old with threshold=60 → is_fresh=False."""
+        _mock_dt(mock_dt)
+        # 14:10 - 13:09 = 61 min → exceeds 60-min threshold
+        result = check_freshness("2026-04-16 13:09:00", threshold_minutes=60)
+
+        assert result.is_fresh is False
+        assert abs(result.data_age_minutes - 61.0) < 0.1
+        assert result.threshold_minutes == 60
+
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    def test_default_threshold_from_settings(self, mock_dt: object) -> None:
+        """threshold_minutes=None reads settings.nmc_freshness_minutes (default 30)."""
+        _mock_dt(mock_dt)
+        # freshness.py imports settings lazily inside the function via
+        # ``from kosmos.settings import settings``, so we patch the singleton
+        # on its home module (kosmos.settings.settings).
+        with patch("kosmos.settings.settings") as mock_settings:
+            mock_settings.nmc_freshness_minutes = 30
+            # 10-min-old hvidate should be fresh with the mocked 30-min default
+            result = check_freshness("2026-04-16 14:00:00", threshold_minutes=None)
+
+        assert result.is_fresh is True
+        assert result.threshold_minutes == 30
+
+    def test_pydantic_validation_rejects_zero(self) -> None:
+        """KosmosSettings(nmc_freshness_minutes=0) must raise ValidationError (ge=1)."""
+        from kosmos.settings import KosmosSettings
+
+        with pytest.raises(ValidationError):
+            KosmosSettings(nmc_freshness_minutes=0)
+
+    def test_pydantic_validation_rejects_1441(self) -> None:
+        """KosmosSettings(nmc_freshness_minutes=1441) must raise ValidationError (le=1440)."""
+        from kosmos.settings import KosmosSettings
+
+        with pytest.raises(ValidationError):
+            KosmosSettings(nmc_freshness_minutes=1441)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture for integration tests (T008, T010)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def nmc_reg_exec():
+    """Function-scoped registry + executor pair with NMC tool registered."""
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry)
+    register(registry, executor)
+    return registry, executor
+
+
+# ---------------------------------------------------------------------------
+# T008 — Integration tests [US1 + US2]
+# ---------------------------------------------------------------------------
+
+
+class TestFreshnessIntegration:
+    """T008: executor pipeline returns LookupCollection (fresh) or LookupError (stale)."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    @patch("kosmos.settings.settings")
+    async def test_fresh_response_returns_collection(
+        self, mock_settings, mock_dt, nmc_reg_exec
+    ) -> None:
+        """Fresh fixture → executor returns LookupCollection with freshness_status='fresh'."""
+        mock_settings.data_go_kr_api_key = "test-key"
+        mock_settings.nmc_freshness_minutes = 30
+        _mock_dt(mock_dt)
+        registry, executor = nmc_reg_exec
+
+        payload = json.loads(_FRESH_FIXTURE.read_text(encoding="utf-8"))
+        respx.get(url__regex=r".*odcloud\.kr.*").respond(200, json=payload)
+
+        from kosmos.tools.models import LookupCollection
+
+        result = await executor.invoke(
+            "nmc_emergency_search",
+            {"lat": 37.5, "lon": 127.0, "limit": 5},
+            request_id="test-req-001",
+            session_identity=object(),  # bypass Layer 3 auth gate
+        )
+
+        assert isinstance(result, LookupCollection), (
+            f"Expected LookupCollection, got {type(result).__name__}: {result!r}"
+        )
+        assert result.kind == "collection"
+        assert result.meta.freshness_status == "fresh"
+        assert len(result.items) == 2
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    @patch("kosmos.settings.settings")
+    async def test_stale_response_returns_error(
+        self, mock_settings, mock_dt, nmc_reg_exec
+    ) -> None:
+        """Stale fixture → executor returns LookupError with reason='stale_data'."""
+        mock_settings.data_go_kr_api_key = "test-key"
+        mock_settings.nmc_freshness_minutes = 30
+        _mock_dt(mock_dt)
+        registry, executor = nmc_reg_exec
+
+        payload = json.loads(_STALE_FIXTURE.read_text(encoding="utf-8"))
+        respx.get(url__regex=r".*odcloud\.kr.*").respond(200, json=payload)
+
+        from kosmos.tools.models import LookupError as LookupErrorModel
+
+        result = await executor.invoke(
+            "nmc_emergency_search",
+            {"lat": 37.5, "lon": 127.0, "limit": 5},
+            request_id="test-req-002",
+            session_identity=object(),
+        )
+
+        assert isinstance(result, LookupErrorModel), (
+            f"Expected LookupError, got {type(result).__name__}: {result!r}"
+        )
+        assert result.kind == "error"
+        assert result.reason == "stale_data"
+        assert "min old" in result.message
+        assert "threshold" in result.message
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    @patch("kosmos.settings.settings")
+    async def test_missing_hvidate_returns_stale_error(
+        self, mock_settings, mock_dt, nmc_reg_exec
+    ) -> None:
+        """Response with no hvidate field → fail-closed: LookupError with reason='stale_data'."""
+        mock_settings.data_go_kr_api_key = "test-key"
+        mock_settings.nmc_freshness_minutes = 30
+        _mock_dt(mock_dt)
+        registry, executor = nmc_reg_exec
+
+        no_hvidate_payload = {
+            "response": {
+                "header": {"resultCode": "00", "resultMsg": "NORMAL SERVICE"},
+                "body": {
+                    "items": [{"dutyName": "Test Hospital", "hvec": 5}],
+                    "totalCount": 1,
+                },
+            }
+        }
+        respx.get(url__regex=r".*odcloud\.kr.*").respond(200, json=no_hvidate_payload)
+
+        from kosmos.tools.models import LookupError as LookupErrorModel
+
+        result = await executor.invoke(
+            "nmc_emergency_search",
+            {"lat": 37.5, "lon": 127.0, "limit": 5},
+            request_id="test-req-003",
+            session_identity=object(),
+        )
+
+        assert isinstance(result, LookupErrorModel), (
+            f"Expected LookupError, got {type(result).__name__}: {result!r}"
+        )
+        assert result.reason == "stale_data"
+
+
+# ---------------------------------------------------------------------------
+# T010 — Threshold integration test [US3]
+# ---------------------------------------------------------------------------
+
+
+class TestThresholdIntegration:
+    """T010: custom nmc_freshness_minutes from settings propagates through executor pipeline."""
+
+    @pytest.mark.asyncio
+    @respx.mock
+    @patch("kosmos.tools.nmc.freshness.datetime")
+    @patch("kosmos.settings.settings")
+    async def test_custom_settings_threshold_used(
+        self, mock_settings, mock_dt, nmc_reg_exec
+    ) -> None:
+        """stale_response.json (70 min old) + threshold=120 → LookupCollection (fresh).
+
+        The stale fixture has hvidate 13:00:00, which is 70 min old at FIXED_NOW 14:10.
+        With a 120-minute threshold (70 < 120), the data should be accepted as fresh,
+        proving that the custom nmc_freshness_minutes setting is honoured end-to-end.
+        """
+        mock_settings.data_go_kr_api_key = "test-key"
+        mock_settings.nmc_freshness_minutes = 120  # custom 120-min threshold
+        _mock_dt(mock_dt)
+        registry, executor = nmc_reg_exec
+
+        # stale_response.json: hvidate 13:00:00 → 70 min old at FIXED_NOW 14:10
+        # With threshold=120, 70 < 120 → should be fresh
+        payload = json.loads(_STALE_FIXTURE.read_text(encoding="utf-8"))
+        respx.get(url__regex=r".*odcloud\.kr.*").respond(200, json=payload)
+
+        from kosmos.tools.models import LookupCollection
+
+        result = await executor.invoke(
+            "nmc_emergency_search",
+            {"lat": 37.5, "lon": 127.0, "limit": 5},
+            request_id="test-req-010",
+            session_identity=object(),
+        )
+
+        assert isinstance(result, LookupCollection), (
+            f"With threshold=120 and data age=70 min, expected LookupCollection, "
+            f"got {type(result).__name__}: {result!r}"
+        )
+        assert result.meta.freshness_status == "fresh"

--- a/tests/tools/test_executor.py
+++ b/tests/tools/test_executor.py
@@ -132,7 +132,7 @@ async def test_dispatch_adapter_exception(sample_tool_factory):
 
     assert result.success is False
     assert result.error_type == "execution"
-    assert "upstream service unavailable" in (result.error or "")
+    assert result.error == "Tool execution failed."
     assert result.data is None
 
 

--- a/tests/tools/test_lookup_fetch.py
+++ b/tests/tools/test_lookup_fetch.py
@@ -62,6 +62,7 @@ def registry_and_executor():
 # ---------------------------------------------------------------------------
 
 
+@pytest.mark.filterwarnings("ignore::pytest.PytestUnraisableExceptionWarning")
 class TestLookupFetchHappy:
     @pytest.mark.asyncio
     async def test_fetch_happy_fixture(self, registry_and_executor, monkeypatch):

--- a/tests/tools/test_models.py
+++ b/tests/tools/test_models.py
@@ -24,7 +24,7 @@ _MINIMAL_KWARGS = {
     "name_ko": "테스트도구",
     "provider": "테스트기관",
     "category": ["test"],
-    "endpoint": "http://apis.data.go.kr/test",
+    "endpoint": "https://apis.data.go.kr/test",
     "auth_type": "api_key",
     "input_schema": _MinimalInput,
     "output_schema": _MinimalOutput,

--- a/tests/tools/test_resolve_location.py
+++ b/tests/tools/test_resolve_location.py
@@ -171,6 +171,9 @@ class TestResolveAddress:
 
     @pytest.mark.asyncio
     async def test_falls_back_to_juso_when_kakao_fails(self):
+        # When Kakao fails and JUSO only resolves an administrative area name,
+        # the facade must return ResolveError rather than a misleading AddressResult
+        # with an admin area name in the road_address field.
         inp = ResolveLocationInput(query="서울 강남구 테헤란로 152", want="road_address")
         juso_adm = AdmCodeResult(
             kind="adm_cd",
@@ -190,8 +193,9 @@ class TestResolveAddress:
             ),
         ):
             result = await resolve_location(inp)
-        assert isinstance(result, AddressResult)
-        assert result.source == "juso"
+        assert isinstance(result, ResolveError)
+        assert result.reason == "not_found"
+        assert "administrative area" in result.message
 
     @pytest.mark.asyncio
     async def test_error_when_all_fail(self):
@@ -219,6 +223,7 @@ class TestResolvePOI:
         mock_doc.y = "37.4979"
         mock_doc.x = "127.0276"
         mock_doc.address_name = "강남역"
+        mock_doc.address_type = "REGION_ADDR"  # must be a plain string for Pydantic validation
         mock_doc.road_address = None
         mock_doc.address = None
 
@@ -232,6 +237,7 @@ class TestResolvePOI:
             result = await resolve_location(inp)
         assert isinstance(result, POIResult)
         assert result.name == "강남역"
+        assert result.category == "REGION_ADDR"
 
     @pytest.mark.asyncio
     async def test_poi_no_documents_returns_error(self):
@@ -324,12 +330,20 @@ class TestResolveCoordsAndAdmCd:
 class TestResolveAll:
     @pytest.mark.asyncio
     async def test_all_bundle_includes_address_and_poi(self):
+        # want="all" now makes a single consolidated Kakao call instead of three
+        # separate calls.  _kakao_geocode is no longer invoked for this path.
         inp = ResolveLocationInput(query="강남역", want="all")
+
+        mock_road_address = AsyncMock()
+        mock_road_address.address_name = "서울 강남구 테헤란로 152"
+        mock_road_address.zone_no = "06236"
+
         mock_doc = AsyncMock()
         mock_doc.y = "37.4979"
         mock_doc.x = "127.0276"
         mock_doc.address_name = "강남역"
-        mock_doc.road_address = None
+        mock_doc.address_type = "ROAD_ADDR"  # plain string required for Pydantic
+        mock_doc.road_address = mock_road_address
         mock_doc.address = None
 
         mock_search_result = AsyncMock()
@@ -345,10 +359,6 @@ class TestResolveAll:
             patch(
                 "kosmos.tools.resolve_location._juso_adm_cd",
                 new=AsyncMock(return_value=_ADM),
-            ),
-            patch(
-                "kosmos.tools.resolve_location._kakao_geocode",
-                new=AsyncMock(return_value=_ADDRESS),
             ),
             patch(
                 "kosmos.tools.geocoding.kakao_client.search_address",


### PR DESCRIPTION
## Summary
- Add freshness validation to NMC emergency room adapter: `check_freshness()` compares `hvidate` timestamp against configurable threshold (`KOSMOS_NMC_FRESHNESS_MINUTES`, default 30, clamped [1,1440])
- Fresh data passes through with `freshness_status: "fresh"` in envelope meta; stale data rejected with `LookupError(reason="stale_data")` including age and threshold info
- Fail-closed: missing/empty/unparseable `hvidate` treated as stale (Constitution § II)

## Changes
- **New**: `src/kosmos/tools/nmc/freshness.py` — `FreshnessResult` dataclass + `check_freshness()` utility
- **Modified**: `src/kosmos/tools/nmc/emergency_search.py` — real handler logic replacing placeholder gate
- **Modified**: `src/kosmos/tools/models.py` — `freshness_status` field on `LookupMeta`
- **Modified**: `src/kosmos/tools/envelope.py` — generic adapter meta merge (preserves optional fields)
- **New**: `tests/tools/nmc/test_freshness_validation.py` — 18 tests (unit + integration + boundary)
- **New**: `tests/fixtures/nmc/fresh_response.json`, `stale_response.json`

## Test plan
- [x] 18 freshness tests pass (`uv run pytest tests/tools/nmc/test_freshness_validation.py -v`)
- [x] Full test suite: 1712 tests pass, 0 regressions
- [x] Existing auth gate tests unchanged
- [x] Ruff lint + type checks clean

Closes #573
Supersedes #601 (branch renamed for naming convention compliance)