### PR TITLE
chore(024): post-merge polish — exception consistency + stale comments

### DIFF
--- a/src/kosmos/tools/mvp_surface.py
+++ b/src/kosmos/tools/mvp_surface.py
@@ -71,7 +71,10 @@ RESOLVE_LOCATION_TOOL = GovAPITool(
         "위치 조회 주소 변환 행정동 코드 좌표 지오코딩 POI 장소 검색 "
         "resolve location address geocode coordinates adm_cd administrative code place"
     ),
-    # TOOL_MIN_AAL row: AAL1 (canonical). Public geocoding; no PII linkage.
+    # TOOL_MIN_AAL row: AAL1 (canonical). Geocoding produces no PII
+    # (pipa_class=non_personal) but still requires an authenticated session at
+    # AAL1 — we want every lookup call linked to a citizen session for rate
+    # limiting and abuse tracking, even though the payload itself is not PII.
     auth_level="AAL1",
     pipa_class="non_personal",
     is_irreversible=False,

--- a/src/kosmos/tools/registry.py
+++ b/src/kosmos/tools/registry.py
@@ -29,9 +29,9 @@ class ToolRegistry:
         Raises:
             DuplicateToolError: If tool.id is already registered.
             RegistrationError: If ``is_personal_data=True`` without ``requires_auth=True``
-                (FR-038 — fail-closed PII invariant).
-            ValueError: If ``tool.auth_level`` disagrees with ``TOOL_MIN_AAL`` (V3 drift
-                backstop for callers that bypass pydantic validation via ``model_construct``).
+                (FR-038 — fail-closed PII invariant), or if ``tool.auth_level`` disagrees
+                with ``TOOL_MIN_AAL`` (V3 drift backstop for callers that bypass pydantic
+                validation via ``model_construct``).
         """
         if tool.id in self._tools:
             raise DuplicateToolError(tool.id)
@@ -62,7 +62,7 @@ class ToolRegistry:
         # GovAPITool's @model_validator already enforces V3 at construction time;
         # we re-check here so registration emits a structured log if an out-of-tree
         # caller bypassed pydantic validation (e.g., model_construct) and re-raises
-        # as ValueError to match the data-model.md §1 contract.
+        # as RegistrationError for consistency with the other FR-038 backstops above.
         expected_aal = TOOL_MIN_AAL.get(tool.id)
         if expected_aal is not None and tool.auth_level != expected_aal:
             logger.error(
@@ -72,10 +72,10 @@ class ToolRegistry:
                 tool.auth_level,
                 expected_aal,
             )
-            raise ValueError(
-                f"V3 violation (FR-001/FR-005): tool {tool.id!r} declares "
-                f"auth_level={tool.auth_level!r} but TOOL_MIN_AAL requires "
-                f"{expected_aal!r}."
+            raise RegistrationError(
+                tool.id,
+                f"V3 violation (FR-001/FR-005): declares auth_level={tool.auth_level!r} "
+                f"but TOOL_MIN_AAL requires {expected_aal!r}.",
             )
 
         self._tools[tool.id] = tool

--- a/tests/tools/test_registration_extensibility.py
+++ b/tests/tools/test_registration_extensibility.py
@@ -166,9 +166,12 @@ class TestPiiRegistrationInvariant:
         we build the violating shape with pydantic's validation disabled.
         """
         registry = ToolRegistry()
-        # Build a V5-valid AAL2 PII tool, then downgrade requires_auth via
-        # model_construct to fabricate the FR-038 violation that the registry
-        # must still catch. GovAPITool is not frozen, so we can assign after.
+        # Build a V5-valid AAL2 PII tool, then downgrade requires_auth to
+        # fabricate the FR-038 violation that the registry must still catch.
+        # GovAPITool is frozen (ConfigDict(frozen=True)), so normal assignment
+        # is blocked — we use object.__setattr__ to bypass the freeze, which is
+        # precisely the "bypassed validation" scenario the registry backstop
+        # exists to defend against.
         good_base = sample_tool_factory(
             id="bad_pii_tool",
             auth_level="AAL2",

--- a/tests/unit/test_tool_call_audit_record.py
+++ b/tests/unit/test_tool_call_audit_record.py
@@ -39,19 +39,6 @@ _VALID_HASH_C = "c" * 64
 # drift on the host. Truncate microseconds for stable serialization.
 _VALID_TS = datetime.now(UTC).replace(microsecond=0)
 
-_SCHEMA_PATH = (
-    __file__.replace("tests/unit/test_tool_call_audit_record.py", "")
-    + "docs/security/tool-call-audit-record.schema.json"
-)
-
-
-def _abs_schema_path() -> str:
-    """Return the absolute path to the JSON Schema artifact."""
-    import pathlib
-
-    repo_root = pathlib.Path(__file__).parent.parent.parent
-    return str(repo_root / "docs" / "security" / "tool-call-audit-record.schema.json")
-
 
 def _minimal_record(**overrides) -> dict:
     """Return a dict that satisfies every required field with valid values."""


### PR DESCRIPTION
## Summary

Post-merge polish follow-ups from Copilot + Codex review of PR #653 (Epic #612, Spec-024 V1). All four items are cosmetic / dead-code / wrong-comment; none breach an invariant. The substantive follow-up (Codex P1 — V6 `auth_type ↔ auth_level` defense-in-depth) is tracked separately as **Epic #654** under Initiative #462.

### Changes

1. **`src/kosmos/tools/registry.py`** — V3 drift backstop now raises `RegistrationError` (consistent with the sibling FR-038 backstops in the same block) instead of `ValueError`. Verified no tests asserted `ValueError` on this path; all 97 registry/invariant/model-ext tests pass.
2. **`src/kosmos/tools/mvp_surface.py`** — rephrase the `resolve_location` comment to clarify `pipa_class=non_personal` coexisting with `requires_auth=True` (AAL1 session for rate limiting / abuse tracking, not because the payload is PII).
3. **`tests/tools/test_registration_extensibility.py`** — fix the misleading "GovAPITool is not frozen" comment. The model IS `ConfigDict(frozen=True)`; `object.__setattr__` is used precisely to simulate the bypassed-validation scenario the registry backstop defends against.
4. **`tests/unit/test_tool_call_audit_record.py`** — remove unused `_SCHEMA_PATH` global + `_abs_schema_path` helper (dead since schema tests were reworked).

### Out of scope

- **Codex P1** (auth_type ↔ auth_level consistency): tracked as Epic #654, linked to Initiative #462. Adds `@model_validator V6` + registry backstop + `PermissionPipeline` audit + spec update.

## Test plan

- [x] `uv run pytest tests/tools/test_registry_invariant.py tests/tools/test_registration_extensibility.py tests/unit/test_tool_call_audit_record.py tests/unit/test_gov_api_tool_extensions.py` → 97 passed
- [x] Full suite `uv run pytest` → 1799 passed, 30 skipped
- [ ] CI green
- [ ] Copilot review pass