### PR TITLE
fix(030-e2e): preserve LookupError as structured data and enforce I9 invariant

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -102,10 +102,6 @@ _KMA_FIXTURE_DIR = _FIXTURE_BASE / "kma"
 # T008: httpx.AsyncClient.get AsyncMock seam with per-scenario error injection
 # ---------------------------------------------------------------------------
 
-# call_count tracker per adapter per scenario — used by degraded-path tests
-# to distinguish first-call vs retry-call behaviour.
-_CALL_COUNTERS: dict[str, int] = {}
-
 
 def _resolve_tape_path(
     adapter_id: str,
@@ -999,17 +995,13 @@ def _build_registry_and_executor() -> tuple[ToolRegistry, ToolExecutor]:
     # registry and executor are captured here so lookup() can perform BM25 search
     # (search mode) and executor.invoke() dispatch (fetch mode).
     # Use model_dump(mode="json") so all fields are JSON-safe (no datetime/UUID objects).
-    # Raise RuntimeError when lookup() returns LookupError so dispatch() records
-    # success=False and the engine sees a failed tool result (mirrors the adapter
-    # contract: error outcomes must propagate as ToolResult.success=False).
-    from kosmos.tools.models import LookupError as _LookupError
-
+    # LookupError is returned as structured data (kind="error") rather than raised as
+    # an exception — this preserves the structured error payload so the LLM receives
+    # the full context and downstream assertions can check kind=="error" in the result.
     async def _lookup_adapter(inp: BaseModel) -> dict[str, Any]:
         actual_inp = inp.root if hasattr(inp, "root") else inp  # type: ignore[attr-defined]
         assert isinstance(actual_inp, (LookupSearchInput, LookupFetchInput))
         result = await _lookup_fn(actual_inp, registry=registry, executor=executor)
-        if isinstance(result, _LookupError):
-            raise RuntimeError(f"lookup error: reason={result.reason}, msg={result.message}")
         return result.model_dump(mode="json")
 
     executor.register_adapter("lookup", _lookup_adapter)

--- a/tests/e2e/models.py
+++ b/tests/e2e/models.py
@@ -221,4 +221,13 @@ class RunReport(BaseModel):
         # I8
         if self.stop_reason == "end_turn" and not self.final_response:
             raise ValueError("I8: stop_reason='end_turn' requires non-empty final_response")
+        # I9: stop_reason="error_unrecoverable" => final_response is None OR graceful Korean msg.
+        if self.stop_reason == "error_unrecoverable" and self.final_response is not None:
+            korean_apology_markers = ["죄송", "장애", "일시적", "다시", "이용할 수 없"]
+            if not any(marker in self.final_response for marker in korean_apology_markers):
+                raise ValueError(
+                    "I9: stop_reason='error_unrecoverable' with non-None final_response "
+                    "must be a graceful Korean apology message containing one of: "
+                    f"{korean_apology_markers!r}"
+                )
         return self

--- a/tests/e2e/test_route_safety_edge.py
+++ b/tests/e2e/test_route_safety_edge.py
@@ -154,7 +154,9 @@ async def test_edge_unregistered_tool_id() -> None:
     """Edge 1: lookup(mode="fetch", tool_id="nonexistent_adapter_xyz") → LookupError.
 
     The executor must return LookupError(reason="unknown_tool") without crashing.
-    Engine continues to the next LLM turn which produces a recovery text.
+    lookup() returns a structured LookupError payload (kind="error") as tool data
+    rather than raising — this preserves the error context so the LLM can reason
+    about it.  Engine continues to the next LLM turn which produces recovery text.
     """
     engine, httpx_mock = _build_engine([_LOOKUP_UNREGISTERED_TOOL, _TEXT_RECOVERY])
 
@@ -167,10 +169,21 @@ async def test_edge_unregistered_tool_id() -> None:
     stop_events = [e for e in events if e.type == "stop"]
     assert stop_events, "No stop event — engine crashed on unknown adapter"
 
-    # Tool result must be a failed result
+    # Tool result must carry a structured LookupError payload (kind="error").
+    # LookupError is returned as data (ToolResult.success=True) so the LLM
+    # receives the full structured context rather than an opaque error string.
     tool_results = [e for e in events if e.type == "tool_result" and e.tool_result is not None]
-    failed = [r for r in tool_results if r.tool_result and not r.tool_result.success]
-    assert failed, "Expected ToolResult(success=False) for unknown adapter"
+    lookup_errors = [
+        r
+        for r in tool_results
+        if r.tool_result
+        and r.tool_result.data is not None
+        and r.tool_result.data.get("kind") == "error"
+    ]
+    assert lookup_errors, (
+        "Expected ToolResult with data.kind='error' for unknown adapter; "
+        f"got tool_results={[r.tool_result for r in tool_results]!r}"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Post-merge follow-up for #990 addressing two Copilot IMPORTANT items flagged in reviews 4134147678 and 4134168884 (submitted after the squash-merge):

- **LookupError contract**: `_lookup_adapter` in `conftest.py` previously raised `RuntimeError` when `lookup()` returned a `LookupError`, converting it to an opaque error string. Now returns the structured payload (`kind/reason/message`) as `ToolResult.data` so the LLM receives full context. Removes dead `_CALL_COUNTERS` module-level dict that was never read.

- **Test alignment**: `test_edge_unregistered_tool_id` assertion updated to check `data.get('kind') == 'error'` to match the new contract (previously checked `ToolResult.success=False`).

- **I9 invariant enforcement**: `RunReport._check_invariants()` now enforces the I9 invariant that was declared in the docstring but silently unenforced: when `stop_reason='error_unrecoverable'` and `final_response` is non-None, the response must contain a graceful Korean apology marker.

## Test plan

- [ ] `uv run pytest tests/e2e/ -x -q` passes (31 tests)
- [ ] `uv run ruff check tests/e2e/conftest.py tests/e2e/test_route_safety_edge.py tests/e2e/models.py` clean
- [ ] Copilot Review Gate passes (no CRITICAL, <3 IMPORTANT)