### PR TITLE
fix(1633): restore tui boot path after dead-code sweep

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -114,8 +114,9 @@ Column definitions:
 | `KOSMOS_PERMISSION_MODE` | OTel span attr | n/a | String span attribute key | `kosmos.permissions.otel_integration.KOSMOS_PERMISSION_MODE` | [Spec 033 Permission v2 (Epic #1297)](#permission-v2-epic-1297) |
 | `KOSMOS_PERMISSION_DECISION` | OTel span attr | n/a | String span attribute key | `kosmos.permissions.otel_integration.KOSMOS_PERMISSION_DECISION` | [Spec 033 Permission v2 (Epic #1297)](#permission-v2-epic-1297) |
 | `KOSMOS_CONSENT_RECEIPT_ID` | OTel span attr | n/a | String span attribute key | `kosmos.permissions.otel_integration.KOSMOS_CONSENT_RECEIPT_ID` | [Spec 033 Permission v2 (Epic #1297)](#permission-v2-epic-1297) |
+| `KOSMOS_IPC_HANDLER` | No | `llm` | `llm` \| `echo` | `kosmos.ipc.stdio.run` | [Epic #1633 dead-code + FriendliAI migration](#epic-1633-tui-boot-recovery) |
 
-> **Row count**: 52 rows (47 `KOSMOS_*` active + 2 `LANGFUSE_*` + 1 `KOSMOS_OTEL_ENDPOINT` +
+> **Row count**: 53 rows (48 `KOSMOS_*` active + 2 `LANGFUSE_*` + 1 `KOSMOS_OTEL_ENDPOINT` +
 > 1 override-family pattern + 1 deprecated). `KOSMOS_KOROAD_API_KEY` and
 > `KOSMOS_KOROAD_ACCIDENT_SEARCH_API_KEY` are concrete expansions of the
 > `KOSMOS_{TOOL_ID}_API_KEY` override-family pattern and are covered by that row.
@@ -712,6 +713,24 @@ oldest entries are evicted.
 | **Range** | Integer >= 1 |
 | **Consumed by** | `kosmos.ipc.tx_cache._DEFAULT_CAPACITY` |
 | **Spec** | Spec 032 FR-029, FR-031 |
+
+### `KOSMOS_IPC_HANDLER`
+
+Selects the `user_input` frame handler in the stdio IPC loop
+(`kosmos.ipc.stdio.run`). The production handler routes UserInputFrames
+through `LLMClient.stream()` to FriendliAI (K-EXAONE). The echo handler
+is a test-only fixture that mirrors every user_input back as
+`AssistantChunkFrame(delta="[echo] {text}", done=True)` — used by
+integration tests in `tui/tests/ipc/bridge.test.ts` that must not depend
+on `FRIENDLI_API_KEY` or network reachability.
+
+| Property | Value |
+|----------|-------|
+| **Default** | `llm` |
+| **Required** | No |
+| **Range** | `llm` \| `echo` |
+| **Consumed by** | `kosmos.ipc.stdio.run` |
+| **Spec** | Epic #1633 FR-007 |
 
 ### OTel span-attribute keys
 

--- a/src/kosmos/ipc/stdio.py
+++ b/src/kosmos/ipc/stdio.py
@@ -415,26 +415,149 @@ async def run(  # noqa: C901
     protocol = asyncio.StreamReaderProtocol(stdin_reader)
     transport, _ = await loop.connect_read_pipe(lambda: protocol, sys.stdin.buffer)
 
-    # Default on_frame: echo user_input frames; route session_event frames to the
-    # session manager.  Wraps every handler in try/except so malformed payloads
-    # never crash the loop (FR-010).
+    # Default on_frame: route `user_input` to the FriendliAI LLM (Epic #1633
+    # FR-007/FR-017) and `session_event` to the session manager. Wraps every
+    # handler in try/except so malformed payloads never crash the loop
+    # (FR-010).
+    #
+    # Per-session conversation history is kept in `_llm_sessions` below; each
+    # user_input appends one message, the model's reply is appended as
+    # assistant, and subsequent turns see the full history. System prompt is
+    # loaded lazily from Spec 026 PromptLoader on first turn.
+    _llm_sessions: dict[str, list[dict[str, object]]] = {}
+    _llm_client_ref: list[object] = []  # holds the singleton LLMClient
+    _llm_system_prompt_cached: list[str | None] = [None]
+
+    async def _ensure_llm_client() -> object:
+        if not _llm_client_ref:
+            from kosmos.llm.client import LLMClient  # noqa: PLC0415
+            from kosmos.llm.config import LLMClientConfig  # noqa: PLC0415
+
+            cfg = LLMClientConfig()
+            _llm_client_ref.append(LLMClient(config=cfg))
+        return _llm_client_ref[0]
+
+    async def _ensure_system_prompt() -> str | None:
+        if _llm_system_prompt_cached[0] is not None:
+            return _llm_system_prompt_cached[0] or None
+        try:
+            from kosmos.prompts.loader import PromptLoader  # noqa: PLC0415
+
+            loader = PromptLoader()
+            _llm_system_prompt_cached[0] = loader.load("system_v1").content
+        except Exception:  # noqa: BLE001
+            _llm_system_prompt_cached[0] = ""  # remember "tried and failed"
+        return _llm_system_prompt_cached[0] or None
+
+    async def _handle_user_input_llm(frame: IPCFrame) -> None:
+        from kosmos.ipc.frame_schema import AssistantChunkFrame  # noqa: PLC0415
+        from kosmos.llm.models import ChatMessage  # noqa: PLC0415
+
+        history = _llm_sessions.setdefault(frame.session_id, [])
+        if not history:
+            system_text = await _ensure_system_prompt()
+            if system_text:
+                history.append({"role": "system", "content": system_text})
+        history.append({"role": "user", "content": frame.text})
+
+        client = await _ensure_llm_client()
+        messages: list[ChatMessage] = []
+        for m in history:
+            role = str(m.get("role", "user"))
+            content = m.get("content")
+            if role in ("system", "user", "assistant", "tool") and isinstance(
+                content, str
+            ):
+                messages.append(
+                    ChatMessage(
+                        role=role,  # type: ignore[arg-type]
+                        content=content,
+                    )
+                )
+
+        message_id = str(uuid.uuid4())
+        assistant_text_chunks: list[str] = []
+        stream_error: Exception | None = None
+
+        try:
+            async for event in client.stream(  # type: ignore[attr-defined]
+                messages=messages, max_tokens=2048
+            ):
+                event_type = getattr(event, "type", None)
+                if event_type == "content_delta":
+                    delta = getattr(event, "content", "") or ""
+                    if delta:
+                        assistant_text_chunks.append(delta)
+                        chunk_frame = AssistantChunkFrame(
+                            session_id=frame.session_id,
+                            correlation_id=frame.correlation_id,
+                            role="llm",
+                            ts=_utcnow(),
+                            kind="assistant_chunk",
+                            message_id=message_id,
+                            delta=delta,
+                            done=False,
+                        )
+                        await write_frame(chunk_frame)
+                elif event_type == "done":
+                    break
+                elif event_type == "error":
+                    stream_error = RuntimeError(
+                        str(getattr(event, "content", "unknown stream error"))
+                    )
+                    break
+        except Exception as exc:  # noqa: BLE001
+            stream_error = exc
+
+        full_text = "".join(assistant_text_chunks)
+        if stream_error is not None:
+            err = ErrorFrame(
+                session_id=frame.session_id,
+                correlation_id=frame.correlation_id or str(uuid.uuid4()),
+                role="llm",
+                ts=_utcnow(),
+                kind="error",
+                code="llm_stream_error",
+                message=str(stream_error),
+                details={"message_id": message_id},
+            )
+            await write_frame(err)
+            return
+
+        # Terminal chunk — done=True signals end-of-turn to the TS side.
+        terminal = AssistantChunkFrame(
+            session_id=frame.session_id,
+            correlation_id=frame.correlation_id,
+            role="llm",
+            ts=_utcnow(),
+            kind="assistant_chunk",
+            message_id=message_id,
+            delta="",
+            done=True,
+        )
+        await write_frame(terminal)
+
+        history.append({"role": "assistant", "content": full_text})
+
     if on_frame is None:
 
         async def _handle_frame(frame: IPCFrame) -> None:
             if frame.kind == "user_input":
-                from kosmos.ipc.frame_schema import AssistantChunkFrame
-
-                echo_frame = AssistantChunkFrame(
-                    session_id=frame.session_id,
-                    correlation_id=frame.correlation_id,
-                    role="backend",
-                    ts=_utcnow(),
-                    kind="assistant_chunk",
-                    message_id=str(uuid.uuid4()),
-                    delta=f"[echo] {frame.text}",
-                    done=True,
-                )
-                await write_frame(echo_frame)
+                try:
+                    await _handle_user_input_llm(frame)
+                except Exception as exc:  # noqa: BLE001
+                    logger.exception("user_input LLM handler failed: %s", exc)
+                    err = ErrorFrame(
+                        session_id=frame.session_id,
+                        correlation_id=frame.correlation_id or str(uuid.uuid4()),
+                        role="llm",
+                        ts=_utcnow(),
+                        kind="error",
+                        code="llm_handler_error",
+                        message=f"LLM handler failed: {exc}",
+                        details={},
+                    )
+                    await write_frame(err)
 
             elif frame.kind == "session_event":
                 evt = frame.event

--- a/src/kosmos/ipc/stdio.py
+++ b/src/kosmos/ipc/stdio.py
@@ -441,17 +441,32 @@ async def run(  # noqa: C901
         if _llm_system_prompt_cached[0] is not None:
             return _llm_system_prompt_cached[0] or None
         try:
-            from kosmos.prompts.loader import PromptLoader  # noqa: PLC0415
+            from pathlib import Path  # noqa: PLC0415
 
-            loader = PromptLoader()
-            _llm_system_prompt_cached[0] = loader.load("system_v1").content
+            from kosmos.context.prompt_loader import PromptLoader  # noqa: PLC0415
+
+            # Default manifest lives at repo-root/prompts/manifest.yaml. The
+            # stdio backend runs from repo root when invoked via
+            # `uv run kosmos --ipc stdio`, so resolve relative to CWD.
+            manifest = Path("prompts") / "manifest.yaml"
+            if not manifest.is_file():
+                _llm_system_prompt_cached[0] = ""
+                return None
+            loader = PromptLoader(manifest_path=manifest)
+            _llm_system_prompt_cached[0] = loader.load("system_v1")
         except Exception:  # noqa: BLE001
             _llm_system_prompt_cached[0] = ""  # remember "tried and failed"
         return _llm_system_prompt_cached[0] or None
 
     async def _handle_user_input_llm(frame: IPCFrame) -> None:  # noqa: C901
-        from kosmos.ipc.frame_schema import AssistantChunkFrame  # noqa: PLC0415
+        from kosmos.ipc.frame_schema import (  # noqa: PLC0415
+            AssistantChunkFrame,
+            UserInputFrame,
+        )
         from kosmos.llm.models import ChatMessage  # noqa: PLC0415
+
+        if not isinstance(frame, UserInputFrame):
+            return
 
         history = _llm_sessions.setdefault(frame.session_id, [])
         if not history:
@@ -547,7 +562,13 @@ async def run(  # noqa: C901
     _handler_mode = (_os.environ.get("KOSMOS_IPC_HANDLER") or "llm").lower()
 
     async def _handle_user_input_echo(frame: IPCFrame) -> None:
-        from kosmos.ipc.frame_schema import AssistantChunkFrame  # noqa: PLC0415
+        from kosmos.ipc.frame_schema import (  # noqa: PLC0415
+            AssistantChunkFrame,
+            UserInputFrame,
+        )
+
+        if not isinstance(frame, UserInputFrame):
+            return
 
         echo_frame = AssistantChunkFrame(
             session_id=frame.session_id,

--- a/src/kosmos/ipc/stdio.py
+++ b/src/kosmos/ipc/stdio.py
@@ -449,7 +449,7 @@ async def run(  # noqa: C901
             _llm_system_prompt_cached[0] = ""  # remember "tried and failed"
         return _llm_system_prompt_cached[0] or None
 
-    async def _handle_user_input_llm(frame: IPCFrame) -> None:
+    async def _handle_user_input_llm(frame: IPCFrame) -> None:  # noqa: C901
         from kosmos.ipc.frame_schema import AssistantChunkFrame  # noqa: PLC0415
         from kosmos.llm.models import ChatMessage  # noqa: PLC0415
 
@@ -539,14 +539,40 @@ async def run(  # noqa: C901
 
         history.append({"role": "assistant", "content": full_text})
 
+    # KOSMOS_IPC_HANDLER env var selects the user_input handler:
+    #   - "llm" (default): route UserInputFrame → LLMClient.stream() → FriendliAI
+    #   - "echo": mirror UserInputFrame back as AssistantChunkFrame "[echo] {text}"
+    # Echo mode is used by integration tests that spawn the real backend but
+    # must not depend on FRIENDLI_API_KEY or network reachability.
+    import os as _os  # noqa: PLC0415
+    _handler_mode = (_os.environ.get("KOSMOS_IPC_HANDLER") or "llm").lower()
+
+    async def _handle_user_input_echo(frame: IPCFrame) -> None:
+        from kosmos.ipc.frame_schema import AssistantChunkFrame  # noqa: PLC0415
+
+        echo_frame = AssistantChunkFrame(
+            session_id=frame.session_id,
+            correlation_id=frame.correlation_id,
+            role="backend",
+            ts=_utcnow(),
+            kind="assistant_chunk",
+            message_id=str(uuid.uuid4()),
+            delta=f"[echo] {frame.text}",
+            done=True,
+        )
+        await write_frame(echo_frame)
+
     if on_frame is None:
 
         async def _handle_frame(frame: IPCFrame) -> None:
             if frame.kind == "user_input":
                 try:
-                    await _handle_user_input_llm(frame)
+                    if _handler_mode == "echo":
+                        await _handle_user_input_echo(frame)
+                    else:
+                        await _handle_user_input_llm(frame)
                 except Exception as exc:  # noqa: BLE001
-                    logger.exception("user_input LLM handler failed: %s", exc)
+                    logger.exception("user_input handler failed: %s", exc)
                     err = ErrorFrame(
                         session_id=frame.session_id,
                         correlation_id=frame.correlation_id or str(uuid.uuid4()),

--- a/src/kosmos/ipc/stdio.py
+++ b/src/kosmos/ipc/stdio.py
@@ -465,9 +465,7 @@ async def run(  # noqa: C901
         for m in history:
             role = str(m.get("role", "user"))
             content = m.get("content")
-            if role in ("system", "user", "assistant", "tool") and isinstance(
-                content, str
-            ):
+            if role in ("system", "user", "assistant", "tool") and isinstance(content, str):
                 messages.append(
                     ChatMessage(
                         role=role,  # type: ignore[arg-type]
@@ -545,6 +543,7 @@ async def run(  # noqa: C901
     # Echo mode is used by integration tests that spawn the real backend but
     # must not depend on FRIENDLI_API_KEY or network reachability.
     import os as _os  # noqa: PLC0415
+
     _handler_mode = (_os.environ.get("KOSMOS_IPC_HANDLER") or "llm").lower()
 
     async def _handle_user_input_echo(frame: IPCFrame) -> None:

--- a/tui/src/commands/login/login.tsx
+++ b/tui/src/commands/login/login.tsx
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+import React from 'react'
+
+export function Login(): React.ReactElement {
+  return React.createElement(
+    'box' as unknown as React.ElementType,
+    null,
+    'KOSMOS does not require login — set FRIENDLI_API_KEY in your environment.',
+  )
+}

--- a/tui/src/commands/logout/logout.ts
+++ b/tui/src/commands/logout/logout.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export async function clearAuthRelatedCaches(): Promise<void> {
+  /* no-op — KOSMOS has no auth cache */
+}
+
+export async function performLogout(): Promise<void> {
+  /* no-op — KOSMOS auth is env-var based; logout is meaningless */
+}

--- a/tui/src/components/grove/Grove.tsx
+++ b/tui/src/components/grove/Grove.tsx
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+import React from 'react'
+
+export type GroveDecision = 'allow' | 'deny' | 'later'
+
+export function GroveDialog(): React.ReactElement | null {
+  return null
+}
+
+export function PrivacySettingsDialog(): React.ReactElement | null {
+  return null
+}

--- a/tui/src/constants/oauth.ts
+++ b/tui/src/constants/oauth.ts
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Anthropic OAuth constants were deleted in Epic #1633 (KOSMOS authenticates
+// only via FRIENDLI_API_KEY, never via OAuth). Consumers still reference these
+// symbols, so we re-export empty strings / inert config — guards around them
+// must fail closed because scopes are empty.
+
+export const CLAUDE_AI_INFERENCE_SCOPE = ''
+export const CLAUDE_AI_PROFILE_SCOPE = ''
+export const MCP_CLIENT_METADATA_URL = ''
+export const OAUTH_BETA_HEADER = ''
+
+export function fileSuffixForOauthConfig(): string {
+  return ''
+}
+
+interface OauthConfigShape {
+  readonly BASE_API_URL: string
+  readonly CLIENT_ID: string
+  readonly AUTHORIZE_URL: string
+  readonly TOKEN_URL: string
+  readonly REVOKE_URL: string
+  readonly SUCCESS_URL: string
+}
+
+// FriendliAI base URL — used by several legacy call sites that still hit
+// `${getOauthConfig().BASE_API_URL}/v1/...` directly. Most of those paths are
+// now dead (bridge/session/grove endpoints reach Anthropic-only routes), but
+// returning a non-null object avoids TypeError crashes during boot.
+const KOSMOS_OAUTH_CONFIG: OauthConfigShape = {
+  BASE_API_URL: 'https://api.friendli.ai/serverless',
+  CLIENT_ID: '',
+  AUTHORIZE_URL: '',
+  TOKEN_URL: '',
+  REVOKE_URL: '',
+  SUCCESS_URL: '',
+}
+
+export function getOauthConfig(): OauthConfigShape {
+  return KOSMOS_OAUTH_CONFIG
+}

--- a/tui/src/ipc/bridge.ts
+++ b/tui/src/ipc/bridge.ts
@@ -111,6 +111,14 @@ export interface BridgeOptions {
    * Called after all reconnect attempts are exhausted without success.
    */
   onReconnectFailed?: () => void
+
+  /**
+   * Additional env vars to merge onto the backend subprocess environment
+   * (on top of the inherited process env). Used primarily by tests to select
+   * the `echo` handler via `{ KOSMOS_IPC_HANDLER: 'echo' }` without needing
+   * FRIENDLI_API_KEY on the CI runner.
+   */
+  env?: Record<string, string>
 }
 
 export interface CrashNotice {
@@ -310,10 +318,14 @@ export function createBridge(opts: BridgeOptions = {}): IPCBridge {
   // ------------------------------------------------------------------
   // Spawn first process
   // ------------------------------------------------------------------
+  const spawnEnv = opts.env
+    ? ({ ...process.env, ...opts.env } as Record<string, string>)
+    : (process.env as Record<string, string>)
   let proc = Bun.spawn(cmd, {
     stdin: 'pipe',
     stdout: 'pipe',
     stderr: 'pipe',
+    env: spawnEnv,
   })
 
   const frameQueue = new AsyncQueue<IPCFrame>()

--- a/tui/src/ipc/bridgeSingleton.ts
+++ b/tui/src/ipc/bridgeSingleton.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 FR-007/FR-017 bootstrap helper.
+//
+// Holds the lazily-spawned, process-wide IPCBridge instance. This is the
+// single place `query/deps.ts::callModel` reads from to construct an
+// `LLMClient` — it guarantees one Python backend per TUI process, started on
+// first use, shared across every turn.
+//
+// The bridge is spawned lazily because cold-starting `uv run kosmos --ipc
+// stdio` adds ~1–2 s to TUI boot; we don't pay that cost unless the first
+// prompt is actually typed. Subsequent turns reuse the running child.
+
+import { createBridge, type IPCBridge } from './bridge.js'
+
+let _bridge: IPCBridge | null = null
+let _sessionId: string | null = null
+
+export function getOrCreateKosmosBridge(): IPCBridge {
+  if (_bridge !== null) return _bridge
+  _bridge = createBridge({})
+  return _bridge
+}
+
+export function getKosmosBridgeSessionId(): string {
+  if (_sessionId === null) {
+    _sessionId = crypto.randomUUID()
+  }
+  return _sessionId
+}
+
+export async function closeKosmosBridge(): Promise<void> {
+  if (_bridge !== null) {
+    const b = _bridge
+    _bridge = null
+    await b.close()
+  }
+}

--- a/tui/src/main.tsx
+++ b/tui/src/main.tsx
@@ -961,6 +961,7 @@ async function run(): Promise<CommanderCommand> {
         let reservedNameError: string | null = null;
         if (nonSdkConfigNames.some(isClaudeInChromeMCPServer)) {
           reservedNameError = `Invalid MCP configuration: "${CLAUDE_IN_CHROME_MCP_SERVER_NAME}" is a reserved MCP name.`;
+        }
         if (reservedNameError) {
           // stderr+exit(1) — a throw here becomes a silent unhandled
           // rejection in stream-json mode (void main() in cli.tsx).
@@ -1241,6 +1242,10 @@ async function run(): Promise<CommanderCommand> {
       initBuiltinPlugins();
       initBundledSkills();
     }
+    // UDS_INBOX feature removed in Epic #1633 — CC wired this through the
+    // Unix-domain inbox path, which KOSMOS does not use. Preserve the
+    // `setup()` signature by passing `undefined`.
+    const messagingSocketPath: string | undefined = undefined;
     const setupPromise = setup(preSetupCwd, permissionMode, allowDangerouslySkipPermissions, worktreeEnabled, worktreeName, tmuxEnabled, sessionId ? validateUuid(sessionId) : undefined, worktreePRNumber, messagingSocketPath);
     const commandsPromise = worktreeEnabled ? null : getCommands(preSetupCwd);
     const agentDefsPromise = worktreeEnabled ? null : getAgentDefinitionsWithOverrides(preSetupCwd);

--- a/tui/src/remote/RemoteSessionManager.ts
+++ b/tui/src/remote/RemoteSessionManager.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export interface RemoteSessionConfig {
+  readonly sessionId?: string
+}
+
+export interface RemotePermissionResponse {
+  readonly allow: boolean
+}
+
+export class RemoteSessionManager {
+  constructor(_config?: RemoteSessionConfig) {
+    /* no-op */
+  }
+  async start(): Promise<void> {
+    /* no-op */
+  }
+  async stop(): Promise<void> {
+    /* no-op */
+  }
+}

--- a/tui/src/remote/remotePermissionBridge.ts
+++ b/tui/src/remote/remotePermissionBridge.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function createSyntheticAssistantMessage(_text: string): null {
+  return null
+}
+
+export function createToolStub(_name: string): null {
+  return null
+}

--- a/tui/src/remote/sdkMessageAdapter.ts
+++ b/tui/src/remote/sdkMessageAdapter.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function convertSDKMessage(_msg: unknown): null {
+  return null
+}
+
+export function isSessionEndMessage(_msg: unknown): boolean {
+  return false
+}

--- a/tui/src/sdk-compat.ts
+++ b/tui/src/sdk-compat.ts
@@ -221,3 +221,53 @@ export class InternalServerError extends APIError {
     this.name = 'InternalServerError'
   }
 }
+
+export class NotFoundError extends APIError {
+  constructor(message: string = 'Not found.') {
+    super(404, undefined, message)
+    this.name = 'NotFoundError'
+  }
+}
+
+export class BadRequestError extends APIError {
+  constructor(message: string = 'Bad request.') {
+    super(400, undefined, message)
+    this.name = 'BadRequestError'
+  }
+}
+
+export class PermissionDeniedError extends APIError {
+  constructor(message: string = 'Permission denied.') {
+    super(403, undefined, message)
+    this.name = 'PermissionDeniedError'
+  }
+}
+
+export class UnprocessableEntityError extends APIError {
+  constructor(message: string = 'Unprocessable entity.') {
+    super(422, undefined, message)
+    this.name = 'UnprocessableEntityError'
+  }
+}
+
+export class ConflictError extends APIError {
+  constructor(message: string = 'Conflict.') {
+    super(409, undefined, message)
+    this.name = 'ConflictError'
+  }
+}
+
+// Beta namespace surface — Anthropic SDK's `@anthropic-ai/sdk/resources/beta`
+// exposed these via `Beta.Messages.*`. We re-expose as module-level type
+// aliases where reachable; the following is a no-op value namespace stub for
+// call sites that reference `Anthropic.Beta.Messages.MessageCreateParams` etc.
+export const Beta = {}
+export type Beta = typeof Beta
+export interface RedactedThinkingBlock {
+  type: 'redacted_thinking'
+  data: string
+}
+export type RedactedThinkingBlockParam = RedactedThinkingBlock
+export type BetaRedactedThinkingBlock = RedactedThinkingBlock
+export type BetaThinkingBlock = ThinkingBlock
+export type BetaWebSearchTool20250305 = Record<string, unknown>

--- a/tui/src/services/analytics/config.ts
+++ b/tui/src/services/analytics/config.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function isAnalyticsDisabled(): boolean {
+  return true
+}
+
+export function isFeedbackSurveyDisabled(): boolean {
+  return true
+}

--- a/tui/src/services/analytics/datadog.ts
+++ b/tui/src/services/analytics/datadog.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export async function shutdownDatadog(): Promise<void> {
+  /* no-op */
+}

--- a/tui/src/services/analytics/firstPartyEventLogger.ts
+++ b/tui/src/services/analytics/firstPartyEventLogger.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function logEventTo1P(_name: string, _attrs?: unknown): void {
+  /* no-op */
+}
+
+export async function shutdown1PEventLogging(): Promise<void> {
+  /* no-op */
+}
+
+export function initialize1PEventLogging(): void {
+  /* no-op */
+}

--- a/tui/src/services/analytics/growthbook.ts
+++ b/tui/src/services/analytics/growthbook.ts
@@ -43,6 +43,58 @@ export async function checkGate(_gateName: string): Promise<boolean> {
 // Lifecycle — no-ops.
 // ---------------------------------------------------------------------------
 
+export function checkSecurityRestrictionGate(_name: string): boolean {
+  return false
+}
+
+export function checkStatsigFeatureGate_CACHED_MAY_BE_STALE(
+  _name: string,
+): boolean {
+  return false
+}
+
+export function getFeatureValue_CACHED_WITH_REFRESH<T>(
+  _name: string,
+  defaultValue: T,
+): T {
+  return defaultValue
+}
+
+export function getFeatureValue_DEPRECATED<T>(
+  _name: string,
+  defaultValue: T,
+): T {
+  return defaultValue
+}
+
+export async function getDynamicConfig_BLOCKS_ON_INIT<T>(
+  _name: string,
+  defaultValue: T,
+): Promise<T> {
+  return defaultValue
+}
+
+export function getDynamicConfig_CACHED_MAY_BE_STALE<T>(
+  _name: string,
+  defaultValue: T,
+): T {
+  return defaultValue
+}
+
+export function onGrowthBookRefresh(_cb: () => void): () => void {
+  return () => {
+    /* no-op unsubscribe */
+  }
+}
+
+export function hasGrowthBookEnvOverride(_name: string): boolean {
+  return false
+}
+
+export async function refreshGrowthBookAfterAuthChange(): Promise<void> {
+  /* no-op */
+}
+
 export async function initializeGrowthBook(): Promise<void> {
   // Intentional no-op.
 }
@@ -54,8 +106,17 @@ export function resetGrowthBook(): void {
 export default {
   getFeatureValue,
   getFeatureValue_CACHED_MAY_BE_STALE,
+  getFeatureValue_CACHED_WITH_REFRESH,
+  getFeatureValue_DEPRECATED,
+  getDynamicConfig_BLOCKS_ON_INIT,
+  getDynamicConfig_CACHED_MAY_BE_STALE,
   checkGate,
   checkGate_CACHED_OR_BLOCKING,
+  checkSecurityRestrictionGate,
+  checkStatsigFeatureGate_CACHED_MAY_BE_STALE,
+  onGrowthBookRefresh,
+  hasGrowthBookEnvOverride,
+  refreshGrowthBookAfterAuthChange,
   initializeGrowthBook,
   resetGrowthBook,
 }

--- a/tui/src/services/analytics/metadata.ts
+++ b/tui/src/services/analytics/metadata.ts
@@ -1,0 +1,45 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Analytics metadata helpers — all return empty payloads or `false` flags so
+// the downstream logEvent stubs receive nothing from the TUI layer.
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type AnalyticsMetadata_I_VERIFIED_THIS_IS_NOT_CODE_OR_FILEPATHS = any
+
+export function extractMcpToolDetails(_toolName: string): null {
+  return null
+}
+
+export function extractSkillName(_toolName: string): string | null {
+  return null
+}
+
+export function extractToolInputForTelemetry(
+  _toolName: string,
+  _input: unknown,
+): Record<string, never> {
+  return {}
+}
+
+export function getFileExtensionForAnalytics(_path: string): string {
+  return ''
+}
+
+export function getFileExtensionsFromBashCommand(_command: string): string[] {
+  return []
+}
+
+export function isToolDetailsLoggingEnabled(): boolean {
+  return false
+}
+
+export function mcpToolDetailsForAnalytics(
+  _toolName: string,
+): Record<string, never> {
+  return {}
+}
+
+export function sanitizeToolNameForAnalytics(toolName: string): string {
+  return toolName
+}

--- a/tui/src/services/analytics/sink.ts
+++ b/tui/src/services/analytics/sink.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function initializeAnalyticsSink(): void {
+  /* no-op */
+}

--- a/tui/src/services/api/adminRequests.ts
+++ b/tui/src/services/api/adminRequests.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export async function checkAdminRequestEligibility(): Promise<boolean> {
+  return false
+}
+
+export async function createAdminRequest(): Promise<null> {
+  return null
+}
+
+export async function getMyAdminRequests(): Promise<readonly never[]> {
+  return []
+}

--- a/tui/src/services/api/claude.ts
+++ b/tui/src/services/api/claude.ts
@@ -1,12 +1,23 @@
 // SPDX-License-Identifier: Apache-2.0
-// KOSMOS-original — Epic #1633 stub restoration.
+// KOSMOS-original — Epic #1633 FR-007 / FR-017 IPC rewire.
 //
-// The real Anthropic-backed `services/api/claude` module was deleted by Epic
-// #1633 in favour of `ipc/llmClient.ts` (FriendliAI-via-IPC). Several legacy
-// callers still import helper symbols from here. The stubs either delegate to
-// the IPC path (via `llmClient.ts` when invoked) or return empty payloads.
+// The legacy CC `services/api/claude` surface is preserved for `query.ts` /
+// compact / WebSearch call-sites, but its runtime now routes through Spec 032
+// stdio IPC to the Python backend (`uv run kosmos --ipc stdio`) rather than
+// calling FriendliAI HTTPS directly. The Python backend wraps
+// `kosmos.llm.client::LLMClient` and emits `AssistantChunkFrame` deltas that
+// `ipc/llmClient.ts::stream()` translates back into Anthropic-shaped stream
+// events. Here we collapse those events into the `{type:'assistant', message:
+// {...}}` envelope `query.ts::queryLoop` consumes.
 
 import type { KosmosUsage } from '../../ipc/llmTypes.js'
+import { LLMClient } from '../../ipc/llmClient.js'
+import {
+  getOrCreateKosmosBridge,
+  getKosmosBridgeSessionId,
+} from '../../ipc/bridgeSingleton.js'
+
+const KOSMOS_MODEL = 'LGAI-EXAONE/K-EXAONE-236B-A23B'
 
 export function getAPIMetadata(): Record<string, string> {
   return {}
@@ -20,7 +31,6 @@ const EMPTY_USAGE: KosmosUsage = {
   input_tokens: 0,
   output_tokens: 0,
   cache_read_input_tokens: 0,
-  cache_creation_input_tokens: 0,
 }
 
 export function accumulateUsage(
@@ -34,124 +44,107 @@ export function updateUsage(_usage: KosmosUsage | undefined): KosmosUsage {
   return EMPTY_USAGE
 }
 
-// Interim KOSMOS-original bridge — pending the full Epic #1633 rewire that
-// wires `query/deps.ts::callModel` directly to `ipc/llmClient.ts::stream()`.
-// For now, we short-circuit from this legacy CC entrypoint straight to
-// FriendliAI Serverless via fetch, transforming the OpenAI-compatible
-// response into the `{type:'assistant', message:{...}}` envelope that
-// `query.ts::queryLoop` expects. This violates contract G1 (no direct
-// HTTPS) but keeps the TUI demonstrably functional while the IPC path is
-// plumbed through the Python backend.
+// ---------------------------------------------------------------------------
+// Message normalization helpers — CC's internal shape → KosmosMessageParam.
+// ---------------------------------------------------------------------------
 
-const FRIENDLI_BASE_URL =
-  process.env.FRIENDLI_BASE_URL ?? 'https://api.friendli.ai/serverless'
+type NormalizedMessage = { role: 'user' | 'assistant'; content: string }
 
-function kosmosFriendliRequestBody(
-  messages: ReadonlyArray<{ role: string; content: unknown }>,
-  systemPrompt: unknown,
-  model: string,
-  maxTokens: number,
-): Record<string, unknown> {
-  const normalizedMessages: Array<{ role: string; content: string }> = []
-  // System prompt — CC sometimes passes array-of-TextBlock; coerce to string.
-  const sys = Array.isArray(systemPrompt)
-    ? systemPrompt
-        .map((b) =>
-          typeof b === 'string'
-            ? b
-            : typeof (b as { text?: unknown })?.text === 'string'
-              ? (b as { text: string }).text
-              : '',
-        )
-        .filter(Boolean)
-        .join('\n\n')
-    : typeof systemPrompt === 'string'
-      ? systemPrompt
-      : ''
-  if (sys) normalizedMessages.push({ role: 'system', content: sys })
-  for (const m of messages) {
-    // CC's internal Message shape: { type: 'user'|'assistant', message: { role, content } }.
-    // query.ts passes those directly, so we need to unwrap one level.
-    const mAny = m as {
-      role?: string
-      content?: unknown
-      type?: string
-      message?: { role?: string; content?: unknown }
+function _normalizeOneMessage(m: unknown): NormalizedMessage | null {
+  const mAny = m as {
+    role?: string
+    content?: unknown
+    type?: string
+    message?: { role?: string; content?: unknown }
+  }
+  const roleRaw =
+    mAny.role ??
+    mAny.message?.role ??
+    (mAny.type === 'assistant' ? 'assistant' : 'user')
+  const role: 'user' | 'assistant' =
+    roleRaw === 'assistant' ? 'assistant' : 'user'
+
+  const rawContent = mAny.content ?? mAny.message?.content
+  let content = ''
+  if (typeof rawContent === 'string') {
+    content = rawContent
+  } else if (Array.isArray(rawContent)) {
+    const parts: string[] = []
+    for (const block of rawContent) {
+      if (typeof block === 'string') {
+        parts.push(block)
+        continue
+      }
+      const b = block as { type?: string; text?: string; content?: unknown }
+      if (b?.type === 'text' && typeof b.text === 'string') {
+        parts.push(b.text)
+      } else if (
+        b?.type === 'tool_result' &&
+        typeof b.content === 'string'
+      ) {
+        parts.push(b.content)
+      }
     }
-    const role =
-      mAny.role ??
-      mAny.message?.role ??
-      (mAny.type === 'assistant' ? 'assistant' : 'user')
-    const rawContent = mAny.content ?? mAny.message?.content
-    const content =
-      typeof rawContent === 'string'
-        ? rawContent
-        : Array.isArray(rawContent)
-          ? rawContent
-              .map((block) => {
-                if (typeof block === 'string') return block
-                const b = block as {
-                  type?: string
-                  text?: string
-                  content?: unknown
-                }
-                if (b?.type === 'text' && typeof b.text === 'string') {
-                  return b.text
-                }
-                if (
-                  b?.type === 'tool_result' &&
-                  typeof b.content === 'string'
-                ) {
-                  return b.content
-                }
-                return ''
-              })
-              .filter(Boolean)
-              .join('\n')
-          : ''
-    if (!content) continue
-    normalizedMessages.push({ role, content })
+    content = parts.filter(Boolean).join('\n')
   }
-  // FriendliAI requires at least one user message — synthesize one if the
-  // entire batch collapsed to system + assistant-only (e.g. tool-only turns).
-  if (
-    !normalizedMessages.some((m) => m.role === 'user') &&
-    normalizedMessages.length > 0
-  ) {
-    normalizedMessages.push({ role: 'user', content: 'Continue.' })
-  }
-  // KOSMOS is a single-model system — always target K-EXAONE regardless of
-  // what upstream passes (CC defaults still leak "claude-opus-*" strings
-  // through commander parse).
-  const KOSMOS_MODEL = 'LGAI-EXAONE/K-EXAONE-236B-A23B'
-  void model
-  return {
-    model: KOSMOS_MODEL,
-    messages: normalizedMessages,
-    max_tokens: Math.min(maxTokens, 32_768),
-    stream: false,
-  }
+  if (!content) return null
+  return { role, content }
 }
 
+function _coerceSystemPrompt(systemPrompt: unknown): string | undefined {
+  if (Array.isArray(systemPrompt)) {
+    const parts = systemPrompt
+      .map((b) =>
+        typeof b === 'string'
+          ? b
+          : typeof (b as { text?: unknown })?.text === 'string'
+            ? (b as { text: string }).text
+            : '',
+      )
+      .filter(Boolean)
+    return parts.length > 0 ? parts.join('\n\n') : undefined
+  }
+  return typeof systemPrompt === 'string' && systemPrompt.length > 0
+    ? systemPrompt
+    : undefined
+}
+
+// ---------------------------------------------------------------------------
+// Main entry point — IPC-routed LLM turn.
+// ---------------------------------------------------------------------------
+
 export async function* queryModelWithStreaming(params: {
-  messages: ReadonlyArray<{ role: string; content: unknown }>
+  messages: ReadonlyArray<unknown>
   systemPrompt?: unknown
-  options: { model: string; maxOutputTokensOverride?: number }
+  options: { model?: string; maxOutputTokensOverride?: number }
   signal?: AbortSignal
 }): AsyncGenerator<unknown, void, unknown> {
-  const apiKey = process.env.FRIENDLI_API_KEY
-  if (!apiKey) {
+  const kosmosMessages: NormalizedMessage[] = []
+  for (const m of params.messages) {
+    const norm = _normalizeOneMessage(m)
+    if (norm) kosmosMessages.push(norm)
+  }
+  if (!kosmosMessages.some((m) => m.role === 'user')) {
+    kosmosMessages.push({ role: 'user', content: 'Continue.' })
+  }
+
+  const system = _coerceSystemPrompt(params.systemPrompt)
+
+  let bridge
+  try {
+    bridge = getOrCreateKosmosBridge()
+  } catch (err) {
     yield {
       type: 'assistant',
       uuid: crypto.randomUUID(),
       message: {
         id: `msg_err_${Date.now().toString(36)}`,
         role: 'assistant',
-        model: params.options.model,
+        model: KOSMOS_MODEL,
         content: [
           {
             type: 'text',
-            text: 'KOSMOS error: FRIENDLI_API_KEY is not set. Export it and restart the TUI.',
+            text: `KOSMOS bridge error: ${(err as Error).message}`,
           },
         ],
         stop_reason: 'end_turn',
@@ -161,86 +154,44 @@ export async function* queryModelWithStreaming(params: {
     return
   }
 
-  const body = kosmosFriendliRequestBody(
-    params.messages,
-    params.systemPrompt,
-    params.options.model,
-    params.options.maxOutputTokensOverride ?? 4_096,
-  )
+  const client = new LLMClient({
+    bridge,
+    model: KOSMOS_MODEL,
+    sessionId: getKosmosBridgeSessionId(),
+  })
+
+  const accumulated: string[] = []
+  let messageId: string | null = null
+  let usage: KosmosUsage = { input_tokens: 0, output_tokens: 0 }
+  let stopReason: 'end_turn' | 'max_tokens' | 'tool_use' | 'stop_sequence' =
+    'end_turn'
 
   try {
-    const url = `${FRIENDLI_BASE_URL}/v1/chat/completions`
-    if (process.env.KOSMOS_DEBUG_LLM === '1') {
-      const b = JSON.stringify(body)
-      process.stderr.write(
-        `[KOSMOS/LLM] POST ${url} body_len=${b.length} head=${b.slice(0, 200)} tail=${b.slice(-300)}\n`,
-      )
-    }
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify(body),
-      signal: params.signal,
+    const stream = client.stream({
+      model: KOSMOS_MODEL,
+      messages: kosmosMessages,
+      max_tokens: Math.min(
+        params.options.maxOutputTokensOverride ?? 2_048,
+        32_768,
+      ),
+      system,
     })
 
-    if (!response.ok) {
-      const errText = await response.text().catch(() => '<no body>')
-      yield {
-        type: 'assistant',
-        uuid: crypto.randomUUID(),
-        message: {
-          id: `msg_err_${Date.now().toString(36)}`,
-          role: 'assistant',
-          model: params.options.model,
-          content: [
-            {
-              type: 'text',
-              text: `KOSMOS API error ${response.status}: ${errText.slice(0, 500)}`,
-            },
-          ],
-          stop_reason: 'end_turn',
-          usage: { input_tokens: 0, output_tokens: 0 },
-        },
+    // Drain the stream for side-effect token streaming (the bridge forwards
+    // AssistantChunkFrames to the UI directly for rendering). queryLoop only
+    // needs the final aggregated assistant message.
+    for await (const evt of stream) {
+      if (evt.type === 'message_start') {
+        messageId = evt.message.id
+      } else if (evt.type === 'content_block_delta') {
+        if (evt.delta.type === 'text_delta') {
+          accumulated.push(evt.delta.text)
+        }
+      } else if (evt.type === 'message_delta') {
+        if (evt.delta.stop_reason) stopReason = evt.delta.stop_reason
+        if (evt.usage) usage = evt.usage
       }
-      return
-    }
-
-    const data = (await response.json()) as {
-      id?: string
-      model?: string
-      choices?: Array<{
-        message?: { content?: string | null }
-        finish_reason?: string
-      }>
-      usage?: {
-        prompt_tokens?: number
-        completion_tokens?: number
-        prompt_tokens_details?: { cached_tokens?: number }
-      }
-    }
-
-    const choice = data.choices?.[0]
-    const content = choice?.message?.content ?? ''
-    yield {
-      type: 'assistant',
-      uuid: crypto.randomUUID(),
-      message: {
-        id: data.id ?? `msg_${Date.now().toString(36)}`,
-        role: 'assistant',
-        model: data.model ?? params.options.model,
-        content: [{ type: 'text', text: content }],
-        stop_reason:
-          choice?.finish_reason === 'length' ? 'max_tokens' : 'end_turn',
-        usage: {
-          input_tokens: data.usage?.prompt_tokens ?? 0,
-          output_tokens: data.usage?.completion_tokens ?? 0,
-          cache_read_input_tokens:
-            data.usage?.prompt_tokens_details?.cached_tokens ?? 0,
-        },
-      },
+      if (params.signal?.aborted) break
     }
   } catch (err) {
     if ((err as Error).name === 'AbortError') return
@@ -250,22 +201,37 @@ export async function* queryModelWithStreaming(params: {
       message: {
         id: `msg_err_${Date.now().toString(36)}`,
         role: 'assistant',
-        model: params.options.model,
+        model: KOSMOS_MODEL,
         content: [
           {
             type: 'text',
-            text: `KOSMOS network error: ${(err as Error).message}`,
+            text: `KOSMOS LLM error: ${(err as Error).message}`,
           },
         ],
         stop_reason: 'end_turn',
         usage: { input_tokens: 0, output_tokens: 0 },
       },
     }
+    return
+  }
+
+  const text = accumulated.join('')
+  yield {
+    type: 'assistant',
+    uuid: crypto.randomUUID(),
+    message: {
+      id: messageId ?? `msg_${Date.now().toString(36)}`,
+      role: 'assistant',
+      model: KOSMOS_MODEL,
+      content: [{ type: 'text', text }],
+      stop_reason: stopReason,
+      usage,
+    },
   }
 }
 
 export async function* queryHaiku(params: {
-  messages: ReadonlyArray<{ role: string; content: unknown }>
+  messages: ReadonlyArray<unknown>
   systemPrompt?: unknown
   options?: { model?: string; maxOutputTokensOverride?: number }
   signal?: AbortSignal
@@ -274,7 +240,7 @@ export async function* queryHaiku(params: {
     messages: params.messages,
     systemPrompt: params.systemPrompt,
     options: {
-      model: params.options?.model ?? 'LGAI-EXAONE/K-EXAONE-236B-A23B',
+      model: params.options?.model ?? KOSMOS_MODEL,
       maxOutputTokensOverride: params.options?.maxOutputTokensOverride,
     },
     signal: params.signal,
@@ -282,18 +248,18 @@ export async function* queryHaiku(params: {
 }
 
 export async function* queryModelWithoutStreaming(params: {
-  messages: ReadonlyArray<{ role: string; content: unknown }>
+  messages: ReadonlyArray<unknown>
   systemPrompt?: unknown
-  options: { model: string; maxOutputTokensOverride?: number }
+  options: { model?: string; maxOutputTokensOverride?: number }
   signal?: AbortSignal
 }): AsyncGenerator<unknown, void, unknown> {
   yield* queryModelWithStreaming(params)
 }
 
 export async function* queryWithModel(params: {
-  messages: ReadonlyArray<{ role: string; content: unknown }>
+  messages: ReadonlyArray<unknown>
   systemPrompt?: unknown
-  options: { model: string; maxOutputTokensOverride?: number }
+  options: { model?: string; maxOutputTokensOverride?: number }
   signal?: AbortSignal
 }): AsyncGenerator<unknown, void, unknown> {
   yield* queryModelWithStreaming(params)
@@ -304,8 +270,6 @@ export async function verifyApiKey(): Promise<boolean> {
 }
 
 export function getMaxOutputTokensForModel(_model: string): number {
-  // K-EXAONE-236B supports up to 32k output tokens on FriendliAI Serverless.
-  // Callers use this to bound `max_tokens` in outbound requests.
   return 32_768
 }
 

--- a/tui/src/services/api/claude.ts
+++ b/tui/src/services/api/claude.ts
@@ -1,0 +1,74 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// The real Anthropic-backed `services/api/claude` module was deleted by Epic
+// #1633 in favour of `ipc/llmClient.ts` (FriendliAI-via-IPC). Several legacy
+// callers still import helper symbols from here. The stubs either delegate to
+// the IPC path (via `llmClient.ts` when invoked) or return empty payloads.
+
+import type { KosmosUsage } from '../../ipc/llmTypes.js'
+
+export function getAPIMetadata(): Record<string, string> {
+  return {}
+}
+
+export function getCacheControl(): null {
+  return null
+}
+
+const EMPTY_USAGE: KosmosUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+}
+
+export function accumulateUsage(
+  _a: KosmosUsage | undefined,
+  _b: KosmosUsage | undefined,
+): KosmosUsage {
+  return EMPTY_USAGE
+}
+
+export function updateUsage(_usage: KosmosUsage | undefined): KosmosUsage {
+  return EMPTY_USAGE
+}
+
+// Query helpers: the real LLM round-trip lives in `ipc/llmClient.ts`.
+// Consumers that still import these helpers receive a fail-closed error so
+// the UI surfaces the stub rather than silently hanging.
+function stubThrow(name: string): never {
+  throw new Error(
+    `KOSMOS: services/api/claude.${name} is a stub — use ipc/llmClient directly`,
+  )
+}
+
+export async function queryHaiku(): Promise<never> {
+  return stubThrow('queryHaiku')
+}
+
+export async function queryModelWithStreaming(): Promise<never> {
+  return stubThrow('queryModelWithStreaming')
+}
+
+export async function queryModelWithoutStreaming(): Promise<never> {
+  return stubThrow('queryModelWithoutStreaming')
+}
+
+export async function queryWithModel(): Promise<never> {
+  return stubThrow('queryWithModel')
+}
+
+export async function verifyApiKey(): Promise<boolean> {
+  return Boolean(process.env.FRIENDLI_API_KEY)
+}
+
+export function getMaxOutputTokensForModel(_model: string): number {
+  // K-EXAONE-236B supports up to 32k output tokens on FriendliAI Serverless.
+  // Callers use this to bound `max_tokens` in outbound requests.
+  return 32_768
+}
+
+export function getExtraBodyParams(): Record<string, never> {
+  return {}
+}

--- a/tui/src/services/api/claude.ts
+++ b/tui/src/services/api/claude.ts
@@ -34,29 +34,269 @@ export function updateUsage(_usage: KosmosUsage | undefined): KosmosUsage {
   return EMPTY_USAGE
 }
 
-// Query helpers: the real LLM round-trip lives in `ipc/llmClient.ts`.
-// Consumers that still import these helpers receive a fail-closed error so
-// the UI surfaces the stub rather than silently hanging.
-function stubThrow(name: string): never {
-  throw new Error(
-    `KOSMOS: services/api/claude.${name} is a stub — use ipc/llmClient directly`,
+// Interim KOSMOS-original bridge — pending the full Epic #1633 rewire that
+// wires `query/deps.ts::callModel` directly to `ipc/llmClient.ts::stream()`.
+// For now, we short-circuit from this legacy CC entrypoint straight to
+// FriendliAI Serverless via fetch, transforming the OpenAI-compatible
+// response into the `{type:'assistant', message:{...}}` envelope that
+// `query.ts::queryLoop` expects. This violates contract G1 (no direct
+// HTTPS) but keeps the TUI demonstrably functional while the IPC path is
+// plumbed through the Python backend.
+
+const FRIENDLI_BASE_URL =
+  process.env.FRIENDLI_BASE_URL ?? 'https://api.friendli.ai/serverless'
+
+function kosmosFriendliRequestBody(
+  messages: ReadonlyArray<{ role: string; content: unknown }>,
+  systemPrompt: unknown,
+  model: string,
+  maxTokens: number,
+): Record<string, unknown> {
+  const normalizedMessages: Array<{ role: string; content: string }> = []
+  // System prompt — CC sometimes passes array-of-TextBlock; coerce to string.
+  const sys = Array.isArray(systemPrompt)
+    ? systemPrompt
+        .map((b) =>
+          typeof b === 'string'
+            ? b
+            : typeof (b as { text?: unknown })?.text === 'string'
+              ? (b as { text: string }).text
+              : '',
+        )
+        .filter(Boolean)
+        .join('\n\n')
+    : typeof systemPrompt === 'string'
+      ? systemPrompt
+      : ''
+  if (sys) normalizedMessages.push({ role: 'system', content: sys })
+  for (const m of messages) {
+    // CC's internal Message shape: { type: 'user'|'assistant', message: { role, content } }.
+    // query.ts passes those directly, so we need to unwrap one level.
+    const mAny = m as {
+      role?: string
+      content?: unknown
+      type?: string
+      message?: { role?: string; content?: unknown }
+    }
+    const role =
+      mAny.role ??
+      mAny.message?.role ??
+      (mAny.type === 'assistant' ? 'assistant' : 'user')
+    const rawContent = mAny.content ?? mAny.message?.content
+    const content =
+      typeof rawContent === 'string'
+        ? rawContent
+        : Array.isArray(rawContent)
+          ? rawContent
+              .map((block) => {
+                if (typeof block === 'string') return block
+                const b = block as {
+                  type?: string
+                  text?: string
+                  content?: unknown
+                }
+                if (b?.type === 'text' && typeof b.text === 'string') {
+                  return b.text
+                }
+                if (
+                  b?.type === 'tool_result' &&
+                  typeof b.content === 'string'
+                ) {
+                  return b.content
+                }
+                return ''
+              })
+              .filter(Boolean)
+              .join('\n')
+          : ''
+    if (!content) continue
+    normalizedMessages.push({ role, content })
+  }
+  // FriendliAI requires at least one user message — synthesize one if the
+  // entire batch collapsed to system + assistant-only (e.g. tool-only turns).
+  if (
+    !normalizedMessages.some((m) => m.role === 'user') &&
+    normalizedMessages.length > 0
+  ) {
+    normalizedMessages.push({ role: 'user', content: 'Continue.' })
+  }
+  // KOSMOS is a single-model system — always target K-EXAONE regardless of
+  // what upstream passes (CC defaults still leak "claude-opus-*" strings
+  // through commander parse).
+  const KOSMOS_MODEL = 'LGAI-EXAONE/K-EXAONE-236B-A23B'
+  void model
+  return {
+    model: KOSMOS_MODEL,
+    messages: normalizedMessages,
+    max_tokens: Math.min(maxTokens, 32_768),
+    stream: false,
+  }
+}
+
+export async function* queryModelWithStreaming(params: {
+  messages: ReadonlyArray<{ role: string; content: unknown }>
+  systemPrompt?: unknown
+  options: { model: string; maxOutputTokensOverride?: number }
+  signal?: AbortSignal
+}): AsyncGenerator<unknown, void, unknown> {
+  const apiKey = process.env.FRIENDLI_API_KEY
+  if (!apiKey) {
+    yield {
+      type: 'assistant',
+      uuid: crypto.randomUUID(),
+      message: {
+        id: `msg_err_${Date.now().toString(36)}`,
+        role: 'assistant',
+        model: params.options.model,
+        content: [
+          {
+            type: 'text',
+            text: 'KOSMOS error: FRIENDLI_API_KEY is not set. Export it and restart the TUI.',
+          },
+        ],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    }
+    return
+  }
+
+  const body = kosmosFriendliRequestBody(
+    params.messages,
+    params.systemPrompt,
+    params.options.model,
+    params.options.maxOutputTokensOverride ?? 4_096,
   )
+
+  try {
+    const url = `${FRIENDLI_BASE_URL}/v1/chat/completions`
+    if (process.env.KOSMOS_DEBUG_LLM === '1') {
+      const b = JSON.stringify(body)
+      process.stderr.write(
+        `[KOSMOS/LLM] POST ${url} body_len=${b.length} head=${b.slice(0, 200)} tail=${b.slice(-300)}\n`,
+      )
+    }
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+      signal: params.signal,
+    })
+
+    if (!response.ok) {
+      const errText = await response.text().catch(() => '<no body>')
+      yield {
+        type: 'assistant',
+        uuid: crypto.randomUUID(),
+        message: {
+          id: `msg_err_${Date.now().toString(36)}`,
+          role: 'assistant',
+          model: params.options.model,
+          content: [
+            {
+              type: 'text',
+              text: `KOSMOS API error ${response.status}: ${errText.slice(0, 500)}`,
+            },
+          ],
+          stop_reason: 'end_turn',
+          usage: { input_tokens: 0, output_tokens: 0 },
+        },
+      }
+      return
+    }
+
+    const data = (await response.json()) as {
+      id?: string
+      model?: string
+      choices?: Array<{
+        message?: { content?: string | null }
+        finish_reason?: string
+      }>
+      usage?: {
+        prompt_tokens?: number
+        completion_tokens?: number
+        prompt_tokens_details?: { cached_tokens?: number }
+      }
+    }
+
+    const choice = data.choices?.[0]
+    const content = choice?.message?.content ?? ''
+    yield {
+      type: 'assistant',
+      uuid: crypto.randomUUID(),
+      message: {
+        id: data.id ?? `msg_${Date.now().toString(36)}`,
+        role: 'assistant',
+        model: data.model ?? params.options.model,
+        content: [{ type: 'text', text: content }],
+        stop_reason:
+          choice?.finish_reason === 'length' ? 'max_tokens' : 'end_turn',
+        usage: {
+          input_tokens: data.usage?.prompt_tokens ?? 0,
+          output_tokens: data.usage?.completion_tokens ?? 0,
+          cache_read_input_tokens:
+            data.usage?.prompt_tokens_details?.cached_tokens ?? 0,
+        },
+      },
+    }
+  } catch (err) {
+    if ((err as Error).name === 'AbortError') return
+    yield {
+      type: 'assistant',
+      uuid: crypto.randomUUID(),
+      message: {
+        id: `msg_err_${Date.now().toString(36)}`,
+        role: 'assistant',
+        model: params.options.model,
+        content: [
+          {
+            type: 'text',
+            text: `KOSMOS network error: ${(err as Error).message}`,
+          },
+        ],
+        stop_reason: 'end_turn',
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    }
+  }
 }
 
-export async function queryHaiku(): Promise<never> {
-  return stubThrow('queryHaiku')
+export async function* queryHaiku(params: {
+  messages: ReadonlyArray<{ role: string; content: unknown }>
+  systemPrompt?: unknown
+  options?: { model?: string; maxOutputTokensOverride?: number }
+  signal?: AbortSignal
+}): AsyncGenerator<unknown, void, unknown> {
+  yield* queryModelWithStreaming({
+    messages: params.messages,
+    systemPrompt: params.systemPrompt,
+    options: {
+      model: params.options?.model ?? 'LGAI-EXAONE/K-EXAONE-236B-A23B',
+      maxOutputTokensOverride: params.options?.maxOutputTokensOverride,
+    },
+    signal: params.signal,
+  })
 }
 
-export async function queryModelWithStreaming(): Promise<never> {
-  return stubThrow('queryModelWithStreaming')
+export async function* queryModelWithoutStreaming(params: {
+  messages: ReadonlyArray<{ role: string; content: unknown }>
+  systemPrompt?: unknown
+  options: { model: string; maxOutputTokensOverride?: number }
+  signal?: AbortSignal
+}): AsyncGenerator<unknown, void, unknown> {
+  yield* queryModelWithStreaming(params)
 }
 
-export async function queryModelWithoutStreaming(): Promise<never> {
-  return stubThrow('queryModelWithoutStreaming')
-}
-
-export async function queryWithModel(): Promise<never> {
-  return stubThrow('queryWithModel')
+export async function* queryWithModel(params: {
+  messages: ReadonlyArray<{ role: string; content: unknown }>
+  systemPrompt?: unknown
+  options: { model: string; maxOutputTokensOverride?: number }
+  signal?: AbortSignal
+}): AsyncGenerator<unknown, void, unknown> {
+  yield* queryModelWithStreaming(params)
 }
 
 export async function verifyApiKey(): Promise<boolean> {

--- a/tui/src/services/api/client.ts
+++ b/tui/src/services/api/client.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// The Anthropic SDK client factory is replaced by `ipc/llmClient.ts` in
+// KOSMOS. Legacy callers that still import `getAnthropicClient` receive a
+// proxy that fail-closes on any method access, surfacing the misuse.
+
+function stubThrow(name: string): never {
+  throw new Error(
+    `KOSMOS: services/api/client.${name} removed — use ipc/llmClient instead`,
+  )
+}
+
+export async function getAnthropicClient(
+  _opts?: unknown,
+): Promise<Record<string, never>> {
+  return new Proxy(
+    {},
+    {
+      get(_t, prop) {
+        stubThrow(String(prop))
+      },
+    },
+  )
+}

--- a/tui/src/services/api/grove.ts
+++ b/tui/src/services/api/grove.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export async function checkGroveForNonInteractive(): Promise<boolean> {
+  return false
+}
+
+export function getGroveNoticeConfig(): null {
+  return null
+}
+
+export function getGroveSettings(): Record<string, never> {
+  return {}
+}
+
+export function isQualifiedForGrove(): boolean {
+  return false
+}

--- a/tui/src/services/api/overageCreditGrant.ts
+++ b/tui/src/services/api/overageCreditGrant.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function formatGrantAmount(_cents: number): string {
+  return '$0.00'
+}
+
+export function getCachedOverageCreditGrant(): null {
+  return null
+}
+
+export function invalidateOverageCreditGrantCache(): void {
+  /* no-op */
+}
+
+export async function refreshOverageCreditGrantCache(): Promise<void> {
+  /* no-op */
+}

--- a/tui/src/services/api/referral.ts
+++ b/tui/src/services/api/referral.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function checkCachedPassesEligibility(): boolean {
+  return false
+}
+
+export async function fetchReferralRedemptions(): Promise<readonly never[]> {
+  return []
+}
+
+export function formatCreditAmount(_cents: number): string {
+  return '$0.00'
+}
+
+export async function getCachedOrFetchPassesEligibility(): Promise<boolean> {
+  return false
+}
+
+export function getCachedReferrerReward(): null {
+  return null
+}
+
+export function getCachedRemainingPasses(): number {
+  return 0
+}

--- a/tui/src/services/api/usage.ts
+++ b/tui/src/services/api/usage.ts
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export interface RateLimit {
+  readonly remaining: number
+  readonly limit: number
+  readonly resetAt: number
+}
+
+export interface ExtraUsage {
+  readonly [key: string]: unknown
+}
+
+export interface Utilization {
+  readonly rateLimits: readonly RateLimit[]
+  readonly extra: ExtraUsage
+}
+
+const EMPTY_UTILIZATION: Utilization = {
+  rateLimits: [],
+  extra: {},
+}
+
+export async function fetchUtilization(): Promise<Utilization> {
+  return EMPTY_UTILIZATION
+}

--- a/tui/src/services/claudeAiLimits.ts
+++ b/tui/src/services/claudeAiLimits.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export interface ClaudeAILimits {
+  readonly remaining: number
+  readonly limit: number
+  readonly resetAt: number
+}
+
+export type OverageDisabledReason = 'quota' | 'policy' | 'none'
+
+const EMPTY_LIMITS: ClaudeAILimits = {
+  remaining: Number.POSITIVE_INFINITY,
+  limit: Number.POSITIVE_INFINITY,
+  resetAt: 0,
+}
+
+export const currentLimits: ClaudeAILimits = EMPTY_LIMITS
+// Callers expect a Set — use `add`/`delete` interfaces. KOSMOS never fires
+// listeners since FriendliAI has no claude.ai-style subscription rate limit.
+export const statusListeners: Set<(l: ClaudeAILimits) => void> = new Set()
+
+export function getRateLimitWarning(): string | null {
+  return null
+}
+
+export function getRawUtilization(): ClaudeAILimits {
+  return EMPTY_LIMITS
+}
+
+export function getUsingOverageText(): string {
+  return ''
+}

--- a/tui/src/services/claudeAiLimitsHook.ts
+++ b/tui/src/services/claudeAiLimitsHook.ts
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+import type { ClaudeAILimits } from './claudeAiLimits.js'
+
+export function useClaudeAiLimits(): ClaudeAILimits {
+  return {
+    remaining: Number.POSITIVE_INFINITY,
+    limit: Number.POSITIVE_INFINITY,
+    resetAt: 0,
+  }
+}

--- a/tui/src/services/internalLogging.ts
+++ b/tui/src/services/internalLogging.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function logPermissionContextForAnts(_ctx: unknown): void {
+  /* no-op — KOSMOS has no internal-ant logging path */
+}

--- a/tui/src/services/mcp/claudeai.ts
+++ b/tui/src/services/mcp/claudeai.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// The upstream Claude Code claude.ai MCP proxy integration has no counterpart
+// in KOSMOS: we neither authenticate against claude.ai nor proxy its MCP
+// connectors (Datadog, Slack, Gmail, BigQuery, PubMed, etc.). Epic #1633 P2
+// deleted the real implementation, but multiple callers (main.tsx, mcp/config,
+// useManageMCPConnections, useMcpConnectivityStatus) still import from this
+// path. Restoring a no-op stub keeps the 298-file import surface intact
+// without reintroducing Anthropic-specific runtime behaviour.
+
+import type { ScopedMcpServerConfig } from './types.js'
+
+export async function fetchClaudeAIMcpConfigsIfEligible(): Promise<
+  Record<string, ScopedMcpServerConfig>
+> {
+  return {}
+}
+
+export function hasClaudeAiMcpEverConnected(_serverName: string): boolean {
+  return false
+}
+
+export function markClaudeAiMcpConnected(_serverName: string): void {
+  /* no-op */
+}
+
+export function clearClaudeAIMcpConfigsCache(): void {
+  /* no-op */
+}

--- a/tui/src/services/oauth/client.ts
+++ b/tui/src/services/oauth/client.ts
@@ -44,10 +44,40 @@ export async function revokeAccessToken(): Promise<void> {
   // Intentional no-op.
 }
 
+export async function createAndStoreApiKey(): Promise<null> {
+  return null
+}
+
+export async function fetchAndStoreUserRoles(): Promise<void> {
+  /* no-op */
+}
+
+export async function populateOAuthAccountInfoIfNeeded(): Promise<void> {
+  /* no-op */
+}
+
+export async function refreshOAuthToken(): Promise<null> {
+  return null
+}
+
+export function shouldUseClaudeAIAuth(): boolean {
+  return false
+}
+
+export async function storeOAuthAccountInfo(): Promise<void> {
+  /* no-op */
+}
+
 export default {
   getOrganizationUUID,
   getUserUUID,
   getAccessToken,
   refreshAccessToken,
   revokeAccessToken,
+  createAndStoreApiKey,
+  fetchAndStoreUserRoles,
+  populateOAuthAccountInfoIfNeeded,
+  refreshOAuthToken,
+  shouldUseClaudeAIAuth,
+  storeOAuthAccountInfo,
 }

--- a/tui/src/services/oauth/getOauthProfile.ts
+++ b/tui/src/services/oauth/getOauthProfile.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export async function getOauthProfileFromApiKey(): Promise<null> {
+  return null
+}
+
+export async function getOauthProfileFromOauthToken(): Promise<null> {
+  return null
+}

--- a/tui/src/services/oauth/index.ts
+++ b/tui/src/services/oauth/index.ts
@@ -2,3 +2,18 @@
 // KOSMOS-original — Epic #1633 P2 · stub-noop replacement for CC OAuth barrel.
 
 export * from './client.js'
+
+export class OAuthService {
+  async login(): Promise<null> {
+    return null
+  }
+  async logout(): Promise<void> {
+    /* no-op */
+  }
+  async refresh(): Promise<null> {
+    return null
+  }
+  isAuthenticated(): boolean {
+    return false
+  }
+}

--- a/tui/src/services/oauth/types.ts
+++ b/tui/src/services/oauth/types.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export type BillingType = 'free' | 'pro' | 'enterprise' | 'unknown'
+export type SubscriptionType = 'free' | 'pro' | 'max' | 'team' | 'enterprise'
+
+export interface OAuthTokens {
+  readonly accessToken: string
+  readonly refreshToken?: string
+}
+
+export interface ReferrerRewardInfo {
+  readonly amountCents: number
+}
+
+export interface ReferralEligibilityResponse {
+  readonly eligible: boolean
+}
+
+export interface ReferralRedemptionsResponse {
+  readonly redemptions: readonly ReferrerRewardInfo[]
+}

--- a/tui/src/services/policyLimits/index.ts
+++ b/tui/src/services/policyLimits/index.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Claude Code's Anthropic-backed policy-limits service (enterprise allow/deny
+// list fetched from console.anthropic.com) has no counterpart in KOSMOS.
+// Epic #1633 deleted the real implementation, but several consumers
+// (entrypoints/init.ts, entrypoints/cli.tsx, bridge/initReplBridge.ts,
+// commands/*, components/*) still import from this path. A no-op stub keeps
+// the import graph intact while making every policy query permissive.
+
+type _PolicyKey = string
+
+let policyLimitsPromise: Promise<void> | null = null
+
+export function initializePolicyLimitsLoadingPromise(): void {
+  if (policyLimitsPromise === null) {
+    policyLimitsPromise = Promise.resolve()
+  }
+}
+
+export async function waitForPolicyLimitsToLoad(): Promise<void> {
+  if (policyLimitsPromise === null) {
+    initializePolicyLimitsLoadingPromise()
+  }
+  await policyLimitsPromise
+}
+
+export function isPolicyAllowed(_key: _PolicyKey): boolean {
+  return true
+}
+
+export function isPolicyLimitsEligible(): boolean {
+  return false
+}

--- a/tui/src/services/remoteManagedSettings/index.ts
+++ b/tui/src/services/remoteManagedSettings/index.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Claude Code's remote-managed-settings service (enterprise settings pushed
+// from console.anthropic.com) has no counterpart in KOSMOS. Deleted by Epic
+// #1633; restored here as a no-op stub for the import graph.
+
+let promise: Promise<void> | null = null
+
+export function initializeRemoteManagedSettingsLoadingPromise(): void {
+  if (promise === null) {
+    promise = Promise.resolve()
+  }
+}
+
+export async function waitForRemoteManagedSettingsToLoad(): Promise<void> {
+  if (promise === null) {
+    initializeRemoteManagedSettingsLoadingPromise()
+  }
+  await promise
+}
+
+export function isEligibleForRemoteManagedSettings(): boolean {
+  return false
+}
+
+export async function loadRemoteManagedSettings(): Promise<void> {
+  /* no-op */
+}
+
+export async function refreshRemoteManagedSettings(): Promise<void> {
+  /* no-op */
+}

--- a/tui/src/services/remoteManagedSettings/syncCache.ts
+++ b/tui/src/services/remoteManagedSettings/syncCache.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function isRemoteManagedSettingsEligible(): boolean {
+  return false
+}

--- a/tui/src/services/remoteManagedSettings/syncCacheState.ts
+++ b/tui/src/services/remoteManagedSettings/syncCacheState.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function getRemoteManagedSettingsSyncFromCache(): null {
+  return null
+}

--- a/tui/src/utils/auth.ts
+++ b/tui/src/utils/auth.ts
@@ -1,107 +1,195 @@
 // SPDX-License-Identifier: Apache-2.0
-// KOSMOS-original — Epic #1633 P2 · stub-noop replacement for CC auth.
+// KOSMOS-original — Epic #1633 stub restoration.
 //
-// The Anthropic OAuth / Claude-ai / ant-internal subscriber surface has been
-// removed. KOSMOS authentication is API-key based and lives entirely in the
-// Python backend (KOSMOS_FRIENDLI_TOKEN / FRIENDLI_API_KEY environment
-// variable). The TUI never handles credentials directly.
-//
-// This file preserves the original export names so existing callers
-// (bridge/, tools/, interactiveHelpers, etc.) compile. Every function
-// resolves to the "unauthenticated / not-an-ant" branch at runtime, which
-// is the correct closed-state answer for a citizen-facing TUI.
+// All Anthropic OAuth / Claude.ai / ant-internal subscriber surfaces are
+// inert in KOSMOS (FriendliAI API-key auth only). Every getter returns null
+// or `false`; every clearer is a no-op.
 
-/**
- * Returns OAuth tokens for the legacy Anthropic Claude.ai subscription.
- * KOSMOS has no OAuth surface — always null.
- */
 export async function getClaudeAIOAuthTokens(): Promise<null> {
   return null
 }
 
-/**
- * True if the current user has a Claude.ai (consumer) subscription.
- * KOSMOS has no such concept — always false.
- */
 export function isClaudeAISubscriber(): boolean {
   return false
 }
 
-/**
- * True if the caller routes through a third-party (3P) LLM service
- * (in CC this included Bedrock / Vertex / Nova). KOSMOS has one provider
- * (FriendliAI) and treats it as first-party to KOSMOS, so this returns
- * false.
- */
-export function isUsing3PServices(): boolean {
+export function isConsumerSubscriber(): boolean {
   return false
 }
 
-/**
- * Clears the Anthropic `apiKeyHelper` cached credentials. KOSMOS does not
- * cache credentials in the TUI process — no-op.
- */
-export function clearApiKeyHelperCache(): void {
-  // Intentional no-op.
-}
-
-/**
- * Optionally pre-fetches an API key via the CC `apiKeyHelper` hook. KOSMOS
- * has no such hook — no-op.
- */
-export async function prefetchApiKeyFromApiKeyHelperIfSafe(): Promise<void> {
-  // Intentional no-op.
-}
-
-/**
- * Returns the account identifier associated with the active OAuth token.
- * KOSMOS has no OAuth surface — always null.
- */
-export function getOauthAccountInfo(): null {
-  return null
-}
-
-/**
- * Returns the organization UUID associated with the active OAuth token.
- * KOSMOS has no OAuth surface — always null.
- */
-export function getOauthOrgUUID(): null {
-  return null
-}
-
-/**
- * Returns true if the active OAuth token has enterprise scope. KOSMOS has
- * no OAuth surface — always false.
- */
-export function isEnterpriseSubscriber(): boolean {
-  return false
-}
-
-/**
- * Returns true if the active subscription includes "Max" tier features.
- * KOSMOS has no subscription concept — always false.
- */
 export function isMaxSubscriber(): boolean {
   return false
 }
 
-/**
- * Returns true if the active subscription includes "Team Premium" tier
- * features. KOSMOS has no subscription concept — always false.
- */
+export function isProSubscriber(): boolean {
+  return false
+}
+
+export function isTeamSubscriber(): boolean {
+  return false
+}
+
 export function isTeamPremiumSubscriber(): boolean {
   return false
 }
 
-export default {
+export function isEnterpriseSubscriber(): boolean {
+  return false
+}
+
+export function isAnthropicAuthEnabled(): boolean {
+  return false
+}
+
+export function is1PApiCustomer(): boolean {
+  return false
+}
+
+export function isUsing3PServices(): boolean {
+  return false
+}
+
+export function isOverageProvisioningAllowed(): boolean {
+  return false
+}
+
+export function hasProfileScope(): boolean {
+  return false
+}
+
+export function getAccountInformation(): null {
+  return null
+}
+
+export function getOauthAccountInfo(): null {
+  return null
+}
+
+export function getOauthOrgUUID(): null {
+  return null
+}
+
+export function getSubscriptionType(): 'free' {
+  return 'free'
+}
+
+export function getSubscriptionName(): string {
+  return ''
+}
+
+export function getAuthTokenSource(): 'none' {
+  return 'none'
+}
+
+export function getRateLimitTier(): 0 {
+  return 0
+}
+
+export function getAnthropicApiKey(): null {
+  return null
+}
+
+export function getAnthropicApiKeyWithSource(): { key: null; source: 'none' } {
+  return { key: null, source: 'none' }
+}
+
+export function getApiKeyFromApiKeyHelper(): null {
+  return null
+}
+
+export function getConfiguredApiKeyHelper(): null {
+  return null
+}
+
+export function getApiKeyHelperElapsedMs(): number {
+  return 0
+}
+
+export async function checkAndRefreshOAuthTokenIfNeeded(): Promise<void> {
+  /* no-op */
+}
+
+export async function refreshAndGetAwsCredentials(): Promise<null> {
+  return null
+}
+
+export async function prefetchAwsCredentialsAndBedRockInfoIfSafe(): Promise<void> {
+  /* no-op */
+}
+
+export async function prefetchGcpCredentialsIfSafe(): Promise<void> {
+  /* no-op */
+}
+
+export async function prefetchApiKeyFromApiKeyHelperIfSafe(): Promise<void> {
+  /* no-op */
+}
+
+export function clearApiKeyHelperCache(): void {
+  /* no-op */
+}
+
+export function clearAwsCredentialsCache(): void {
+  /* no-op */
+}
+
+export function clearGcpCredentialsCache(): void {
+  /* no-op */
+}
+
+export function clearOAuthTokenCache(): void {
+  /* no-op */
+}
+
+export async function handleOAuth401Error(): Promise<void> {
+  /* no-op */
+}
+
+export async function saveOAuthTokensIfNeeded(): Promise<void> {
+  /* no-op */
+}
+
+export async function validateForceLoginOrg(): Promise<boolean> {
+  return false
+}
+
+const _default = {
   getClaudeAIOAuthTokens,
   isClaudeAISubscriber,
+  isConsumerSubscriber,
+  isMaxSubscriber,
+  isProSubscriber,
+  isTeamSubscriber,
+  isTeamPremiumSubscriber,
+  isEnterpriseSubscriber,
+  isAnthropicAuthEnabled,
+  is1PApiCustomer,
   isUsing3PServices,
-  clearApiKeyHelperCache,
-  prefetchApiKeyFromApiKeyHelperIfSafe,
+  isOverageProvisioningAllowed,
+  hasProfileScope,
+  getAccountInformation,
   getOauthAccountInfo,
   getOauthOrgUUID,
-  isEnterpriseSubscriber,
-  isMaxSubscriber,
-  isTeamPremiumSubscriber,
+  getSubscriptionType,
+  getAuthTokenSource,
+  getRateLimitTier,
+  getAnthropicApiKey,
+  getAnthropicApiKeyWithSource,
+  getApiKeyFromApiKeyHelper,
+  getConfiguredApiKeyHelper,
+  getApiKeyHelperElapsedMs,
+  checkAndRefreshOAuthTokenIfNeeded,
+  refreshAndGetAwsCredentials,
+  prefetchAwsCredentialsAndBedRockInfoIfSafe,
+  prefetchGcpCredentialsIfSafe,
+  prefetchApiKeyFromApiKeyHelperIfSafe,
+  clearApiKeyHelperCache,
+  clearAwsCredentialsCache,
+  clearGcpCredentialsCache,
+  clearOAuthTokenCache,
+  handleOAuth401Error,
+  saveOAuthTokensIfNeeded,
+  validateForceLoginOrg,
 }
+
+export default _default

--- a/tui/src/utils/background/remote/preconditions.ts
+++ b/tui/src/utils/background/remote/preconditions.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export async function checkIsGitClean(): Promise<boolean> {
+  return true
+}
+
+export async function checkNeedsClaudeAiLogin(): Promise<boolean> {
+  return false
+}
+
+export async function checkRepoForRemoteAccess(): Promise<boolean> {
+  return false
+}

--- a/tui/src/utils/background/remote/remoteSession.ts
+++ b/tui/src/utils/background/remote/remoteSession.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export type BackgroundRemoteSessionPrecondition =
+  | 'git_dirty'
+  | 'no_auth'
+  | 'unsupported_repo'
+  | 'ok'
+
+export async function checkBackgroundRemoteSessionEligibility(): Promise<BackgroundRemoteSessionPrecondition> {
+  return 'no_auth'
+}

--- a/tui/src/utils/betas.ts
+++ b/tui/src/utils/betas.ts
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Anthropic `anthropic-beta` header manipulation has no counterpart in the
+// FriendliAI path. Callers read this module to decide which betas to surface
+// on outbound requests; KOSMOS returns empty sets + `false` flags so no
+// Anthropic-specific beta tokens ever leak into a FriendliAI call.
+
+export function getModelBetas(_model: string): string[] {
+  return []
+}
+
+export function getMergedBetas(
+  _model: string,
+  _additional?: readonly string[],
+): string[] {
+  return []
+}
+
+export function modelSupportsStructuredOutputs(_model: string): boolean {
+  return false
+}
+
+export function modelSupportsAutoMode(_model: string): boolean {
+  return false
+}
+
+export function shouldIncludeFirstPartyOnlyBetas(): boolean {
+  return false
+}
+
+export function shouldUseGlobalCacheScope(): boolean {
+  return false
+}

--- a/tui/src/utils/model/antModels.ts
+++ b/tui/src/utils/model/antModels.ts
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Anthropic model alias resolution is replaced by the K-EXAONE single
+// constant in `utils/model/model.ts::getDefaultMainLoopModel()`. Callers that
+// still reach for `resolveAntModel()` get the K-EXAONE ID back.
+
+const KOSMOS_MODEL = 'LGAI-EXAONE/K-EXAONE-236B-A23B'
+
+export function resolveAntModel(_alias: string): string {
+  return KOSMOS_MODEL
+}

--- a/tui/src/utils/modelCost.ts
+++ b/tui/src/utils/modelCost.ts
@@ -1,0 +1,49 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Claude Code's model-cost catalog priced every Anthropic model. KOSMOS only
+// invokes K-EXAONE via FriendliAI Serverless, which bills per run rather than
+// per token, so cost math collapses to zero. Callers that render cost figures
+// will show "$0.00" — acceptable for a student-portfolio build.
+
+export interface CostTier {
+  readonly inputPerMillion: number
+  readonly outputPerMillion: number
+  readonly cacheReadPerMillion: number
+  readonly cacheWritePerMillion: number
+}
+
+const ZERO_TIER: CostTier = {
+  inputPerMillion: 0,
+  outputPerMillion: 0,
+  cacheReadPerMillion: 0,
+  cacheWritePerMillion: 0,
+}
+
+export const COST_HAIKU_35: CostTier = ZERO_TIER
+export const COST_HAIKU_45: CostTier = ZERO_TIER
+export const COST_TIER_3_15: CostTier = ZERO_TIER
+
+export function getOpus46CostTier(): CostTier {
+  return ZERO_TIER
+}
+
+export function calculateCostFromTokens(
+  _inputTokens: number,
+  _outputTokens: number,
+  _model?: string,
+): number {
+  return 0
+}
+
+export function calculateUSDCost(
+  _inputTokens: number,
+  _outputTokens: number,
+  _model?: string,
+): number {
+  return 0
+}
+
+export function formatModelPricing(_model: string): string {
+  return '$0.00 / 1M input · $0.00 / 1M output'
+}

--- a/tui/src/utils/secureStorage/index.ts
+++ b/tui/src/utils/secureStorage/index.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Claude Code's macOS Keychain / Linux libsecret-backed secure storage has no
+// counterpart in KOSMOS (LLM credentials live exclusively in the
+// FRIENDLI_API_KEY environment variable). The stub exposes an in-memory
+// placeholder so callers compile; every getter returns null.
+
+import type { SecureStorageData } from './types.js'
+
+interface SecureStorageApi {
+  get(_key: string): Promise<SecureStorageData | null>
+  set(_key: string, _value: string): Promise<void>
+  delete(_key: string): Promise<void>
+}
+
+export function getSecureStorage(): SecureStorageApi {
+  return {
+    async get() {
+      return null
+    },
+    async set() {
+      /* no-op */
+    },
+    async delete() {
+      /* no-op */
+    },
+  }
+}

--- a/tui/src/utils/secureStorage/keychainPrefetch.ts
+++ b/tui/src/utils/secureStorage/keychainPrefetch.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function startKeychainPrefetch(): void {
+  /* no-op */
+}
+
+export async function ensureKeychainPrefetchCompleted(): Promise<void> {
+  /* no-op */
+}

--- a/tui/src/utils/secureStorage/macOsKeychainHelpers.ts
+++ b/tui/src/utils/secureStorage/macOsKeychainHelpers.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function clearKeychainCache(): void {
+  /* no-op */
+}
+
+export function getMacOsKeychainStorageServiceName(): string {
+  return 'com.kosmos.placeholder'
+}

--- a/tui/src/utils/secureStorage/macOsKeychainStorage.ts
+++ b/tui/src/utils/secureStorage/macOsKeychainStorage.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function isMacOsKeychainLocked(): boolean {
+  return false
+}

--- a/tui/src/utils/secureStorage/types.ts
+++ b/tui/src/utils/secureStorage/types.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export interface SecureStorageData {
+  readonly value: string | null
+}

--- a/tui/src/utils/telemetry/betaSessionTracing.ts
+++ b/tui/src/utils/telemetry/betaSessionTracing.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function clearBetaTracingState(): void {
+  /* no-op */
+}
+
+export function isBetaTracingEnabled(): boolean {
+  return false
+}

--- a/tui/src/utils/telemetry/events.ts
+++ b/tui/src/utils/telemetry/events.ts
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function logOTelEvent(_name: string, _attrs?: unknown): void {
+  /* no-op */
+}
+
+export function redactIfDisabled<T>(value: T): T | '[REDACTED]' {
+  return value
+}

--- a/tui/src/utils/telemetry/perfettoTracing.ts
+++ b/tui/src/utils/telemetry/perfettoTracing.ts
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function isPerfettoTracingEnabled(): boolean {
+  return false
+}
+
+export function registerAgent(_agent: unknown): void {
+  /* no-op */
+}
+
+export function unregisterAgent(_agent: unknown): void {
+  /* no-op */
+}

--- a/tui/src/utils/telemetry/pluginTelemetry.ts
+++ b/tui/src/utils/telemetry/pluginTelemetry.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function buildPluginTelemetryFields(
+  _plugin: unknown,
+): Record<string, never> {
+  return {}
+}
+
+export function buildPluginCommandTelemetryFields(
+  _plugin: unknown,
+  _command: unknown,
+): Record<string, never> {
+  return {}
+}
+
+export function classifyPluginCommandError(_err: unknown): string {
+  return 'unknown'
+}
+
+export function logPluginLoadErrors(_errors: readonly unknown[]): void {
+  /* no-op */
+}
+
+export function logPluginsEnabledForSession(
+  _plugins: readonly unknown[],
+): void {
+  /* no-op */
+}

--- a/tui/src/utils/telemetry/sessionTracing.ts
+++ b/tui/src/utils/telemetry/sessionTracing.ts
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Claude Code's session-tracing spans (Datadog-backed) have no counterpart
+// in KOSMOS. OTEL emission happens inside `ipc/llmClient.ts` via the
+// FriendliAI path; these legacy helpers remain as compile-time no-ops.
+
+export interface Span {
+  end(): void
+}
+
+const NOOP_SPAN: Span = {
+  end() {
+    /* no-op */
+  },
+}
+
+export function startToolSpan(): Span {
+  return NOOP_SPAN
+}
+
+export function endToolSpan(_span?: Span): void {
+  /* no-op */
+}
+
+export function startToolExecutionSpan(): Span {
+  return NOOP_SPAN
+}
+
+export function endToolExecutionSpan(_span?: Span): void {
+  /* no-op */
+}
+
+export function startToolBlockedOnUserSpan(): Span {
+  return NOOP_SPAN
+}
+
+export function endToolBlockedOnUserSpan(_span?: Span): void {
+  /* no-op */
+}
+
+export function endLLMRequestSpan(_span?: Span): void {
+  /* no-op */
+}
+
+export function startInteractionSpan(): Span {
+  return NOOP_SPAN
+}
+
+export function endInteractionSpan(_span?: Span): void {
+  /* no-op */
+}
+
+export function startHookSpan(): Span {
+  return NOOP_SPAN
+}
+
+export function endHookSpan(_span?: Span): void {
+  /* no-op */
+}
+
+export function addToolContentEvent(_name: string, _data?: unknown): void {
+  /* no-op */
+}
+
+export function isBetaTracingEnabled(): boolean {
+  return false
+}

--- a/tui/src/utils/telemetry/skillLoadedEvent.ts
+++ b/tui/src/utils/telemetry/skillLoadedEvent.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function logSkillsLoaded(_skills: readonly unknown[]): void {
+  /* no-op */
+}

--- a/tui/src/utils/teleport.tsx
+++ b/tui/src/utils/teleport.tsx
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+//
+// Claude Code's "teleport to remote session" feature (cloud-backed worktree
+// handoff) has no counterpart in KOSMOS. All exports are inert — callers
+// receive empty payloads and no background work is kicked off.
+
+export interface TeleportResult {
+  readonly success: boolean
+  readonly reason?: string
+}
+
+export type TeleportProgressStep =
+  | 'init'
+  | 'bundling'
+  | 'uploading'
+  | 'routing'
+  | 'done'
+
+export interface PollRemoteSessionResponse {
+  readonly messages: readonly never[]
+  readonly done: boolean
+}
+
+export async function teleportToRemote(): Promise<TeleportResult> {
+  return { success: false, reason: 'KOSMOS: teleport disabled' }
+}
+
+export async function teleportResumeCodeSession(): Promise<TeleportResult> {
+  return { success: false, reason: 'KOSMOS: teleport disabled' }
+}
+
+export async function pollRemoteSessionEvents(): Promise<PollRemoteSessionResponse> {
+  return { messages: [], done: true }
+}
+
+export async function processMessagesForTeleportResume(): Promise<readonly never[]> {
+  return []
+}
+
+export async function archiveRemoteSession(): Promise<void> {
+  /* no-op */
+}
+
+export async function checkOutTeleportedSessionBranch(): Promise<boolean> {
+  return false
+}

--- a/tui/src/utils/teleport/api.ts
+++ b/tui/src/utils/teleport/api.ts
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export interface RemoteMessageContent {
+  readonly text?: string
+}
+
+export interface CodeSession {
+  readonly id: string
+  readonly title?: string
+}
+
+export async function fetchCodeSessionsFromSessionsAPI(): Promise<readonly CodeSession[]> {
+  return []
+}
+
+export async function fetchSession(_id: string): Promise<CodeSession | null> {
+  return null
+}
+
+export function getOAuthHeaders(): Record<string, string> {
+  return {}
+}
+
+export function isTransientNetworkError(_err: unknown): boolean {
+  return false
+}
+
+export function prepareApiRequest(): null {
+  return null
+}
+
+export async function updateSessionTitle(
+  _id: string,
+  _title: string,
+): Promise<void> {
+  /* no-op */
+}

--- a/tui/src/utils/teleport/environmentSelection.ts
+++ b/tui/src/utils/teleport/environmentSelection.ts
@@ -1,0 +1,6 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export function getEnvironmentSelectionInfo(): null {
+  return null
+}

--- a/tui/src/utils/teleport/environments.ts
+++ b/tui/src/utils/teleport/environments.ts
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: Apache-2.0
+// KOSMOS-original — Epic #1633 stub restoration.
+
+export type EnvironmentKind = 'cloud' | 'local' | 'unknown'
+
+export interface EnvironmentResource {
+  readonly kind: EnvironmentKind
+  readonly id: string
+}
+
+export function createDefaultCloudEnvironment(): EnvironmentResource {
+  return { kind: 'cloud', id: 'kosmos-placeholder' }
+}
+
+export async function fetchEnvironments(): Promise<readonly EnvironmentResource[]> {
+  return []
+}

--- a/tui/tests/ipc/bridge.test.ts
+++ b/tui/tests/ipc/bridge.test.ts
@@ -38,9 +38,14 @@ function makeUserInputFrame(sid: string, text: string): IPCFrame {
 // Tests
 // ---------------------------------------------------------------------------
 
+// KOSMOS_IPC_HANDLER=echo selects the test-friendly echo handler in
+// src/kosmos/ipc/stdio.py — matches these tests' FIFO / lifecycle assertions
+// without requiring FRIENDLI_API_KEY on the CI runner.
+const ECHO_ENV = { KOSMOS_IPC_HANDLER: 'echo' }
+
 describe('bridge: process lifecycle', () => {
   test('backend spawns and starts within 5 s', async () => {
-    const bridge = createBridge({ cmd: BACKEND_CMD })
+    const bridge = createBridge({ cmd: BACKEND_CMD, env: ECHO_ENV })
     // Give it up to 5 s to be reachable.  The original 2 s bound was flaky
     // on shared CI runners under load (observed 2 002 ms on main-branch
     // runs where the PR CI passed at ~1.8 s).  5 s keeps the test fast
@@ -68,7 +73,7 @@ describe('bridge: process lifecycle', () => {
   })
 
   test('close() terminates the backend within 5 s', async () => {
-    const bridge = createBridge({ cmd: BACKEND_CMD })
+    const bridge = createBridge({ cmd: BACKEND_CMD, env: ECHO_ENV })
     // Send one frame to confirm it is live
     bridge.send(makeUserInputFrame('test-close-01', 'ping'))
     // Consume one frame
@@ -82,7 +87,7 @@ describe('bridge: process lifecycle', () => {
 
 describe('bridge: FIFO frame ordering (FR-005)', () => {
   test('10 user_input frames arrive back as assistant_chunks in order', async () => {
-    const bridge = createBridge({ cmd: BACKEND_CMD })
+    const bridge = createBridge({ cmd: BACKEND_CMD, env: ECHO_ENV })
     const sid = 'test-fifo-session-01'
     const texts = Array.from({ length: 10 }, (_, i) => `message-${i}`)
 


### PR DESCRIPTION
## Summary

Epic #1633 (PR #1706) deleted ~100 files but left the TUI un-bootable AND query/deps.ts::callModel pointing at a stub that threw on first prompt. This PR restores TUI bootability AND delivers the full Spec 032 IPC path to K-EXAONE that FR-007 / FR-017 require.

## 1. Root-cause boot fixes in main.tsx

- **L963** — missing closing `}` on the `isClaudeInChromeMCPServer` if-block. Epic #1633's `feature('CHICAGO_MCP')` strip took the brace with it.
- **L1247** — restore `const messagingSocketPath: string | undefined = undefined` — the UDS_INBOX feature() branch was removed but `setup()` still references the variable.

## 2. Stub restoration (23 stubs, KOSMOS-original, Apache-2.0)

Files deleted by Epic #1633 but still imported from ~150 call sites. Restored as compile-time surface only; every runtime path is a no-op, fail-closed, or fixed "disabled" answer. Full list in commit df93c36.

## 3. Python backend LLM handler (src/kosmos/ipc/stdio.py)

Replace the echo handler with a real LLM handler:
- On UserInputFrame: append to per-session conversation history, call `LLMClient.stream()` with accumulated messages, relay each `content_delta` as an `AssistantChunkFrame(done=false)`, emit terminal `AssistantChunkFrame(done=true)` at stream end.
- System prompt loaded lazily from Spec 026 PromptLoader on first turn per session.
- Errors surface as `ErrorFrame(class=llm)`.
- Assistant text appended to history so multi-turn context works.

## 4. TUI bridge singleton (tui/src/ipc/bridgeSingleton.ts)

New module — lazy singleton that spawns `uv run kosmos --ipc stdio` (override via `KOSMOS_BACKEND_CMD`) on first access. One Python backend per TUI process, shared across every LLM turn.

## 5. services/api/claude.ts IPC rewire

- Construct `LLMClient({ bridge, model, sessionId })` per turn
- Drive its async generator; accumulate `content_block_delta` text into one assistant message for `query.ts::queryLoop`
- Token streaming happens via `AssistantChunkFrame` below this layer — this helper only produces the final `{type:'assistant', message:{...}}` envelope

## Epic #1633 FRs newly satisfied

| FR/SC | Before | After |
|---|---|---|
| **FR-007** | Stub threw "use ipc/llmClient directly" | All LLM traffic goes through stdio IPC |
| **FR-017** | `query/deps.ts::callModel` pointed at Anthropic-SDK-shape stub | Uses IPC-backed LLMClient via `queryModelWithStreaming` wrapper |
| **SC-001** | Non-measurable (single-shot fetch) | Token streaming via `AssistantChunkFrame` delta chunks |

## End-to-end verified via print mode

```
$ bun run src/main.tsx -p "1+1=? 숫자만." --output-format text
2

$ bun run src/main.tsx -p "5 곱하기 7은?" --output-format text
5 곱하기 7은 35입니다.  $ 5 × 7 = 35 $

$ bun run src/main.tsx -p "서울을 소개하는 한 문장." --output-format text
서울은 한국의 수도이자 현대와 전통이 공존하는 역동적인 도시입니다.
```

Each run spawns a fresh Python backend, handshakes via Spec 032 frames, streams K-EXAONE tokens back, terminates cleanly.

## Out of scope (deferred to other epics)

- **Tool-use block streaming** — Epic #1634 tool-system redesign.
- **Interactive UI token animation** — protocol end-to-end verified in print mode; whether the Ink renderer paints chunks mid-stream is a UI-layer concern tracked separately.

## Test plan

- [x] `bun run src/main.tsx --help` exits 0
- [x] Python stdio handler test: `(echo "$frame"; sleep) | uv run kosmos --ipc stdio` emits 3 AssistantChunkFrames for "1+1=?"
- [x] `bun run src/main.tsx -p "<prompt>"` returns live K-EXAONE response via full IPC path (3 prompts verified)
- [ ] CI green (Lint & Type Check, Test Python 3.12/3.13, CodeQL, Secret Detection)
- [ ] TUI smoke in CI