### PR TITLE
fix(1633): pin stdio roundtrip test to echo handler mode

### DIFF
--- a/tests/ipc/test_stdio_roundtrip.py
+++ b/tests/ipc/test_stdio_roundtrip.py
@@ -72,7 +72,16 @@ async def _read_lines(stream: asyncio.StreamReader, n: int, timeout: float = 10.
 
 @pytest.fixture
 async def backend_proc() -> AsyncIterator[asyncio.subprocess.Process]:
-    """Spawn ``uv run kosmos --ipc stdio`` and yield the process handle."""
+    """Spawn ``uv run kosmos --ipc stdio`` and yield the process handle.
+
+    KOSMOS_IPC_HANDLER=echo selects the test-friendly echo handler so the
+    round-trip test does not depend on FRIENDLI_API_KEY or network. The
+    production handler (Epic #1633) routes user_input frames through
+    LLMClient.stream() against FriendliAI.
+    """
+    import os
+
+    env = {**os.environ, "KOSMOS_IPC_HANDLER": "echo"}
     proc = await asyncio.create_subprocess_exec(
         sys.executable,
         "-m",
@@ -83,6 +92,7 @@ async def backend_proc() -> AsyncIterator[asyncio.subprocess.Process]:
         stdout=asyncio.subprocess.PIPE,
         stderr=asyncio.subprocess.PIPE,
         cwd=_PROJECT_ROOT,
+        env=env,
     )
     yield proc
     if proc.returncode is None:


### PR DESCRIPTION
## Summary

Main-branch CI failed on commit 1b5f734 (merge of #1708) because `tests/ipc/test_stdio_roundtrip.py::test_user_input_echo_roundtrip` still assumes the old echo handler. After the LLM-routed rewire landed, the CI runner (no FRIENDLI_API_KEY) fails the LLM call silently, no assistant_chunk is emitted, and the test times out expecting 1 response line.

Fix: set `KOSMOS_IPC_HANDLER=echo` in the subprocess env — same mitigation already applied to `tui/tests/ipc/bridge.test.ts` in #1708.

## Local verification

```
$ uv run pytest tests/ipc/test_stdio_roundtrip.py -v
5 passed in 2.23s
```

## Also seen in main CI but not in scope of this PR

- **SBOM Generation** divergence between runs on `zipp 3.23.0 ↔ 3.23.1` — external dependency race, not triggered by my code changes. Will clear on a follow-up `uv lock` refresh or a retry.

## Test plan

- [x] Local pytest passes
- [ ] CI pass on all gates