### PR TITLE
docs(agents): deprecate § Copilot Review Gate, document Codex inline review

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -84,22 +84,16 @@ Small fixes (typos, one-line bugs, docs-only) skip the cycle.
 
 Conventional Commits. Branches: `feat/`, `fix/`, `docs/`, `refactor/`, `test/`, `chore/`. PRs for code; direct `main` commits only for `docs:` / `chore:` touching no source. Full details: `docs/conventions.md`.
 
-## Copilot Review Gate
+## Code review
 
-Cloudflare Worker (`infra/copilot-gate-app/`) → Check Run gate. **CRITICAL >= 1 → fail**, **IMPORTANT >= 3 → fail**, else pass. Deploy: `cd infra/copilot-gate-app && npx wrangler deploy`.
+After every push, read inline review comments left by **Codex** (`chatgpt-codex-connector[bot]`) on the PR and address them:
 
-**After every push (including fix commits from Copilot review feedback):**
-1. Read Copilot review comments (`gh api 'repos/OWNER/REPO/pulls/N/comments'`), fix issues, commit and push.
-2. **Always** re-request Copilot review via GraphQL after push — it does NOT auto-trigger:
-   ```bash
-   PR_NODE_ID=$(gh api repos/umyunsang/KOSMOS/pulls/<N> --jq '.node_id')
-   gh api graphql -f query='mutation($input: RequestReviewsByLoginInput!) { requestReviewsByLogin(input: $input) { pullRequest { id } } }' \
-     -F "input[pullRequestId]=$PR_NODE_ID" -F 'input[botLogins][]=copilot-pull-request-reviewer[bot]' -F 'input[union]:=true'
-   ```
-3. If gate stays `pending`/`in_progress` for 2+ min after re-request, add label `copilot-review-bypass`.
-4. `requestReviewsByLogin` has **~1/3 failure rate** — retry once before resorting to bypass label.
+```bash
+gh api repos/umyunsang/KOSMOS/pulls/<N>/comments \
+  --jq '.[] | select(.user.login == "chatgpt-codex-connector[bot]") | "\(.path):\(.line) \(.body)"'
+```
 
-Full procedure: `docs/copilot-gate.md`.
+Codex flags issues with severity badges (P1/P2/P3). Fix or defer each with a reply. Codex auto-reviews on every push — no manual trigger needed.
 
 ## New tool adapter
 


### PR DESCRIPTION
## Summary

AGENTS.md의 \`§ Copilot Review Gate\` 섹션을 \`§ Code review\` 로 대체. Copilot Review Gate 자동화 (Cloudflare Worker + GraphQL re-request + bypass label fallback) 는 더 이상 KOSMOS의 active code-review pipeline이 아님. 새 섹션은 실제 동작 중인 워크플로 — Codex (\`chatgpt-codex-connector[bot]\`) 가 매 push마다 자동 inline review + P1/P2/P3 severity badge — 만 기록.

## Changes

- \`AGENTS.md\` Line 87-102: \`## Copilot Review Gate\` 섹션 (16 lines, Cloudflare Worker + GraphQL mutation + bypass label fallback) 삭제
- 그 자리에 \`## Code review\` 섹션 (10 lines) 추가: Codex inline review를 \`gh api\` 로 read하는 명령 + severity badge 처리 가이드

## Out of scope (follow-up cleanup)

deprecated artifacts 그대로 둠:
- \`infra/copilot-gate-app/\` Cloudflare Worker
- \`docs/copilot-gate.md\` runbook

Worker가 GitHub Checks API에 더 이상 연결되어 있지 않음을 stakeholder가 확인한 뒤 별도 chore PR로 삭제 권장.

## Test plan

- [x] \`grep "Copilot\|copilot" AGENTS.md\` — empty (잔재 0건)
- [x] AGENTS.md ≤ 120 lines 룰 유지 (현재: 더 짧아짐)

## Memory alignment

\`feedback_codex_reviewer.md\` ("PR push 후 Copilot + Codex 둘 다 리뷰 코멘트 확인 필수") 는 이번 정리로 Codex-only 로 좁혀짐. 메모리는 별도로 사용자가 정리.

## Refs

- 사용자 지시 (2026-04-27): "§ Copilot Review Gate 절차는 패지되었어 AGENTS.md 에서 해당내용 삭제하고 코덱스가 인라인 코멘트로 코드리뷰하는 내용만 확인해"