### PR TITLE
ci(deps): bump actions/checkout from 4 to 6

### DIFF
--- a/.github/workflows/cc-byte-identical-guard.yml
+++ b/.github/workflows/cc-byte-identical-guard.yml
@@ -52,7 +52,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/tui-attribution-gate.yml
+++ b/.github/workflows/tui-attribution-gate.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository (including .references/ for diff-upstream)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full checkout so .references/ is present for diff-upstream.sh
           fetch-depth: 1

--- a/.github/workflows/tui-ipc-drift.yml
+++ b/.github/workflows/tui-ipc-drift.yml
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v5

--- a/.github/workflows/tui-smoke.yml
+++ b/.github/workflows/tui-smoke.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2


### PR DESCRIPTION
Restores closed Dependabot PR #1593 after branch cleanup. Reviewed diff: updates actions/checkout from v4 to v6 in workflow files only. Release note highlights: Node.js 24 support and credential persistence changes; GitHub-hosted runners satisfy the runner requirement.