### PR TITLE
ci(deps): bump actions/setup-python from 5 to 6

### DIFF
--- a/.github/workflows/cc-byte-identical-guard.yml
+++ b/.github/workflows/cc-byte-identical-guard.yml
@@ -57,7 +57,7 @@ jobs:
           fetch-depth: 1
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/tui-ipc-drift.yml
+++ b/.github/workflows/tui-ipc-drift.yml
@@ -40,7 +40,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/tui-smoke.yml
+++ b/.github/workflows/tui-smoke.yml
@@ -58,7 +58,7 @@ jobs:
         # `uv run kosmos --ipc stdio` echo backend — not a mock — to verify
         # the stdio JSONL contract end-to-end. Skipping Python here would
         # force those tests into a mocked half-world and mask backend drift.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 


### PR DESCRIPTION
Restores closed Dependabot PR #1592 after branch cleanup. Reviewed diff: updates actions/setup-python from v5 to v6 in workflow files only. Release note highlights: Node.js 24 runtime; GitHub-hosted runners meet the runner requirement.