### PR TITLE
ci(deps): bump astral-sh/setup-uv from 4 to 7

### DIFF
--- a/.github/workflows/tui-ipc-drift.yml
+++ b/.github/workflows/tui-ipc-drift.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: ">=0.5"
 

--- a/.github/workflows/tui-smoke.yml
+++ b/.github/workflows/tui-smoke.yml
@@ -63,7 +63,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true


### PR DESCRIPTION
Restores closed Dependabot PR #1594 after branch cleanup. Reviewed diff: updates astral-sh/setup-uv from v4/v5 to v7 in workflow files only. Release note highlights: Node.js 24 runtime, removal of deprecated server-url input, and cache handling fixes. KOSMOS workflows do not use server-url.