### PR TITLE
chore(deps): bump GitHub Actions Node 24 runtimes

### DIFF
--- a/.github/workflows/cc-byte-identical-guard.yml
+++ b/.github/workflows/cc-byte-identical-guard.yml
@@ -52,12 +52,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/eval.yml
+++ b/.github/workflows/eval.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/tui-attribution-gate.yml
+++ b/.github/workflows/tui-attribution-gate.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Checkout repository (including .references/ for diff-upstream)"
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           # Full checkout so .references/ is present for diff-upstream.sh
           fetch-depth: 1

--- a/.github/workflows/tui-ipc-drift.yml
+++ b/.github/workflows/tui-ipc-drift.yml
@@ -37,15 +37,15 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v4
+        uses: astral-sh/setup-uv@v7
         with:
           version: ">=0.5"
 

--- a/.github/workflows/tui-smoke.yml
+++ b/.github/workflows/tui-smoke.yml
@@ -40,7 +40,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Bun
         uses: oven-sh/setup-bun@v2
@@ -58,12 +58,12 @@ jobs:
         # `uv run kosmos --ipc stdio` echo backend — not a mock — to verify
         # the stdio JSONL contract end-to-end. Skipping Python here would
         # force those tests into a mocked half-world and mask backend drift.
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
           enable-cache: true

--- a/tui/src/.cc-byte-identical-whitelist.yaml
+++ b/tui/src/.cc-byte-identical-whitelist.yaml
@@ -42,6 +42,7 @@ causes:
   W11: "Sandbox-runtime install hint stripped"
   W12: "OTEL frame_commit instrumentation hook"
   W13: "Dead-code cleanup (Spec 1633/1978/2293 — Anthropic services/api/auth/secureStorage/teleport stubbed at call site)"
+  W14: "Real-use TUI audit correction (accessibility/legibility, no contract change)"
 
 # Each entry must specify: path (repo-root relative), cause (one or comma-separated),
 # spec_ref (issue # or docs path). Optional: notes, expected_sha256 (locks
@@ -187,6 +188,14 @@ entries:
     notes: "'npm install -g @anthropic-ai/sandbox-runtime' install hint removed."
 
   # ── W13: dead-code cleanup (Spec 1633 / 1978 / 2293) ──
+  - path: tui/src/components/PromptInput/PromptInputFooterSuggestions.tsx
+    cause: W14
+    spec_ref: "specs/realuse-audit-2026-05-05/fixes/g7-autocomplete.md"
+    notes: "Selected-row caret glyph for slash autocomplete legibility; preserves CC layout budget."
+  - path: tui/src/components/agents/ToolSelector.tsx
+    cause: W13,W8
+    spec_ref: "#1633 (TungstenTool removal), specs/cc-migration-audit/scope-S3-components-screens.md § 5.3"
+    notes: "Claude Code-internal TungstenTool bucket removed; sourceMappingURL stripped."
   - path: tui/src/components/messages/AssistantTextMessage.tsx
     cause: W13,W1
     spec_ref: "#1633 (services/api/errors removal), #2293 (secureStorage removal)"


### PR DESCRIPTION
Restores and combines the reviewed Dependabot updates from closed PRs #1592, #1593, and #1594.

Checked content:
- actions/checkout v4 -> v6 in workflow files that still used v4
- actions/setup-python v5 -> v6 in workflow files that still used v5
- astral-sh/setup-uv v4/v5 -> v7 in workflow files that still used older versions

Release-note review:
- checkout v6: Node.js 24 support and credential persistence changes; GitHub-hosted runners satisfy the runner requirement.
- setup-python v6: Node.js 24 runtime; GitHub-hosted runners satisfy the runner requirement.
- setup-uv v7: Node.js 24 runtime, server-url input removed; KOSMOS workflows do not use server-url.

CI guard follow-up:
- Adds S3 whitelist entries for existing PR #2773 TUI divergences exposed by rerunning workflow-only guards.
- Includes [tui-bun-linux-known-issue] for the repository-documented Linux Bun loader flake path.