### PR TITLE
chore(ci): update Infisical action to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
       - name: Env registry drift check
         run: uv run python scripts/audit-env-registry.py
       - name: Fetch secrets from Infisical (OIDC federation)
-        uses: Infisical/secrets-action@8802effbe453d0576cd923567dcc2c97a1f54058  # v1.0.15
+        uses: Infisical/secrets-action@77ab1f4ccd183a543cb5b42435fbd181189f4995  # v1.0.16
         with:
           method: oidc
           identity-id: ${{ vars.INFISICAL_CLIENT_ID }}


### PR DESCRIPTION
## Summary
- Bump `Infisical/secrets-action` from the pinned v1.0.15 commit to the pinned v1.0.16 commit.
- Preserve the existing OIDC inputs and SHA-pinned action style.
- Remove the GitHub Actions Node 20 deprecation warning seen on the CI test job.

## Research
- Official `Infisical/secrets-action` v1.0.16 release was published 2026-04-25.
- The v1.0.16 release notes include `chore(version): update node version`.
- `action.yaml` at v1.0.16 declares `runs.using: node24`; v1.0.15 declared `node20`.
- Tag `v1.0.16` resolves to commit `77ab1f4ccd183a543cb5b42435fbd181189f4995`.

## Validation
- `git diff --check`
- `rg -n "Infisical/secrets-action|v1.0.16|v1.0.15|node20|node24" .github/workflows/ci.yml`