### PR TITLE
feat: add verified data.go.kr adapter wave

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,12 +32,15 @@ The UMMAYA migration-completion release. Initiative #1631 closed; the six Phase 
 
 ## [Unreleased]
 
-### Fixed
-- Corrected prepackage TUI branding so resume instructions, terminal titles, and package/version output use UMMAYA/ummaya and `v0.1.0-alpha` instead of upstream Claude CLI names or issue-number build metadata.
-
 ### Added
+
+- Added fourteen direct-curl verified data.go.kr-style `find` adapters, generated JSON schemas, and docs for the first credential-backed public-data adapter wave.
 - Initial project scaffold with `README.md` and `.gitignore`
 - Apache License 2.0
 - Contribution guide, Code of Conduct (Contributor Covenant 2.1), security policy
 - Issue templates for bug reports, feature requests, and API adapter proposals
 - Pull request template
+
+### Fixed
+
+- Corrected prepackage TUI branding so resume instructions, terminal titles, and package/version output use UMMAYA/ummaya and `v0.1.0-alpha` instead of upstream Claude CLI names or issue-number build metadata.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,6 +1,6 @@
 # UMMAYA API Catalog
 
-This directory documents every active adapter registered with UMMAYA at the close of the Claude Code → Korean public-service harness migration (Initiative #1631, Epic P6 #1637). Active adapters span seven Korean ministries and agencies: live `find` adapters call `data.go.kr` or public-infrastructure endpoints, live `locate` adapters wrap provider-specific geocoding APIs, and mock `send`/`check` adapters replay public-spec-mirrored fixtures. Subscription adapters are intentionally deferred until UMMAYA has an app/push-notification runtime.
+This directory documents every active adapter registered with UMMAYA at the close of the Claude Code → Korean public-service harness migration (Initiative #1631, Epic P6 #1637) plus the direct-curl verified public-data wave from Epic #2797. Active adapters span Korean ministries, public corporations, and public-infrastructure endpoints: live `find` adapters call `data.go.kr` or provider LINK APIs, live `locate` adapters wrap provider-specific geocoding APIs, and mock `send`/`check` adapters replay public-spec-mirrored fixtures. Subscription adapters are intentionally deferred until UMMAYA has an app/push-notification runtime.
 
 The catalog is intended for three audiences:
 
@@ -32,6 +32,20 @@ Every adapter spec follows the seven-section template in [`specs/1637-p6-docs-sm
 | NMC | `nmc_emergency_search` | `find` | live | 3 | [nmc/emergency_search.md](./nmc/emergency_search.md) | [nmc_emergency_search.json](./schemas/nmc_emergency_search.json) |
 | NFA119 | `nfa_emergency_info_service` | `find` | live | 1 | [nfa119/emergency_info_service.md](./nfa119/emergency_info_service.md) | [nfa_emergency_info_service.json](./schemas/nfa_emergency_info_service.json) |
 | MOHW | `mohw_welfare_eligibility_search` | `find` | live | 1 | [mohw/welfare_eligibility_search.md](./mohw/welfare_eligibility_search.md) | [mohw_welfare_eligibility_search.json](./schemas/mohw_welfare_eligibility_search.json) |
+| FSC | `fsc_corporate_finance_summary` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [fsc_corporate_finance_summary.json](./schemas/fsc_corporate_finance_summary.json) |
+| KECO / AirKorea | `airkorea_ctprvn_air_quality` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [airkorea_ctprvn_air_quality.json](./schemas/airkorea_ctprvn_air_quality.json) |
+| FTC | `ftc_large_group_status` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [ftc_large_group_status.json](./schemas/ftc_large_group_status.json) |
+| FTC | `ftc_public_ym_list` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [ftc_public_ym_list.json](./schemas/ftc_public_ym_list.json) |
+| MOLIT / TAGO | `tago_bus_route_search` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [tago_bus_route_search.json](./schemas/tago_bus_route_search.json) |
+| MOLIT / TAGO | `tago_bus_arrival_search` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [tago_bus_arrival_search.json](./schemas/tago_bus_arrival_search.json) |
+| MOLIT / TAGO | `tago_bus_location_search` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [tago_bus_location_search.json](./schemas/tago_bus_location_search.json) |
+| MOLIT / TAGO | `tago_bus_station_search` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [tago_bus_station_search.json](./schemas/tago_bus_station_search.json) |
+| KEPCO | `kepco_contract_power_usage` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [kepco_contract_power_usage.json](./schemas/kepco_contract_power_usage.json) |
+| PPS | `pps_bid_public_info` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [pps_bid_public_info.json](./schemas/pps_bid_public_info.json) |
+| REB | `reb_real_estate_stat_table` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [reb_real_estate_stat_table.json](./schemas/reb_real_estate_stat_table.json) |
+| BFC | `bfc_funeral_area_fee` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [bfc_funeral_area_fee.json](./schemas/bfc_funeral_area_fee.json) |
+| KCUE | `kcue_finance_regional_tuition` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [kcue_finance_regional_tuition.json](./schemas/kcue_finance_regional_tuition.json) |
+| KCUE | `kcue_student_regional_foreign` | `find` | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) | [kcue_student_regional_foreign.json](./schemas/kcue_student_regional_foreign.json) |
 | Mock — Check | `mock_verify_digital_onepass` | `check` | mock | 2 | [verify/digital_onepass.md](./verify/digital_onepass.md) | [mock_verify_digital_onepass.json](./schemas/mock_verify_digital_onepass.json) |
 | Mock — Check | `mock_verify_mobile_id` | `check` | mock | 2 | [verify/mobile_id.md](./verify/mobile_id.md) | [mock_verify_mobile_id.json](./schemas/mock_verify_mobile_id.json) |
 | Mock — Check | `mock_verify_gongdong_injeungseo` | `check` | mock | 3 | [verify/gongdong_injeungseo.md](./verify/gongdong_injeungseo.md) | [mock_verify_gongdong_injeungseo.json](./schemas/mock_verify_gongdong_injeungseo.json) |
@@ -48,11 +62,19 @@ Every adapter spec follows the seven-section template in [`specs/1637-p6-docs-sm
 
 ## Matrix B — adapters by primitive
 
-### `find` (12 ministry adapters)
+### `find` (26 ministry and public-data adapters)
 
 | tool_id | Source | Tier | Permission | Spec |
 |---|---|---|---|---|
+| `airkorea_ctprvn_air_quality` | KECO / AirKorea | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `bfc_funeral_area_fee` | BFC | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `fsc_corporate_finance_summary` | FSC | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `ftc_large_group_status` | FTC | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `ftc_public_ym_list` | FTC | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
 | `hira_hospital_search` | HIRA | live | 1 | [hira/hospital_search.md](./hira/hospital_search.md) |
+| `kcue_finance_regional_tuition` | KCUE | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `kcue_student_regional_foreign` | KCUE | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `kepco_contract_power_usage` | KEPCO | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
 | `kma_current_observation` | KMA | live | 1 | [kma/current_observation.md](./kma/current_observation.md) |
 | `kma_forecast_fetch` | KMA | live | 1 | [kma/forecast_fetch.md](./kma/forecast_fetch.md) |
 | `kma_pre_warning` | KMA | live | 1 | [kma/pre_warning.md](./kma/pre_warning.md) |
@@ -64,6 +86,12 @@ Every adapter spec follows the seven-section template in [`specs/1637-p6-docs-sm
 | `mohw_welfare_eligibility_search` | MOHW | live | 1 | [mohw/welfare_eligibility_search.md](./mohw/welfare_eligibility_search.md) |
 | `nfa_emergency_info_service` | NFA119 | live | 1 | [nfa119/emergency_info_service.md](./nfa119/emergency_info_service.md) |
 | `nmc_emergency_search` | NMC | live | 3 (gated) | [nmc/emergency_search.md](./nmc/emergency_search.md) |
+| `pps_bid_public_info` | PPS | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `reb_real_estate_stat_table` | REB | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `tago_bus_arrival_search` | MOLIT / TAGO | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `tago_bus_location_search` | MOLIT / TAGO | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `tago_bus_route_search` | MOLIT / TAGO | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
+| `tago_bus_station_search` | MOLIT / TAGO | live | 1 | [verified-data-go-kr/README.md](./verified-data-go-kr/README.md) |
 
 ### `locate` (5 provider adapters)
 

--- a/docs/api/schemas/airkorea_ctprvn_air_quality.json
+++ b/docs/api/schemas/airkorea_ctprvn_air_quality.json
@@ -1,0 +1,70 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/airkorea_ctprvn_air_quality.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for AirKorea city/province air quality.",
+  "properties": {
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    },
+    "sido_name": {
+      "description": "Korean province/city name.",
+      "minLength": 1,
+      "title": "Sido Name",
+      "type": "string"
+    },
+    "ver": {
+      "default": "1.0",
+      "description": "AirKorea response version.",
+      "title": "Ver",
+      "type": "string"
+    }
+  },
+  "required": [
+    "sido_name"
+  ],
+  "title": "airkorea_ctprvn_air_quality",
+  "type": "object"
+}

--- a/docs/api/schemas/bfc_funeral_area_fee.json
+++ b/docs/api/schemas/bfc_funeral_area_fee.json
@@ -1,0 +1,55 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/bfc_funeral_area_fee.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for BFC funeral area fee list.",
+  "properties": {
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    }
+  },
+  "title": "bfc_funeral_area_fee",
+  "type": "object"
+}

--- a/docs/api/schemas/fsc_corporate_finance_summary.json
+++ b/docs/api/schemas/fsc_corporate_finance_summary.json
@@ -1,0 +1,72 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/fsc_corporate_finance_summary.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for FSC corporate finance summary.",
+  "properties": {
+    "biz_year": {
+      "description": "Business year.",
+      "maxLength": 4,
+      "minLength": 4,
+      "title": "Biz Year",
+      "type": "string"
+    },
+    "crno": {
+      "description": "Corporate registration number.",
+      "minLength": 1,
+      "title": "Crno",
+      "type": "string"
+    },
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "crno",
+    "biz_year"
+  ],
+  "title": "fsc_corporate_finance_summary",
+  "type": "object"
+}

--- a/docs/api/schemas/ftc_large_group_status.json
+++ b/docs/api/schemas/ftc_large_group_status.json
@@ -1,0 +1,64 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/ftc_large_group_status.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for FTC large corporate group status.",
+  "properties": {
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    },
+    "presentn_year": {
+      "description": "Disclosure year/month.",
+      "minLength": 4,
+      "title": "Presentn Year",
+      "type": "string"
+    }
+  },
+  "required": [
+    "presentn_year"
+  ],
+  "title": "ftc_large_group_status",
+  "type": "object"
+}

--- a/docs/api/schemas/ftc_public_ym_list.json
+++ b/docs/api/schemas/ftc_public_ym_list.json
@@ -1,0 +1,71 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/ftc_public_ym_list.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for FTC public disclosure year/month.",
+  "properties": {
+    "job_se_code": {
+      "description": "FTC job section code.",
+      "minLength": 1,
+      "title": "Job Se Code",
+      "type": "string"
+    },
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    },
+    "presentn_year": {
+      "description": "Disclosure year.",
+      "minLength": 4,
+      "title": "Presentn Year",
+      "type": "string"
+    }
+  },
+  "required": [
+    "job_se_code",
+    "presentn_year"
+  ],
+  "title": "ftc_public_ym_list",
+  "type": "object"
+}

--- a/docs/api/schemas/kcue_finance_regional_tuition.json
+++ b/docs/api/schemas/kcue_finance_regional_tuition.json
@@ -1,0 +1,64 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/kcue_finance_regional_tuition.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for KCUE regional tuition status.",
+  "properties": {
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    },
+    "schl_div_cd": {
+      "description": "School division code.",
+      "minLength": 1,
+      "title": "Schl Div Cd",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schl_div_cd"
+  ],
+  "title": "kcue_finance_regional_tuition",
+  "type": "object"
+}

--- a/docs/api/schemas/kcue_student_regional_foreign.json
+++ b/docs/api/schemas/kcue_student_regional_foreign.json
@@ -1,0 +1,64 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/kcue_student_regional_foreign.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for KCUE regional foreign student status.",
+  "properties": {
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    },
+    "schl_div_cd": {
+      "description": "School division code.",
+      "minLength": 1,
+      "title": "Schl Div Cd",
+      "type": "string"
+    }
+  },
+  "required": [
+    "schl_div_cd"
+  ],
+  "title": "kcue_student_regional_foreign",
+  "type": "object"
+}

--- a/docs/api/schemas/kepco_contract_power_usage.json
+++ b/docs/api/schemas/kepco_contract_power_usage.json
@@ -1,0 +1,97 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/kepco_contract_power_usage.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for KEPCO contract-type power usage.",
+  "properties": {
+    "city_cd": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "City/county/district code.",
+      "title": "City Cd"
+    },
+    "cntr_cd": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Contract type code.",
+      "title": "Cntr Cd"
+    },
+    "metro_cd": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Metropolitan code.",
+      "title": "Metro Cd"
+    },
+    "month": {
+      "description": "Usage month.",
+      "maxLength": 2,
+      "minLength": 1,
+      "title": "Month",
+      "type": "string"
+    },
+    "year": {
+      "description": "Usage year.",
+      "maxLength": 4,
+      "minLength": 4,
+      "title": "Year",
+      "type": "string"
+    }
+  },
+  "required": [
+    "year",
+    "month"
+  ],
+  "title": "kepco_contract_power_usage",
+  "type": "object"
+}

--- a/docs/api/schemas/pps_bid_public_info.json
+++ b/docs/api/schemas/pps_bid_public_info.json
@@ -1,0 +1,77 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/pps_bid_public_info.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for PPS bid public information.",
+  "properties": {
+    "bid_ntce_no": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Bid notice number.",
+      "title": "Bid Ntce No"
+    },
+    "inqry_div": {
+      "description": "PPS inquiry division.",
+      "minLength": 1,
+      "title": "Inqry Div",
+      "type": "string"
+    },
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "inqry_div"
+  ],
+  "title": "pps_bid_public_info",
+  "type": "object"
+}

--- a/docs/api/schemas/reb_real_estate_stat_table.json
+++ b/docs/api/schemas/reb_real_estate_stat_table.json
@@ -1,0 +1,68 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/reb_real_estate_stat_table.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for REB statistic table search.",
+  "properties": {
+    "p_index": {
+      "default": 1,
+      "description": "Page index.",
+      "minimum": 1,
+      "title": "P Index",
+      "type": "integer"
+    },
+    "p_size": {
+      "default": 100,
+      "description": "Page size.",
+      "maximum": 1000,
+      "minimum": 1,
+      "title": "P Size",
+      "type": "integer"
+    },
+    "statbl_id": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Optional statistic table ID.",
+      "title": "Statbl Id"
+    }
+  },
+  "title": "reb_real_estate_stat_table",
+  "type": "object"
+}

--- a/docs/api/schemas/tago_bus_arrival_search.json
+++ b/docs/api/schemas/tago_bus_arrival_search.json
@@ -1,0 +1,71 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/tago_bus_arrival_search.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for TAGO bus arrival search.",
+  "properties": {
+    "city_code": {
+      "description": "TAGO city code.",
+      "minLength": 1,
+      "title": "City Code",
+      "type": "string"
+    },
+    "node_id": {
+      "description": "TAGO bus station ID.",
+      "minLength": 1,
+      "title": "Node Id",
+      "type": "string"
+    },
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "city_code",
+    "node_id"
+  ],
+  "title": "tago_bus_arrival_search",
+  "type": "object"
+}

--- a/docs/api/schemas/tago_bus_location_search.json
+++ b/docs/api/schemas/tago_bus_location_search.json
@@ -1,0 +1,71 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/tago_bus_location_search.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for TAGO bus location search.",
+  "properties": {
+    "city_code": {
+      "description": "TAGO city code.",
+      "minLength": 1,
+      "title": "City Code",
+      "type": "string"
+    },
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    },
+    "route_id": {
+      "description": "TAGO route ID.",
+      "minLength": 1,
+      "title": "Route Id",
+      "type": "string"
+    }
+  },
+  "required": [
+    "city_code",
+    "route_id"
+  ],
+  "title": "tago_bus_location_search",
+  "type": "object"
+}

--- a/docs/api/schemas/tago_bus_route_search.json
+++ b/docs/api/schemas/tago_bus_route_search.json
@@ -1,0 +1,71 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/tago_bus_route_search.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for TAGO bus route search.",
+  "properties": {
+    "city_code": {
+      "description": "TAGO city code.",
+      "minLength": 1,
+      "title": "City Code",
+      "type": "string"
+    },
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    },
+    "route_no": {
+      "description": "Bus route number.",
+      "minLength": 1,
+      "title": "Route No",
+      "type": "string"
+    }
+  },
+  "required": [
+    "city_code",
+    "route_no"
+  ],
+  "title": "tago_bus_route_search",
+  "type": "object"
+}

--- a/docs/api/schemas/tago_bus_station_search.json
+++ b/docs/api/schemas/tago_bus_station_search.json
@@ -1,0 +1,90 @@
+{
+  "$defs": {
+    "_VerifiedCollectionSchema": {
+      "description": "Output schema used by legacy ToolExecutor.dispatch validation.",
+      "properties": {
+        "items": {
+          "items": {
+            "additionalProperties": true,
+            "type": "object"
+          },
+          "title": "Items",
+          "type": "array"
+        },
+        "kind": {
+          "title": "Kind",
+          "type": "string"
+        },
+        "total_count": {
+          "title": "Total Count",
+          "type": "integer"
+        }
+      },
+      "required": [
+        "kind",
+        "items",
+        "total_count"
+      ],
+      "title": "_VerifiedCollectionSchema",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/tago_bus_station_search.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Input for TAGO bus station search.",
+  "properties": {
+    "city_code": {
+      "description": "TAGO city code.",
+      "minLength": 1,
+      "title": "City Code",
+      "type": "string"
+    },
+    "node_nm": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Bus station name.",
+      "title": "Node Nm"
+    },
+    "node_no": {
+      "anyOf": [
+        {
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Bus station number.",
+      "title": "Node No"
+    },
+    "num_of_rows": {
+      "default": 10,
+      "description": "Rows per page.",
+      "maximum": 100,
+      "minimum": 1,
+      "title": "Num Of Rows",
+      "type": "integer"
+    },
+    "page_no": {
+      "default": 1,
+      "description": "Page number.",
+      "minimum": 1,
+      "title": "Page No",
+      "type": "integer"
+    }
+  },
+  "required": [
+    "city_code"
+  ],
+  "title": "tago_bus_station_search",
+  "type": "object"
+}

--- a/docs/api/verified-data-go-kr/README.md
+++ b/docs/api/verified-data-go-kr/README.md
@@ -1,0 +1,50 @@
+# Verified data.go.kr Adapter Wave
+
+Feature: `specs/2797-data-go-kr-verified-adapters`
+Epic: #2797
+
+This catalog page covers the first direct-curl verified public-data wave. Every
+adapter below is a live, read-only `find` adapter backed by a saved successful
+probe under `docs/api/data-go-kr-candidate-docs/<id>/probes/live-2026-05-16/`.
+The thirty newly scoped candidates in `SCOPED-NEW-30-manifest.json` are not
+included because they were still inside the post-application authorization
+window when this wave was implemented.
+
+## Included Adapters
+
+| data.go.kr ID | tool_id | Source | Primitive | Env var | Evidence |
+|---|---|---|---|---|---|
+| `15043459` | `fsc_corporate_finance_summary` | 금융위원회 기업 재무정보 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15043459/probes/live-2026-05-16/corporate-finance-summary.body.json` |
+| `15073861` | `airkorea_ctprvn_air_quality` | AirKorea 대기오염정보 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15073861/probes/live-2026-05-16/airkorea-ctprvn.body.json` |
+| `15091886` | `ftc_large_group_status` | 공정위 대규모기업집단 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15091886/probes/live-2026-05-16/ftc-large-group.body.xml` |
+| `15091910` | `ftc_public_ym_list` | 공정위 사용 가능 공개년월 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15091910/probes/live-2026-05-16/ftc-public-ym.body.xml` |
+| `15098529` | `tago_bus_route_search` | TAGO 버스노선정보 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15098529/probes/live-2026-05-16/tago-bus-route.body.xml` |
+| `15098530` | `tago_bus_arrival_search` | TAGO 버스도착정보 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15098530/probes/live-2026-05-16/tago-bus-arrival.body.xml` |
+| `15098533` | `tago_bus_location_search` | TAGO 버스위치정보 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15098533/probes/live-2026-05-16/tago-bus-location.body.xml` |
+| `15098534` | `tago_bus_station_search` | TAGO 버스정류소정보 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15098534/probes/live-2026-05-16/tago-bus-station.body.xml` |
+| `15101360` | `kepco_contract_power_usage` | 한국전력 계약종별 전력사용량 | `find` | `UMMAYA_KEPCO_POWER_DATA_API_KEY` | `15101360/probes/live-2026-05-16/kepco-contract-type.body.json` |
+| `15129394` | `pps_bid_public_info` | 조달청 나라장터 입찰공고정보 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15129394/probes/live-2026-05-16/pps-bid-service.body.json` |
+| `15134761` | `reb_real_estate_stat_table` | 한국부동산원 부동산통계 | `find` | `UMMAYA_REB_REAL_ESTATE_STATS_API_KEY` | `15134761/probes/live-2026-05-16/reb-stat-table.body.json` |
+| `15157485` | `bfc_funeral_area_fee` | 부산시설공단 장례비산출 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15157485/probes/live-2026-05-16/funeral-area-list.body.json` |
+| `15158680` | `kcue_finance_regional_tuition` | 대학알리미 재정 현황 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15158680/probes/live-2026-05-16/finance-regional-tuition.body.xml` |
+| `15158684` | `kcue_student_regional_foreign` | 대학정보공시 학생 현황 | `find` | `UMMAYA_DATA_GO_KR_API_KEY` | `15158684/probes/live-2026-05-16/student-regional-foreign.body.xml` |
+
+## Excluded From This Wave
+
+| Candidate set | Status | Handling |
+|---|---|---|
+| `SCOPED-NEW-30-manifest.json` | Applied less than two hours before implementation; service-key authorization unavailable. | Excluded from manifest and tests. Re-probe after authorization. |
+| `15081808` NTS business status | Endpoint contract known, approved-key probes still returned upstream `-5`. | Deferred as a future `check` adapter. |
+| `15000032` EMS submit/cancel | Real submit/cancel behavior with no sandbox evidence. | Deferred as a future `send` candidate; no live call. |
+| `15149906` MOJ stay-person counter | Gateway/backend returned 502 or redirect loop during direct curl. | Deferred until callable evidence exists. |
+| `15074634` MSIT announcement | Official endpoint returned gateway block responses. | Deferred until a working official sample is found. |
+
+## Runtime Contract
+
+- All adapters register as `GovAPITool` with `primitive="find"` and
+  `adapter_mode="live"`.
+- Default tests use fixture replay only; no live public API call is made in CI.
+- Direct runtime calls require the listed environment variables and route through
+  `ToolExecutor.invoke()` or the `find` meta-tool.
+- Parser output is normalized to `{"kind": "collection", "items": [...],
+  "total_count": N}` so it passes the existing `LookupCollection` envelope.

--- a/specs/2797-data-go-kr-verified-adapters/checklists/requirements.md
+++ b/specs/2797-data-go-kr-verified-adapters/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: data.go.kr Verified Adapter Wave
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-16  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Scope is intentionally limited to APIs in `LIVE-PROBE-RESULTS-2026-05-16.md` marked `Confirmed Callable`.
+- The 30 newly scoped candidates are explicitly deferred until their authorization window has passed and direct successful probes exist.

--- a/specs/2797-data-go-kr-verified-adapters/contracts/adapter-wave.md
+++ b/specs/2797-data-go-kr-verified-adapters/contracts/adapter-wave.md
@@ -1,0 +1,59 @@
+# Contract: Verified Adapter Wave
+
+## Scope
+
+This contract defines the adapter registration requirements for the first data.go.kr verified API wave.
+
+## Included Tool IDs
+
+| Tool ID | Source ID | Primitive | Credential Family | Evidence Body |
+|---------|-----------|-----------|-------------------|---------------|
+| `fsc_corporate_finance_summary` | `15043459` | `find` | `data_go_kr_service_key` | `corporate-finance-summary.body.json` |
+| `airkorea_ctprvn_air_quality` | `15073861` | `find` | `data_go_kr_service_key` | `airkorea-ctprvn.body.json` |
+| `ftc_large_group_status` | `15091886` | `find` | `data_go_kr_service_key` | `ftc-large-group.body.xml` |
+| `ftc_public_ym_list` | `15091910` | `find` | `data_go_kr_service_key` | `ftc-public-ym.body.xml` |
+| `tago_bus_route_search` | `15098529` | `find` | `data_go_kr_service_key` | `tago-bus-route.body.xml` |
+| `tago_bus_arrival_search` | `15098530` | `find` | `data_go_kr_service_key` | `tago-bus-arrival.body.xml` |
+| `tago_bus_location_search` | `15098533` | `find` | `data_go_kr_service_key` | `tago-bus-location.body.xml` |
+| `tago_bus_station_search` | `15098534` | `find` | `data_go_kr_service_key` | `tago-bus-station.body.xml` |
+| `kepco_contract_power_usage` | `15101360` | `find` | `kepco_power_data_key` | `kepco-contract-type.body.json` |
+| `pps_bid_public_info` | `15129394` | `find` | `data_go_kr_service_key` | `pps-bid-service.body.json` |
+| `reb_real_estate_stat_table` | `15134761` | `find` | `reb_r_one_key` | `reb-stat-table.body.json` |
+| `bfc_funeral_area_fee` | `15157485` | `find` | `data_go_kr_service_key` | `funeral-area-list.body.json` |
+| `kcue_finance_regional_tuition` | `15158680` | `find` | `data_go_kr_service_key` | `finance-regional-tuition.body.xml` |
+| `kcue_student_regional_foreign` | `15158684` | `find` | `data_go_kr_service_key` | `student-regional-foreign.body.xml` |
+
+## Registration Requirements
+
+Each included adapter MUST:
+
+- Register a distinct `GovAPITool` with `primitive="find"`.
+- Use `adapter_mode="live"`.
+- Use `auth_type="api_key"`.
+- Use a Pydantic v2 input schema with `extra="forbid"`.
+- Use a Pydantic v2 output schema that does not contain `Any`.
+- Provide bilingual `search_hint` text.
+- Provide `trigger_examples` with citizen-facing Korean examples.
+- Provide an `AdapterRealDomainPolicy` citation with `citizen_facing_gate="read-only"`.
+- Bind an async executor adapter in `register(registry, executor)`.
+
+## Exclusion Requirements
+
+The implementation MUST NOT:
+
+- Register any tool ID from `SCOPED-NEW-30-manifest.json`.
+- Register any `Reachable But Not Yet Callable` API as a live adapter.
+- Register any `Not Live-Probed` API as a live adapter.
+- Add a new root primitive.
+- Add a side-effecting `send` adapter in this wave.
+- Add a `check` adapter in this wave.
+
+## Registry Smoke Contract
+
+After `register_all_tools(registry, executor)`:
+
+- All 14 included tool IDs are present in the registry.
+- All 14 included tool IDs are present in `executor._adapters`.
+- Each included adapter has `primitive == "find"`.
+- No included adapter is `is_core=True`.
+- `lookup/search` can surface a representative included adapter from its Korean citizen query terms.

--- a/specs/2797-data-go-kr-verified-adapters/contracts/fixture-contract.md
+++ b/specs/2797-data-go-kr-verified-adapters/contracts/fixture-contract.md
@@ -1,0 +1,89 @@
+# Contract: Fixture Replay and Parser Behavior
+
+## Scope
+
+This contract defines how verified adapter fixtures are used in tests and how adapters normalize upstream responses.
+
+## Fixture Sources
+
+Successful fixture bodies come from:
+
+```text
+docs/api/data-go-kr-candidate-docs/<id>/probes/live-2026-05-16/*.body.json
+docs/api/data-go-kr-candidate-docs/<id>/probes/live-2026-05-16/*.body.xml
+```
+
+Successful fixture headers come from matching `*.headers.txt` files.
+
+## Default Test Rule
+
+Default tests MUST read fixture files from disk and MUST NOT call live upstream APIs.
+
+Allowed:
+
+- Unit tests for JSON parsing.
+- Unit tests for XML parsing.
+- Unit tests for result-code error extraction.
+- Unit tests for adapter registration and executor binding.
+- Integration tests that call adapter functions with fixture-injected clients.
+
+Forbidden in default tests:
+
+- Network calls to `apis.data.go.kr`.
+- Network calls to `bigdata.kepco.co.kr`.
+- Network calls to `www.reb.or.kr`.
+- Network calls to TAGO, AirKorea, FTC, PPS, KCUE, or Busan Facilities endpoints.
+
+## Parser Output Contract
+
+Every parser returns:
+
+```json
+{
+  "kind": "collection",
+  "items": [
+    {
+      "record": {
+        "officialFieldName": "official value"
+      }
+    }
+  ],
+  "total_count": 1
+}
+```
+
+Rules:
+
+- `kind` is always `collection` for successful adapter outputs in this wave.
+- `items` is an array, even when the upstream returns a single object.
+- `total_count` comes from upstream metadata when available; otherwise it equals `len(items)`.
+- Official upstream field names are preserved inside `record`.
+- API keys, request URLs with keys, and secret headers are never included in output.
+
+## Error Contract
+
+When an upstream response carries an error code or malformed body:
+
+- The adapter raises a tool-domain exception.
+- The executor converts it into the standard `LookupError` envelope.
+- The error message includes sanitized upstream result code and message where available.
+- The LLM-facing failure message tells the model not to fabricate results.
+
+## XML Rules
+
+XML parser behavior:
+
+- Ignore XML namespaces for simple public-data records.
+- Normalize repeated `item` elements into multiple records.
+- Normalize single `item` objects into a one-record list.
+- Read `resultCode` and `resultMsg` or agency-specific equivalents when present.
+- Treat `00`, `0`, `NORMAL SERVICE.`, `NORMAL_CODE`, `SUCCESS`, and provider-specific normal codes documented by fixtures as success.
+
+## JSON Rules
+
+JSON parser behavior:
+
+- Support common data.go.kr shapes such as `response.header`, `response.body.items.item`.
+- Support provider shapes where records are under `data`, `result`, `items`, or top-level arrays.
+- Normalize zero-result shapes into an empty `items` list with success.
+- Treat service-key or quota error objects as upstream errors.

--- a/specs/2797-data-go-kr-verified-adapters/data-model.md
+++ b/specs/2797-data-go-kr-verified-adapters/data-model.md
@@ -1,0 +1,158 @@
+# Data Model: data.go.kr Verified Adapter Wave
+
+## Verified API Candidate
+
+Represents one directly proven public-service API operation or operation family allowed into this wave.
+
+Fields:
+
+- `data_go_kr_id`: official data.go.kr ID where applicable.
+- `tool_id`: stable snake_case UMMAYA adapter ID.
+- `api_name_ko`: Korean official or portal-visible API name.
+- `institution`: owning agency or provider.
+- `primitive`: always `find` for this wave.
+- `endpoint`: official endpoint URL or provider endpoint for `LINK` APIs.
+- `credential_family`: `data_go_kr_service_key`, `kepco_power_data_key`, or `reb_r_one_key`.
+- `evidence_body_path`: saved successful direct-call response body.
+- `evidence_header_path`: saved successful direct-call response headers.
+- `response_format`: `json` or `xml`.
+- `citizen_domain`: citizen-facing topic label.
+
+Validation rules:
+
+- `primitive` must equal `find`.
+- `evidence_body_path` must point to an existing saved direct successful probe body.
+- `credential_family` must match the source endpoint family.
+- APIs from `SCOPED-NEW-30-manifest.json` are invalid for this wave.
+
+## Adapter Registration
+
+Represents the ToolRegistry entry for one verified adapter.
+
+Fields:
+
+- `id`: stable snake_case `tool_id`.
+- `name_ko`: Korean display name.
+- `ministry`: existing `Ministry` enum value, using `OTHER` only when no precise enum exists yet.
+- `category`: non-empty topic tags.
+- `endpoint`: official endpoint.
+- `auth_type`: `api_key`.
+- `input_schema`: Pydantic v2 request model.
+- `output_schema`: Pydantic v2 response model.
+- `search_hint`: bilingual Korean/English discovery text.
+- `policy`: agency/portal citation with `citizen_facing_gate="read-only"`.
+- `adapter_mode`: `live`.
+- `primitive`: `find`.
+
+Validation rules:
+
+- No registered adapter may omit `primitive`.
+- No registered adapter may use a root primitive outside `find`, `locate`, `send`, `check`.
+- No registered adapter from this wave may require session identity for default read-only execution.
+- No registered adapter may cite UMMAYA-invented permission classes as its policy source.
+
+## Verified Public Data Input
+
+Represents one adapter-specific Pydantic input model.
+
+Shared fields where applicable:
+
+- `page_no`: 1-indexed page number, bounded by the official API contract.
+- `num_of_rows`: page size, bounded by the official API contract.
+- Format selectors such as `result_type`, `return_type`, or `type` are fixed by the adapter when the evidence proves one reliable format.
+
+Adapter-specific fields:
+
+- FSC finance: `crno`, `biz_year`.
+- AirKorea: `sido_name`, optional `ver`.
+- FTC large group: `presentn_year`.
+- FTC public year/month: `job_se_code`, `presentn_year`.
+- TAGO route: `city_code`, `route_no`.
+- TAGO arrival: `city_code`, `node_id`.
+- TAGO bus location: `city_code`, `route_id`.
+- TAGO station: `city_code`, optional `node_name`, optional `node_no`.
+- KEPCO power usage: `year`, `month`, optional `metro_cd`, optional `city_cd`, optional `cntr_cd`.
+- PPS bid: `inqry_div`, `bid_ntce_no`.
+- REB stats table: optional `statbl_id`, `page_index`, `page_size`.
+- BFC funeral cost: `page_no`, `num_of_rows`.
+- KCUE finance: `schl_div_cd`.
+- KCUE student: `schl_div_cd`.
+
+Validation rules:
+
+- Required fields must match official probe/contract names semantically, while Python model fields use snake_case.
+- Adapter code maps snake_case fields to official wire params.
+- Models use `extra="forbid"` to reject accidental unsupported params.
+
+## Verified Public Data Output
+
+Represents normalized adapter output before `find` envelope normalization.
+
+Fields:
+
+- `kind`: `collection`.
+- `items`: list of typed public-data records.
+- `total_count`: total upstream count if available, otherwise item count.
+
+## Verified Public Data Item
+
+Represents one heterogeneous public API record.
+
+Fields:
+
+- `record`: map from official field names to typed JSON-like values.
+
+Allowed value types:
+
+- string
+- integer
+- float
+- boolean
+- null
+- list of allowed values
+- map of string to allowed values
+
+Validation rules:
+
+- No `Any` appears in the public output schema.
+- Empty strings are preserved when they come from official data.
+- Secrets and service keys are never included.
+
+## Fixture Set
+
+Represents recorded payloads used by tests.
+
+Fields:
+
+- `success_body`: response body for a successful upstream call.
+- `success_headers`: response headers for a successful upstream call.
+- `zero_result_body`: optional successful zero-result body.
+- `error_body`: upstream error body.
+- `format`: `json` or `xml`.
+
+Validation rules:
+
+- Default tests may read fixtures only.
+- Fixtures must not contain API keys, citizen identifiers, or secret headers.
+- Error fixtures must preserve upstream result code and sanitized message.
+
+## State Transitions
+
+```text
+candidate documented
+  -> direct successful probe saved
+  -> included in spec
+  -> adapter registration authored
+  -> fixture replay tests pass
+  -> routing/search smoke passes
+  -> UMMAYA real-use smoke passes
+```
+
+Deferred candidates remain:
+
+```text
+candidate documented
+  -> blocked / unauthorized / unsafe / no successful probe
+  -> deferred tracking issue
+  -> future Spec Kit cycle after evidence changes
+```

--- a/specs/2797-data-go-kr-verified-adapters/dispatch-tree.md
+++ b/specs/2797-data-go-kr-verified-adapters/dispatch-tree.md
@@ -1,0 +1,22 @@
+# Dispatch Tree: data.go.kr Verified Adapter Wave
+
+Feature: `2797-data-go-kr-verified-adapters`
+Epic: #2797
+
+## Execution Mode
+
+Lead solo. The user instructed autonomous continuation without approval gates, and the current implementation slice is tightly coupled through one shared helper package plus one central registration point.
+
+## Task Map
+
+- Phase 1 Setup: T001-T004
+- Phase 2 Tests First: T005-T007, T012-T013, T018-T019, T023
+- Phase 3 Core Helper: T008-T011, T020-T024
+- Phase 4 Adapter Wave: T014-T017
+- Phase 5 Documentation/Schema: T025-T026
+- Phase 6 Verification: T027-T032
+- Phase 7 Bookkeeping: T033
+
+## Parallel-Safe Notes
+
+T016 contains thirteen independent adapter wrappers, but they share the manifest, parsing helper, registration helper, and schema generation flow. They are kept in one Lead-owned patch to avoid contradictory public contracts across modules.

--- a/specs/2797-data-go-kr-verified-adapters/plan.md
+++ b/specs/2797-data-go-kr-verified-adapters/plan.md
@@ -1,0 +1,126 @@
+# Implementation Plan: data.go.kr Verified Adapter Wave
+
+**Branch**: `feat/data-go-kr-verified-adapters` | **Date**: 2026-05-16 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `/Users/um-yunsang/UMMAYA/specs/2797-data-go-kr-verified-adapters/spec.md`
+
+## Summary
+
+Wrap only the APIs marked `Confirmed Callable` in `docs/api/data-go-kr-candidate-docs/LIVE-PROBE-RESULTS-2026-05-16.md` as first-class UMMAYA `find` adapters. The 30 newly scoped candidates are explicitly deferred because their service applications are still within the two-hour authorization window and lack direct successful curl evidence.
+
+The implementation will add one shared verified-API helper layer for response parsing, fixture replay, error normalization, and envelope output, then register one thin adapter module per verified agency API family. This preserves UMMAYA's rule that each callable agency module appears as a separate ToolRegistry adapter while avoiding 14 copies of XML/JSON parsing logic.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+  
+**Primary Dependencies**: Existing `httpx`, Pydantic v2, stdlib `xml.etree.ElementTree`, stdlib `json`; no new dependency  
+**Storage**: Recorded fixture files and docs artifacts only; no database  
+**Testing**: `uv run pytest` with fixture-only default tests; live tests remain opt-in and skipped by default  
+**Target Platform**: UMMAYA Python backend plus existing TUI/stdout primitive dispatch  
+**Project Type**: CLI/backend tool-adapter feature inside existing repository  
+**Performance Goals**: Adapter discovery stays bounded by the existing BM25/routing index; fixture parsing for each adapter completes within ordinary unit-test time.  
+**Constraints**: No live citizen-infrastructure API calls in CI; no hardcoded API keys; Pydantic v2 I/O only; no `Any` in new tool I/O schemas; stdlib logging only; English source text except Korean domain data.  
+**Scale/Scope**: 14 verified read-only adapters, grouped internally by agency where useful but registered as individual tool IDs.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Gate Result | Evidence |
+|-----------|-------------|----------|
+| I. Reference-Driven Development | PASS | Research maps Tool System decisions to `docs/vision.md`, `.references/claude-code-sourcemap/restored-src/src/Tool.ts`, `MCPTool.ts`, and existing UMMAYA adapter modules. |
+| II. Fail-Closed Security | PASS | Only direct-success read-only APIs are included. Deferred APIs remain unregistered. Adapter policy citations are agency/portal citations, not UMMAYA-invented classes. |
+| III. Pydantic v2 Strict Typing | PASS | Plan requires explicit input/output models and a typed generic public-data item model for heterogeneous records; new I/O schemas must avoid `Any`. |
+| IV. Government API Compliance | PASS | Default tests use fixtures only. Credentials remain `UMMAYA_` env vars. Live calls are manual/local only. |
+| V. Policy Alignment | PASS | Feature extends official Open API access through the citizen-facing `find` surface without adding side-effecting actions. |
+| VI. Deferred Work Accountability | PASS | Spec contains explicit deferred rows for 30 pending candidates and other blocked APIs; `/speckit-taskstoissues` will create/attach tracking issues. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2797-data-go-kr-verified-adapters/
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   ├── adapter-wave.md
+│   └── fixture-contract.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/ummaya/tools/
+├── verified_data_go_kr/
+│   ├── __init__.py
+│   ├── _client.py
+│   ├── _models.py
+│   ├── _parsing.py
+│   ├── airkorea_air_quality.py
+│   ├── bfc_funeral_cost.py
+│   ├── fsc_corporate_finance.py
+│   ├── ftc_large_group.py
+│   ├── ftc_public_ym.py
+│   ├── kcue_finance_status.py
+│   ├── kcue_student_status.py
+│   ├── kepco_power_usage.py
+│   ├── pps_bid_public_info.py
+│   ├── reb_real_estate_stats.py
+│   ├── tago_bus_arrival.py
+│   ├── tago_bus_location.py
+│   ├── tago_bus_route.py
+│   └── tago_bus_station.py
+└── register_all.py
+
+tests/tools/verified_data_go_kr/
+├── fixtures/
+├── test_adapter_registration.py
+├── test_adapter_fixture_replay.py
+├── test_error_parsing.py
+└── test_no_scoped_new_30_registration.py
+
+docs/api/
+├── data-go-kr-candidate-docs/
+└── verified-data-go-kr/
+```
+
+**Structure Decision**: Use a new `verified_data_go_kr` package because the first wave crosses multiple ministries but shares the same evidence-gated adapter mechanics. This avoids placing unrelated agencies under one ministry folder while preserving individual `tool_id` registration and avoiding a generic LLM-visible catch-all adapter.
+
+## Phase 0 Research Output
+
+Research is captured in [research.md](./research.md). Key decisions:
+
+- All 14 included APIs map to `find`; no `locate`, `send`, or `check` adapter ships in this wave.
+- Use a typed common response model with flexible item records rather than hand-writing 14 unrelated full output models.
+- Implement provider-key `LINK` APIs (`15101360`, `15134761`) with separate credential env vars.
+- Default tests replay saved fixtures only.
+- Defer 30 pending candidates and all blocked/reachable-only APIs.
+
+## Phase 1 Design Output
+
+Design artifacts:
+
+- [data-model.md](./data-model.md)
+- [contracts/adapter-wave.md](./contracts/adapter-wave.md)
+- [contracts/fixture-contract.md](./contracts/fixture-contract.md)
+- [quickstart.md](./quickstart.md)
+
+## Post-Design Constitution Check
+
+| Principle | Gate Result | Notes |
+|-----------|-------------|-------|
+| I. Reference-Driven Development | PASS | Each design decision in research has a reference entry. |
+| II. Fail-Closed Security | PASS | Unauthorized and blocked APIs are not registered. |
+| III. Pydantic v2 Strict Typing | PASS | Contracts require Pydantic models and no `Any` in I/O schemas. |
+| IV. Government API Compliance | PASS | Fixture-only default tests are required. |
+| V. Policy Alignment | PASS | Adapters only expose read-only public-service lookups. |
+| VI. Deferred Work Accountability | PASS | Deferred rows remain explicit for `/speckit-taskstoissues`. |
+
+## Complexity Tracking
+
+No constitution violations are introduced.

--- a/specs/2797-data-go-kr-verified-adapters/quickstart.md
+++ b/specs/2797-data-go-kr-verified-adapters/quickstart.md
@@ -1,0 +1,92 @@
+# Quickstart: data.go.kr Verified Adapter Wave
+
+## 1. Verify Scope
+
+```bash
+rg -n "Confirmed Callable|Reachable But Not Yet Callable|Not Live-Probed" \
+  docs/api/data-go-kr-candidate-docs/LIVE-PROBE-RESULTS-2026-05-16.md
+```
+
+Only rows under `Confirmed Callable` are in scope.
+
+## 2. Verify Registered Adapters
+
+```bash
+uv run pytest tests/tools/verified_data_go_kr/test_adapter_registration.py
+```
+
+Expected:
+
+- 14 verified adapters are registered.
+- All 14 use `primitive="find"`.
+- No adapter from `SCOPED-NEW-30-manifest.json` is registered.
+
+## 3. Replay Fixtures
+
+```bash
+uv run pytest tests/tools/verified_data_go_kr/test_adapter_fixture_replay.py
+```
+
+Expected:
+
+- JSON and XML fixtures parse into `kind="collection"` outputs.
+- Zero-result fixtures stay successful.
+- Error fixtures become fail-closed error envelopes.
+
+## 4. Run Focused Registry Tests
+
+```bash
+uv run pytest tests/tools/test_registration.py tests/tools/test_routing_index.py
+```
+
+Expected:
+
+- Tool count updates to include the 14 new verified adapters.
+- Routing index validation passes.
+
+## 5. Run Backend Verification
+
+```bash
+uv run ruff check src tests
+uv run ruff format --check src tests
+uv run mypy src
+uv run pytest -m "not live"
+```
+
+Expected:
+
+- No lint, type, or fixture-replay failures.
+- No live public API calls in the default test set.
+
+## 6. Run UMMAYA Real-Use Smoke
+
+Use local credentials only outside CI. The initial smoke should use a verified small read-only API such as 부산 장례비산출 or AirKorea.
+
+```bash
+UMMAYA_LIVE_ADAPTER_MODE=direct uv run ummaya
+```
+
+Citizen prompts to verify:
+
+```text
+부산 영락공원 장례식장 시설 사용료를 찾아줘
+서울 대기오염 측정소별 실시간 정보를 조회해줘
+대전 5번 버스 노선 정보를 찾아줘
+```
+
+Expected:
+
+- UMMAYA searches and calls the matching `find` adapter.
+- Tool result is grounded in the adapter output.
+- No fabricated fallback result appears after an adapter error.
+- Permission flow stays read-only and does not request identity for public data.
+
+## 7. PR Evidence
+
+PR description must include:
+
+- Spec path.
+- List of 14 included verified APIs.
+- Fixture-only test command output.
+- UMMAYA real-use smoke summary.
+- `TUI no-change` unless `tui/src/**` is modified.

--- a/specs/2797-data-go-kr-verified-adapters/real-use-smoke.md
+++ b/specs/2797-data-go-kr-verified-adapters/real-use-smoke.md
@@ -1,4 +1,4 @@
-# Real-Use Smoke: data.go.kr Verified Adapter Wave
+# Real Terminal Verification: data.go.kr Verified Adapter Wave
 
 Date: 2026-05-16 KST
 Mode: `UMMAYA_LIVE_ADAPTER_MODE=direct`
@@ -35,6 +35,41 @@ after `register_all_tools()` populated the UMMAYA registry.
 
 The two TAGO zero-result calls matched the live-probe evidence shape and are
 normal successful empty collections, not errors.
+
+## Interactive `ummaya` Terminal Run
+
+Command:
+
+```bash
+UMMAYA_LIVE_ADAPTER_MODE=direct UMMAYA_K_EXAONE_THINKING=false uv run ummaya
+```
+
+Prompt typed into the live terminal:
+
+```text
+부산광역시 장례식장 시설 사용료 목록을 공공 API 도구로 조회해서 알려줘.
+```
+
+Final clean run result:
+
+- UMMAYA booted into the interactive REPL and accepted the prompt from the terminal.
+- The LLM selected the public-data primitive path and emitted a single tool call.
+- The visible terminal tool panel rendered `도구 결과` with `성공  tool_id='find'`.
+- The selected adapter was `bfc_funeral_area_fee`.
+- The final answer was grounded in the observed tool result and listed four returned fee rows:
+  `부산, 울산 및 경남`, `그 외 지역`, `지역 주민 (남산동, 청룡노포동, 선두구동)`,
+  and `국가보훈기본법에 따른 희생·공헌자`.
+- No `도구 오류`, traceback, schema mismatch, fabricated fallback, or retry prompt appeared.
+
+Observed abnormal flows during the real terminal run and fixes applied before
+the final clean run:
+
+| Observed terminal failure | Root cause | Fix |
+|---|---|---|
+| FriendliAI HTTP 422 rejected `function.trigger_phrase`. | Raw registry tool dicts carried UMMAYA-only metadata into the provider payload. | Normalize every raw tool dict through `ToolDefinition.model_validate(...).model_dump()` before sending. |
+| `find` / `locate` root primitive calls failed with `No adapter registered for tool`. | The Rich REPL path dispatched root primitive names directly instead of fanning out to the selected adapter id. | Add root primitive fan-out in `dispatch_tool_calls()` using the primitive input schema, then invoke the selected adapter. |
+| Tool-result follow-up crashed with `Object of type datetime is not JSON serializable`. | Primitive facade output used Python-mode Pydantic dumps, leaving `datetime` values in `ToolResult.data`. | Dump primitive facade outputs with `model_dump(mode="json")`, matching IPC/session wire patterns. |
+| The model called `locate` before a location-independent public-data `find` request. | Rich REPL exposed all root primitives even after BM25 selected a `find` adapter whose schema did not need coordinates or admin codes. | Add dynamic adapter context and a per-turn provider tool allow-list so this request exposes only `find`. |
 
 ## Primitive Path
 

--- a/specs/2797-data-go-kr-verified-adapters/real-use-smoke.md
+++ b/specs/2797-data-go-kr-verified-adapters/real-use-smoke.md
@@ -1,0 +1,49 @@
+# Real-Use Smoke: data.go.kr Verified Adapter Wave
+
+Date: 2026-05-16 KST
+Mode: `UMMAYA_LIVE_ADAPTER_MODE=direct`
+Entrypoint smoke: `uv run ummaya --version` returned `ummaya 0.1.9`.
+
+Secrets were loaded from local `.env` and were not printed. Required env vars
+were present:
+
+- `UMMAYA_DATA_GO_KR_API_KEY`
+- `UMMAYA_KEPCO_POWER_DATA_API_KEY`
+- `UMMAYA_REB_REAL_ESTATE_STATS_API_KEY`
+
+## Direct Adapter Calls
+
+All fourteen read-only live adapters were invoked through `ToolExecutor.invoke()`
+after `register_all_tools()` populated the UMMAYA registry.
+
+| tool_id | Result |
+|---|---|
+| `fsc_corporate_finance_summary` | `collection`, `items=1`, `total_count=2` |
+| `airkorea_ctprvn_air_quality` | `collection`, `items=5`, `total_count=40` |
+| `ftc_large_group_status` | `collection`, `items=10`, `total_count=71` |
+| `ftc_public_ym_list` | `collection`, `items=1`, `total_count=1` |
+| `tago_bus_route_search` | `collection`, `items=10`, `total_count=17` |
+| `tago_bus_arrival_search` | `collection`, `items=0`, `total_count=0` |
+| `tago_bus_location_search` | `collection`, `items=0`, `total_count=0` |
+| `tago_bus_station_search` | `collection`, `items=1`, `total_count=1` |
+| `kepco_contract_power_usage` | `collection`, `items=1`, `total_count=1` |
+| `pps_bid_public_info` | `collection`, `items=1`, `total_count=1` |
+| `reb_real_estate_stat_table` | `collection`, `items=5`, `total_count=738` |
+| `bfc_funeral_area_fee` | `collection`, `items=4`, `total_count=4` |
+| `kcue_finance_regional_tuition` | `collection`, `items=5`, `total_count=20` |
+| `kcue_student_regional_foreign` | `collection`, `items=5`, `total_count=20` |
+
+The two TAGO zero-result calls matched the live-probe evidence shape and are
+normal successful empty collections, not errors.
+
+## Primitive Path
+
+The LLM-facing primitive path was exercised through `lookup()`:
+
+1. `find(mode="search", query="부산 장례식장 시설사용료", top_k=5)` returned
+   `bfc_funeral_area_fee` as the top candidate.
+2. `find(mode="fetch", tool_id="bfc_funeral_area_fee", params={...})` returned
+   `LookupCollection(source="bfc_funeral_area_fee", items=4, total_count=4)`.
+
+No adapter returned `LookupError`, no schema normalization error occurred, and
+no permission gate blocked the read-only flows.

--- a/specs/2797-data-go-kr-verified-adapters/research.md
+++ b/specs/2797-data-go-kr-verified-adapters/research.md
@@ -1,0 +1,113 @@
+# Research: data.go.kr Verified Adapter Wave
+
+## Reference Bootstrap
+
+- UMMAYA thesis/docs:
+  - `docs/vision.md` § Reference materials and Layer 2 Tool System.
+  - `docs/requirements/ummaya-migration-tree.md` L1-B and L1-C.
+  - `docs/onboarding/five-primitive-harness.md` active primitive guidance.
+  - `docs/api/README.md` adapter catalog and fixture-first testing conventions.
+- CC restored-src files:
+  - `.references/claude-code-sourcemap/restored-src/src/Tool.ts`
+  - `.references/claude-code-sourcemap/restored-src/src/tools/MCPTool/MCPTool.ts`
+  - `.references/claude-code-sourcemap/restored-src/src/tools/ToolSearchTool/ToolSearchTool.ts`
+  - `.references/claude-code-sourcemap/restored-src/src/tools/GrepTool/GrepTool.ts`
+- Adapter/API sources:
+  - `docs/api/data-go-kr-candidate-docs/LIVE-PROBE-RESULTS-2026-05-16.md`
+  - `docs/api/data-go-kr-candidate-docs/P0-P1-WRAPPING-NOTES.md`
+  - `docs/api/data-go-kr-candidate-docs/P2-WRAPPING-NOTES.md`
+  - `docs/api/data-go-kr-candidate-docs/SCOPED-NEW-30-manifest.json`
+  - Per-candidate `data-go-kr-inline-swagger.json`, provider guides, and saved probe artifacts.
+- External primary sources:
+  - Official data.go.kr detail pages captured under `docs/api/data-go-kr-candidate-docs/<id>/data-go-kr-detail.html`.
+  - KEPCO and REB provider portal pages captured under their candidate folders for `LINK` APIs.
+- Implementation constraints:
+  - No default CI live calls.
+  - No new dependency.
+  - New adapter I/O schemas must use Pydantic v2 and avoid `Any`.
+  - Permission policy must cite agency/portal source text.
+- Unknowns or blocked evidence:
+  - 30 newly scoped candidates are not authorized yet and are out of scope.
+  - APIs in `Reachable But Not Yet Callable` and `Not Live-Probed` are out of scope.
+
+## Deferred Item Validation
+
+The spec contains a complete `Scope Boundaries & Deferred Items` section. All `NEEDS TRACKING` rows are intentional and will be resolved through `/speckit-taskstoissues` before implementation tasks are treated as fully issue-backed.
+
+No unregistered deferral language was found outside the deferred-items table after the spec was generated.
+
+## Decision: Map all included APIs to `find`
+
+**Decision**: The 14 `Confirmed Callable` APIs in the live probe report are registered under the active `find` primitive.
+
+**Rationale**: Their observed operations are read-only lookup/statistics/catalog calls. They do not resolve addresses into administrative codes, mutate agency state, or verify an identity/status assertion. UMMAYA's active primitive harness keeps domain specialization in adapters while exposing only `find`, `locate`, `send`, and `check` to the LLM.
+
+**Alternatives considered**:
+
+- `locate`: rejected because bus station, facility, and public-data records may contain addresses or coordinates but do not perform address/coordinate resolution.
+- `send`: rejected because no included API creates, submits, pays, cancels, or signs anything.
+- `check`: rejected because the included set excludes the NTS business-status API; aggregate public statistics are not identity/status verification.
+
+## Decision: Use one shared verified-API helper package plus individual adapter modules
+
+**Decision**: Add `src/ummaya/tools/verified_data_go_kr/` with shared request, parser, fixture, and output helpers, and keep one module per registered adapter.
+
+**Rationale**: The wave crosses several agencies but repeats the same concerns: API-key params, XML/JSON normalization, result-code extraction, fixture replay, and `find` envelope output. A shared helper prevents 14 copies of fragile parsing code while each adapter still has its own `tool_id`, input schema, search hints, policy citation, and registration.
+
+**Alternatives considered**:
+
+- A single generic LLM-visible adapter: rejected because it would hide the agency module boundaries from ToolRegistry and weaken BM25 discovery.
+- Full bespoke parser per API: rejected because it duplicates error handling and creates inconsistent envelope behavior.
+
+## Decision: Use typed flexible public-data records for heterogeneous responses
+
+**Decision**: Use a common Pydantic output model with `VerifiedPublicDataItem` records whose values are constrained to JSON-like scalar/list/map unions instead of `Any`.
+
+**Rationale**: The verified APIs expose unrelated fields: finance summaries, air-quality stations, FTC groups, bus records, REB statistics, university statistics, and funeral fee rows. The user value is reliable tool-call wrapping and source-grounded record delivery, not immediate domain-specific analytics. A typed flexible record keeps strict Pydantic v2 boundaries without inventing lossy common fields.
+
+**Alternatives considered**:
+
+- Full field-by-field output model for each API: deferred because it would make the first wave too large before real-use smoke proves the tool-call flow.
+- `dict[str, Any]`: rejected by constitution and AGENTS.md strict typing rules.
+
+## Decision: Provider-key `LINK` APIs keep separate credential families
+
+**Decision**: `15101360` KEPCO and `15134761` REB use provider-specific credential env vars instead of `UMMAYA_DATA_GO_KR_API_KEY`.
+
+**Rationale**: The intake notes and live probe report identify these as provider endpoints with separate keys. Treating them as data.go.kr service-key calls would make live invocation fail and obscure root cause during debugging.
+
+**Alternatives considered**:
+
+- Route through the shared data.go.kr key: rejected because it contradicts the saved evidence.
+- Defer all `LINK` APIs: rejected because direct successful probes already exist.
+
+## Decision: Default tests replay fixtures only
+
+**Decision**: CI/default pytest uses recorded fixtures and parser/registration tests; live contract probes are excluded unless marked live and explicitly requested.
+
+**Rationale**: The constitution and AGENTS.md forbid live government/citizen-infrastructure calls in default CI. Saved body/header artifacts are sufficient to prove parser and envelope behavior.
+
+**Alternatives considered**:
+
+- Re-probe during tests: rejected by project rule.
+- Skip parser fixture tests: rejected because response-shape regressions would reach the LLM surface.
+
+## Decision: First-wave grouping
+
+**Decision**: Implement the 14 adapters as thin modules, with related modules allowed to share local constants:
+
+| Group | Adapters |
+|-------|----------|
+| finance/corporate | `fsc_corporate_finance`, `kepco_power_usage`, `reb_real_estate_stats` |
+| environment/safety | `airkorea_air_quality` |
+| public administration | `ftc_large_group`, `ftc_public_ym`, `pps_bid_public_info` |
+| transportation | `tago_bus_route`, `tago_bus_arrival`, `tago_bus_location`, `tago_bus_station` |
+| welfare/civic cost | `bfc_funeral_cost` |
+| education | `kcue_finance_status`, `kcue_student_status` |
+
+**Rationale**: These groups mirror agency/domain boundaries while keeping task slices manageable.
+
+**Alternatives considered**:
+
+- Implement only the smallest adapter first: rejected because the user requested proceeding through the verified APIs before PR.
+- Implement all as one file: rejected because it would make ownership, testing, and future deprecation harder.

--- a/specs/2797-data-go-kr-verified-adapters/spec.md
+++ b/specs/2797-data-go-kr-verified-adapters/spec.md
@@ -1,0 +1,150 @@
+# Feature Specification: data.go.kr Verified Adapter Wave
+
+**Feature Branch**: `feat/data-go-kr-verified-adapters`  
+**Created**: 2026-05-16  
+**Status**: Draft  
+**Input**: User description: "Wrap the data.go.kr APIs that have already passed direct real-use curl verification first. The 30 newly scoped candidates are excluded for now because their applications are still within the two-hour approval window."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Discover Verified Public Service Adapters (Priority: P1)
+
+A citizen asks UMMAYA about a public-service domain covered by a directly verified API, and the system surfaces only adapters whose upstream endpoint, credential path, request parameters, and response shape have already been proven by saved curl evidence.
+
+**Why this priority**: It prevents unverified candidate APIs from entering the tool-call surface while preserving UMMAYA's thesis that one official callable agency module becomes one registered tool adapter.
+
+**Independent Test**: Can be fully tested by searching for each verified domain and confirming the routing surface returns only adapters backed by `LIVE-PROBE-RESULTS-2026-05-16.md` evidence.
+
+**Acceptance Scenarios**:
+
+1. **Given** a citizen asks for 부산 장례 비용 information, **When** UMMAYA searches available tools, **Then** it returns a 부산시설공단 장례비산출 `find` adapter backed by the saved `15157485` live probe.
+2. **Given** a citizen asks for a domain from the 30 newly scoped but not-yet-authorized candidates, **When** UMMAYA searches available tools, **Then** no live adapter from that unauthorized set is registered in this feature.
+3. **Given** an API was reachable but not callable in the probe report, **When** UMMAYA builds the adapter catalog, **Then** that API is documented as deferred and is not exposed as a callable adapter.
+
+---
+
+### User Story 2 - Fetch Read-Only Public Data Through `find` (Priority: P1)
+
+A citizen asks for public read-only information from a verified API, and UMMAYA calls the matching `find` adapter without mutating agency state or requiring citizen identity proof beyond the agency's API-key access requirement.
+
+**Why this priority**: All APIs in the first verified wave are read-only lookup/statistics/catalog APIs. They should enter the existing `find` primitive rather than reintroducing domain-specific verbs.
+
+**Independent Test**: Can be fully tested by replaying recorded successful and error response fixtures for each included adapter without making live API calls in CI.
+
+**Acceptance Scenarios**:
+
+1. **Given** a verified API returns HTTP 200 with a normal service code in saved evidence, **When** its adapter receives valid search parameters, **Then** the adapter returns a normalized result envelope with source, query, result count, and item records.
+2. **Given** the upstream returns a valid zero-result response, **When** the adapter receives parameters that match that response, **Then** the adapter returns an empty successful result rather than an error.
+3. **Given** the upstream returns an authentication or service error shape, **When** the adapter parses the fixture, **Then** the adapter returns a fail-closed tool error with the upstream result code and sanitized reason.
+
+---
+
+### User Story 3 - Maintain Evidence-Gated Scope (Priority: P2)
+
+A maintainer reviews the adapter wave and can trace every included API to a saved direct-call artifact, while excluded APIs have a concrete deferral reason.
+
+**Why this priority**: UMMAYA's adapter surface must stay auditable. Intake notes alone do not authorize code; direct evidence and explicit scope boundaries do.
+
+**Independent Test**: Can be fully tested by comparing the spec's included and deferred API tables against the saved probe report and candidate intake documents.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reviewer opens the feature spec, **When** they inspect the included API list, **Then** every row references a direct successful probe artifact under `docs/api/data-go-kr-candidate-docs/<id>/probes/live-2026-05-16/`.
+2. **Given** a reviewer opens the deferred list, **When** they inspect the reason for each deferral group, **Then** every excluded API has a blocker tied to authorization latency, missing key registration, gateway failure, live-call safety, or sample-data absence.
+
+### Edge Cases
+
+- The upstream returns HTTP 200 with an error payload such as invalid key, quota exceeded, or service not registered.
+- The upstream returns XML for one operation and JSON for another within the same agency family.
+- A saved successful probe has a valid zero-result body; this must not be treated as a failed adapter.
+- A `LINK` API uses a provider-specific key rather than `UMMAYA_DATA_GO_KR_API_KEY`.
+- A candidate API has a captured Swagger or guide but lacks direct successful curl evidence.
+- A newly approved candidate becomes callable after this spec is reviewed; it remains out of scope until a follow-up Spec Kit cycle updates the evidence set.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST include only APIs listed as `Confirmed Callable` in `docs/api/data-go-kr-candidate-docs/LIVE-PROBE-RESULTS-2026-05-16.md` for this adapter wave.
+- **FR-002**: System MUST register each included API under the active `find` primitive unless a later approved spec proves the API performs identity/status verification or state mutation.
+- **FR-003**: System MUST NOT register any of the 30 newly scoped candidates from `SCOPED-NEW-30-manifest.json` in this feature because their service applications are still within the two-hour authorization window and lack direct successful probes.
+- **FR-004**: System MUST NOT register APIs listed as `Reachable But Not Yet Callable` or `Not Live-Probed` in the live probe report as live adapters in this feature.
+- **FR-005**: System MUST preserve the existing active primitive surface: `find`, `locate`, `send`, and `check`; no legacy domain verbs or `subscribe` surface may be introduced.
+- **FR-006**: System MUST keep all included adapters read-only, idempotent, and free of agency-state mutation.
+- **FR-007**: System MUST produce a documented adapter mapping for each included API, covering data.go.kr ID, Korean API name, owning institution, primitive, source mode, credential family, direct evidence artifact, and citizen-facing domain.
+- **FR-008**: System MUST require recorded fixtures for successful, zero-result where available, and upstream error responses before a verified adapter is considered complete.
+- **FR-009**: System MUST ensure default CI tests replay fixtures only and never call live data.go.kr, KEPCO, REB, TAGO, AirKorea, FTC, PPS, university, finance, or funeral-cost endpoints.
+- **FR-010**: System MUST mark provider-key `LINK` APIs separately from data.go.kr service-key APIs so their credential source is not conflated.
+- **FR-011**: System MUST show bilingual search hints for each included adapter, including Korean citizen phrasing, English glosses, institution names, and domain synonyms.
+- **FR-012**: System MUST fail closed when required query parameters are missing, duplicated incompatibly, out of documented range, or not supported by the saved official contract.
+- **FR-013**: System MUST document deferred candidates with a concrete blocker and must not silently omit blocked APIs from the implementation report.
+- **FR-014**: System MUST keep permission classification adapter-level and cite the agency or portal source rather than inventing a UMMAYA-only permission policy.
+
+### Included Verified API Set
+
+| ID | API | Institution | Primitive | Inclusion Evidence |
+|----|-----|-------------|-----------|--------------------|
+| `15043459` | 금융위원회 기업 재무정보 | Financial Services Commission | `find` | `15043459/probes/live-2026-05-16/corporate-finance-summary.body.json` |
+| `15073861` | AirKorea 대기오염정보 | 한국환경공단 / AirKorea | `find` | `15073861/probes/live-2026-05-16/airkorea-ctprvn.body.json` |
+| `15091886` | 공정위 대규모기업집단 | Fair Trade Commission | `find` | `15091886/probes/live-2026-05-16/ftc-large-group.body.xml` |
+| `15091910` | 공정위 사용 가능 공개년월 | Fair Trade Commission | `find` | `15091910/probes/live-2026-05-16/ftc-public-ym.body.xml` |
+| `15098529` | TAGO 버스노선정보 | MOLIT / TAGO | `find` | `15098529/probes/live-2026-05-16/tago-bus-route.body.xml` |
+| `15098530` | TAGO 버스도착정보 | MOLIT / TAGO | `find` | `15098530/probes/live-2026-05-16/tago-bus-arrival.body.xml` |
+| `15098533` | TAGO 버스위치정보 | MOLIT / TAGO | `find` | `15098533/probes/live-2026-05-16/tago-bus-location.body.xml` |
+| `15098534` | TAGO 버스정류소정보 | MOLIT / TAGO | `find` | `15098534/probes/live-2026-05-16/tago-bus-station.body.xml` |
+| `15101360` | KEPCO 계약종별 전력사용량 | Korea Electric Power Corporation | `find` | `15101360/probes/live-2026-05-16/kepco-contract-type.body.json` |
+| `15129394` | 조달청 나라장터 입찰공고정보 | Public Procurement Service | `find` | `15129394/probes/live-2026-05-16/pps-bid-service.body.json` |
+| `15134761` | 한국부동산원 부동산통계 | Korea Real Estate Board | `find` | `15134761/probes/live-2026-05-16/reb-stat-table.body.json` |
+| `15157485` | 부산시설공단 장례비산출 | Busan Facilities Corporation | `find` | `15157485/probes/live-2026-05-16/funeral-area-list.body.json` |
+| `15158680` | 대학알리미 재정 현황 | Korean Council for University Education | `find` | `15158680/probes/live-2026-05-16/finance-regional-tuition.body.xml` |
+| `15158684` | 대학정보공시 학생 현황 | Korean Council for University Education | `find` | `15158684/probes/live-2026-05-16/student-regional-foreign.body.xml` |
+
+### Key Entities *(include if feature involves data)*
+
+- **Verified API Candidate**: A public-service API with saved direct curl evidence proving endpoint, credential path, parameters, response status, and body shape.
+- **Adapter Registration**: The tool catalog entry that binds one verified API module to an active primitive, discovery hints, credential family, and agency policy citation.
+- **Evidence Artifact**: A sanitized saved response header or body file under `docs/api/data-go-kr-candidate-docs/<id>/probes/live-2026-05-16/`.
+- **Fixture Set**: Replayable successful, zero-result, and error payloads used by tests so CI never calls live public APIs.
+- **Deferred Candidate**: An API that has intake documentation but is not allowed in this feature because it lacks direct successful call evidence or safe live-call conditions.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of included adapters are traceable to a saved direct successful probe artifact from 2026-05-16.
+- **SC-002**: 0 APIs from `SCOPED-NEW-30-manifest.json` are registered as live adapters in this feature.
+- **SC-003**: 100% of included adapters are registered under `find` and no new root primitive or legacy domain verb is introduced.
+- **SC-004**: 100% of default test coverage for this feature uses fixtures and performs no live external citizen-infrastructure calls.
+- **SC-005**: Each included adapter has bilingual discovery hints and at least one citizen-facing trigger phrase.
+- **SC-006**: Each included adapter has an explicit deferral-safe error behavior for invalid key, upstream service error, malformed response, and empty result.
+- **SC-007**: The adapter catalog and generated schema artifacts list every included adapter and omit every deferred candidate.
+
+## Assumptions
+
+- The saved direct probe artifacts are sufficient evidence to start specification and planning, but implementation tasks may still request targeted re-probes when a response shape is incomplete.
+- All included APIs are read-only public or API-key-gated public data surfaces and therefore map to `find` in this feature.
+- `15101360` and `15134761` are provider-key `LINK` APIs and must use their own credential family rather than the shared data.go.kr service key.
+- The first implementation plan may group closely related operations, such as the four TAGO bus APIs or the two university APIs, while still preserving one clear adapter registration per callable agency module.
+- The 30 newly scoped candidates can be reconsidered after their approval window passes and direct curl probes prove callable behavior.
+
+## Scope Boundaries & Deferred Items *(mandatory)*
+
+### Out of Scope (Permanent)
+
+- Reintroducing legacy verbs such as `pay`, `issue_certificate`, `submit_application`, or `subscribe_alert` — the active harness surface is fixed to `find`, `locate`, `send`, and `check`.
+- Mocking opaque citizen-transaction systems without a public callable contract — those remain scenario-only per UMMAYA's mock-vs-scenario rule.
+- Calling live public APIs from default CI — public API contract checks may be local/manual or marked live only, never part of default test execution.
+
+### Deferred to Future Work
+
+| Item | Reason for Deferral | Target Epic/Phase | Tracking Issue |
+|------|---------------------|-------------------|----------------|
+| 30 candidates in `SCOPED-NEW-30-manifest.json` | Their data.go.kr applications are still within the two-hour authorization window and lack successful direct probes. | Follow-up wave under Epic #2797 | #2832 |
+| `15000122` and `15000215` 법제처 SOAP services | WSDL is reachable, but the current key returns service-key registration errors. | Follow-up wave under Epic #2797 | #2833 |
+| `15000241` EMS 행방조회 | Endpoint reacts to key presence, but no currently valid EMS tracking sample has proven a successful data response. | Follow-up wave under Epic #2797 | #2834 |
+| `15081808` 국세청 사업자 상태조회 | Endpoint and POST body are known, but approved-key probes currently return upstream `-5`; classify later as `check` only after successful evidence. | Follow-up `check` adapter wave | #2835 |
+| `15074634` MSIT business announcements | Approved and documented, but the official endpoint returned gateway blocking during direct probe. | Follow-up wave under Epic #2797 | #2836 |
+| `15149906` MOJ stay-person counter | Approved and documented, but the gateway returned 502 and the direct backend redirected unexpectedly during direct probe. | Follow-up wave under Epic #2797 | #2837 |
+| `15000032` EMS 신청 저장 서비스 | It is a `send` candidate with real submit/cancel behavior; no sandbox or safe test endpoint is proven. | Future `send` adapter wave | #2838 |
+| `15056641` CareerNet job information | External CareerNet key approval is pending; no issued key was visible at capture time. | Follow-up external-key wave | #2839 |
+| `15087442` KDCA health information | External KDCA registration status and supported endpoint version need reconciliation before wrapping. | Follow-up external-key wave | #2840 |

--- a/specs/2797-data-go-kr-verified-adapters/tasks.md
+++ b/specs/2797-data-go-kr-verified-adapters/tasks.md
@@ -1,0 +1,160 @@
+# Tasks: data.go.kr Verified Adapter Wave
+
+**Input**: Design documents from `/Users/um-yunsang/UMMAYA/specs/2797-data-go-kr-verified-adapters/`  
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/)
+
+**Tests**: Required. User explicitly requested implementation through real-use validation, and the spec requires fixture-only CI tests.
+
+**Organization**: Tasks are grouped by user story to enable independent verification.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Prepare feature package, fixture paths, and registration constants.
+
+- [X] T001 Create `src/ummaya/tools/verified_data_go_kr/__init__.py` package scaffold (#2799)
+- [X] T002 Create `tests/tools/verified_data_go_kr/__init__.py` and fixture test package scaffold (#2800)
+- [X] T003 Add verified adapter ID/evidence manifest in `src/ummaya/tools/verified_data_go_kr/_manifest.py` (#2801)
+- [X] T004 Add documentation index stub in `docs/api/verified-data-go-kr/README.md` (#2802)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Shared typed models, parsers, and fixture replay harness that all adapters depend on.
+
+**CRITICAL**: No user story adapter implementation can begin until this phase is complete.
+
+- [X] T005 [P] Write failing model contract tests in `tests/tools/verified_data_go_kr/test_models.py` (#2803)
+- [X] T006 [P] Write failing JSON/XML parser tests in `tests/tools/verified_data_go_kr/test_parsing.py` (#2804)
+- [X] T007 [P] Write failing registration exclusion tests in `tests/tools/verified_data_go_kr/test_no_scoped_new_30_registration.py` (#2805)
+- [X] T008 Implement typed public-data models in `src/ummaya/tools/verified_data_go_kr/_models.py` (#2806)
+- [X] T009 Implement fixture-safe JSON/XML parser helpers in `src/ummaya/tools/verified_data_go_kr/_parsing.py` (#2807)
+- [X] T010 Implement shared HTTP param/client helpers in `src/ummaya/tools/verified_data_go_kr/_client.py` (#2808)
+- [X] T011 Update `src/ummaya/tools/verified_data_go_kr/__init__.py` exports for shared helpers (#2809)
+
+**Checkpoint**: Foundational parser/model tests fail before implementation and pass after T008-T011.
+
+---
+
+## Phase 3: User Story 1 - Discover Verified Public Service Adapters (Priority: P1) MVP
+
+**Goal**: The routing surface exposes only the 14 direct-success verified adapters and excludes unauthorized/blocked candidates.
+
+**Independent Test**: Run registration/search tests and verify all 14 included IDs are present while 30 newly scoped IDs are absent.
+
+### Tests for User Story 1
+
+- [X] T012 [P] [US1] Write failing adapter registration tests in `tests/tools/verified_data_go_kr/test_adapter_registration.py` (#2810)
+- [X] T013 [P] [US1] Write failing routing/search tests in `tests/tools/verified_data_go_kr/test_verified_search.py` (#2811)
+
+### Implementation for User Story 1
+
+- [X] T014 [US1] Implement first representative adapter `bfc_funeral_area_fee` in `src/ummaya/tools/verified_data_go_kr/bfc_funeral_cost.py` (#2812)
+- [X] T015 [US1] Register `bfc_funeral_area_fee` from `src/ummaya/tools/register_all.py` (#2813)
+- [X] T016 [US1] Implement and register remaining verified adapter modules listed in `contracts/adapter-wave.md` (#2814)
+- [X] T017 [US1] Update `docs/api/verified-data-go-kr/README.md` with the 14-adapter matrix and deferred exclusions (#2815)
+
+**Checkpoint**: All 14 verified adapters are discoverable through registry/search; no unauthorized 30-candidate adapter is registered.
+
+---
+
+## Phase 4: User Story 2 - Fetch Read-Only Public Data Through `find` (Priority: P1)
+
+**Goal**: Each verified adapter can parse fixture-backed upstream data and return a normalized `find` collection output without live network calls in CI.
+
+**Independent Test**: Run fixture replay tests for JSON, XML, zero-result, and upstream error behavior.
+
+### Tests for User Story 2
+
+- [X] T018 [P] [US2] Write failing fixture replay tests in `tests/tools/verified_data_go_kr/test_adapter_fixture_replay.py` (#2816)
+- [X] T019 [P] [US2] Write failing upstream error parsing tests in `tests/tools/verified_data_go_kr/test_error_parsing.py` (#2817)
+
+### Implementation for User Story 2
+
+- [X] T020 [US2] Add fixture-injected adapter call path to `src/ummaya/tools/verified_data_go_kr/_client.py` (#2818)
+- [X] T021 [US2] Ensure all verified adapter modules normalize successful fixtures into `kind="collection"` outputs (#2819)
+- [X] T022 [US2] Ensure parser/client errors produce fail-closed tool-domain exceptions with sanitized upstream codes (#2820)
+
+**Checkpoint**: Fixture replay proves successful and error-path behavior without external API calls.
+
+---
+
+## Phase 5: User Story 3 - Maintain Evidence-Gated Scope (Priority: P2)
+
+**Goal**: Maintainers can trace included adapters to saved direct-call evidence and deferred APIs to concrete blockers.
+
+**Independent Test**: Run manifest/docs consistency tests against the live probe report and candidate manifest.
+
+### Tests for User Story 3
+
+- [X] T023 [P] [US3] Write failing evidence consistency tests in `tests/tools/verified_data_go_kr/test_evidence_consistency.py` (#2821)
+
+### Implementation for User Story 3
+
+- [X] T024 [US3] Add evidence path validation to `src/ummaya/tools/verified_data_go_kr/_manifest.py` (#2822)
+- [X] T025 [US3] Update `docs/api/README.md` to link the verified data.go.kr adapter wave (#2823)
+- [X] T026 [US3] Generate or update adapter schemas for the new verified adapters under `docs/api/schemas/` (#2824)
+
+**Checkpoint**: Evidence consistency and docs/schema checks prove every included adapter is traceable.
+
+---
+
+## Phase 6: Polish & Validation
+
+**Purpose**: Full verification, UMMAYA real-use smoke, and PR-ready evidence.
+
+- [X] T027 Run `uv run ruff check src tests` and fix all reported issues (#2825)
+- [X] T028 Run `uv run ruff format --check src tests` and fix all reported issues (#2826)
+- [X] T029 Run `uv run mypy src` and fix all reported issues (#2827)
+- [X] T030 Run `uv run pytest -m "not live"` and fix all reported issues (#2828)
+- [X] T031 Run UMMAYA real-use smoke from `quickstart.md` with direct live adapter mode and record summary in `specs/2797-data-go-kr-verified-adapters/real-use-smoke.md` (#2829)
+- [X] T032 Inspect real-use smoke output for abnormal flow, fabricated fallback, wrong adapter selection, permission misclassification, and debug until clean (#2830)
+- [X] T033 Update `specs/2797-data-go-kr-verified-adapters/tasks.md` task checkboxes as each task completes (#2831)
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 has no dependencies.
+- Phase 2 depends on Phase 1 and blocks all user stories.
+- Phase 3 and Phase 4 both depend on Phase 2; execute Phase 3 first for registry visibility, then Phase 4 for fixture execution.
+- Phase 5 depends on Phase 3 and Phase 4.
+- Phase 6 depends on all user stories.
+
+### User Story Dependencies
+
+- US1: Starts after foundational helpers exist.
+- US2: Starts after at least one representative adapter exists, then applies to all 14 adapters.
+- US3: Starts after adapter set is known and fixture replay behavior is stable.
+
+### Parallel Opportunities
+
+- T005-T007 can run in parallel.
+- T012-T013 can run in parallel.
+- T018-T019 can run in parallel.
+- Individual adapter modules inside T016 are parallel-safe by file, but Lead may execute them solo in this session.
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete setup and foundational helpers.
+2. Implement `bfc_funeral_area_fee` as the first representative verified adapter.
+3. Prove discovery, fixture replay, and one real-use smoke.
+4. Extend the same pattern to the remaining 13 verified adapters.
+
+### Full Wave Completion
+
+1. Complete all 14 adapter registrations.
+2. Run fixture-only tests and full backend checks.
+3. Run UMMAYA real-use smoke with at least 부산 장례비산출, AirKorea, and TAGO prompts.
+4. Debug abnormal flow before PR.
+
+## Notes
+
+- Total tasks: 33, below the 90-task hard budget.
+- No task may add a dependency.
+- No task may call live public APIs from default tests.
+- `tui/src/**` is not touched by this plan; PR should declare `TUI no-change`.

--- a/src/ummaya/engine/engine.py
+++ b/src/ummaya/engine/engine.py
@@ -8,6 +8,7 @@ the standalone ``query()`` async generator.
 
 from __future__ import annotations
 
+import json
 import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
@@ -19,6 +20,7 @@ from ummaya.engine.models import QueryContext, QueryState, SessionBudget
 from ummaya.engine.query import query
 from ummaya.llm.client import LLMClient
 from ummaya.llm.models import ChatMessage
+from ummaya.tools.errors import ToolNotFoundError
 from ummaya.tools.executor import ToolExecutor
 from ummaya.tools.registry import ToolRegistry
 
@@ -26,6 +28,53 @@ if TYPE_CHECKING:
     from ummaya.permissions.models import SessionContext
 
 logger = logging.getLogger(__name__)
+
+_LOCATION_DEPENDENT_SCHEMA_KEYS = frozenset(
+    {
+        "adm_cd",
+        "admcd",
+        "admin_code",
+        "administrative_code",
+        "latitude",
+        "lat",
+        "longitude",
+        "lon",
+        "lng",
+        "nx",
+        "ny",
+        "q0",
+        "q1",
+        "region_cd",
+        "region_code",
+    }
+)
+
+
+def _schema_requires_location_resolution(
+    input_schema_json: object,
+    required_params: object,
+) -> bool:
+    """Return True when an adapter schema needs prior locate output."""
+
+    return _contains_location_dependent_key(input_schema_json) or _contains_location_dependent_key(
+        required_params
+    )
+
+
+def _contains_location_dependent_key(value: object) -> bool:
+    """Recursively detect coordinate/admin-code schema fields."""
+
+    if isinstance(value, dict):
+        for key, nested in value.items():
+            if str(key).lower() in _LOCATION_DEPENDENT_SCHEMA_KEYS:
+                return True
+            if _contains_location_dependent_key(nested):
+                return True
+    elif isinstance(value, list):
+        return any(_contains_location_dependent_key(item) for item in value)
+    elif isinstance(value, str):
+        return value.lower() in _LOCATION_DEPENDENT_SCHEMA_KEYS
+    return False
 
 
 class QueryEngine:
@@ -156,6 +205,12 @@ class QueryEngine:
                 ChatMessage(role="user", content=assembled.turn_attachment.content),
             )
 
+        dynamic_adapter_message, allowed_core_tool_ids = self._build_available_adapters_context(
+            user_message
+        )
+        if dynamic_adapter_message is not None:
+            self._state.messages.append(dynamic_adapter_message)
+
         # Append user message to history
         self._state.messages.append(
             ChatMessage(role="user", content=user_message),
@@ -169,6 +224,7 @@ class QueryEngine:
             tool_registry=self._tool_registry,
             config=self._config,
             session_context=self._permission_session,
+            allowed_core_tool_ids=allowed_core_tool_ids,
         )
 
         # Delegate to per-turn query loop
@@ -183,6 +239,11 @@ class QueryEngine:
                 stop_message=f"Unexpected error: {exc}",
             )
         finally:
+            if dynamic_adapter_message is not None:
+                try:
+                    self._state.messages.remove(dynamic_adapter_message)
+                except ValueError:
+                    logger.debug("Dynamic adapter context already absent from state")
             self._state.turn_count += 1
             logger.info(
                 "Turn %d completed: tokens_used=%d, messages=%d",
@@ -204,6 +265,92 @@ class QueryEngine:
             messages=[system_msg],
         )
         logger.info("QueryEngine reset: conversation cleared")
+
+    def _build_available_adapters_message(self, user_message: str) -> ChatMessage | None:
+        """Inject BM25 adapter candidates for the current citizen utterance."""
+
+        message, _allowed_core_tool_ids = self._build_available_adapters_context(user_message)
+        return message
+
+    def _build_available_adapters_context(
+        self, user_message: str
+    ) -> tuple[ChatMessage | None, frozenset[str] | None]:
+        """Build dynamic adapter context and per-turn primitive exposure."""
+
+        try:
+            from ummaya.tools.search import search  # noqa: PLC0415
+
+            candidates = search(
+                user_message,
+                self._tool_registry.bm25_index,
+                self._tool_registry,
+                top_k=15,
+            )
+        except Exception:  # noqa: BLE001
+            logger.exception("available_adapters auto-inject failed")
+            return None, None
+
+        adapter_lines: list[str] = []
+        visible_primitives: set[str] = set()
+        has_location_dependent_schema = False
+        visible_count = 0
+        for candidate in candidates:
+            try:
+                tool = self._tool_registry.find(candidate.tool_id)
+            except ToolNotFoundError:
+                continue
+            if tool.is_core or tool.ministry == "UMMAYA":
+                continue
+            if isinstance(candidate.primitive, str):
+                visible_primitives.add(candidate.primitive)
+            if _schema_requires_location_resolution(
+                candidate.input_schema_json,
+                candidate.required_params,
+            ):
+                has_location_dependent_schema = True
+            schema_json = json.dumps(
+                candidate.input_schema_json,
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+            adapter_lines.extend(
+                [
+                    f"- tool_id: {candidate.tool_id}",
+                    f"  primitive: {candidate.primitive}",
+                    f"  description: {candidate.llm_description or tool.name_ko}",
+                    f"  required_params: {candidate.required_params}",
+                    f"  input_schema_json: {schema_json}",
+                    f"  call_hint: {candidate.primitive}("
+                    f'{{"tool_id":"{candidate.tool_id}","params":{{...}}}})',
+                    f"  policy_url: {candidate.real_classification_url or ''}",
+                ]
+            )
+            visible_count += 1
+            if visible_count >= 5:
+                break
+
+        if not adapter_lines:
+            return None, None
+
+        allowed_core_tool_ids: frozenset[str] | None = None
+        if visible_primitives == {"find"} and not has_location_dependent_schema:
+            allowed_core_tool_ids = frozenset({"find"})
+
+        content = "\n".join(
+            [
+                "<available_adapters>",
+                "Use these adapter candidates for this citizen request. "
+                "For public-data lookup/list/statistics requests, call "
+                "find({tool_id, params}) with a tool_id from this block. "
+                "Do not call locate just because the citizen text contains a "
+                "city/province name; treat that as the dataset/filter term. "
+                "Call locate only when the selected adapter schema requires "
+                "coordinates, administrative codes, or a place-to-region conversion.",
+                *adapter_lines,
+                "</available_adapters>",
+            ]
+        )
+        return ChatMessage(role="system", content=content), allowed_core_tool_ids
 
     def set_permission_session(self, session: SessionContext | None) -> None:
         """Update the permission-pipeline session used for subsequent turns.

--- a/src/ummaya/engine/models.py
+++ b/src/ummaya/engine/models.py
@@ -120,6 +120,14 @@ class QueryContext(BaseModel):
     when the engine is driven outside the stdio bridge (unit tests / REPL).
     """
 
+    allowed_core_tool_ids: frozenset[str] | None = None
+    """Optional per-turn provider tool allow-list for root primitives.
+
+    Used by the Rich REPL path when BM25 has already selected location-independent
+    public-data adapters. It keeps the exposed provider surface aligned with the
+    selected adapter primitive instead of letting unrelated root primitives race.
+    """
+
 
 # ---------------------------------------------------------------------------
 # SessionBudget

--- a/src/ummaya/engine/query.py
+++ b/src/ummaya/engine/query.py
@@ -14,11 +14,12 @@ import json
 import logging
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, cast
 
 from opentelemetry import context as _otel_context
 from opentelemetry import trace
 from opentelemetry.trace import Status, StatusCode
+from pydantic import ValidationError
 
 from ummaya.engine.events import QueryEvent, StopReason
 from ummaya.engine.models import QueryContext
@@ -80,6 +81,18 @@ def _assemble_tool_calls(
     ]
 
 
+def _tool_definition_name(tool_def: ToolDefinition | dict[str, object]) -> str | None:
+    """Extract a root primitive name from an OpenAI tool definition."""
+
+    if isinstance(tool_def, ToolDefinition):
+        return tool_def.function.name
+    function = tool_def.get("function")
+    if not isinstance(function, dict):
+        return None
+    name = function.get("name")
+    return name if isinstance(name, str) else None
+
+
 # ---------------------------------------------------------------------------
 # Concurrent tool dispatch (partition-sort algorithm, R-004)
 # ---------------------------------------------------------------------------
@@ -130,6 +143,13 @@ async def dispatch_tool_calls(  # noqa: C901
 
     async def _dispatch_one(tc: ToolCall) -> ToolResult:
         """Dispatch a single tool call via the executor."""
+        if tc.function.name in {"find", "locate"}:
+            return await _dispatch_root_primitive(
+                tc,
+                tool_registry,
+                tool_executor,
+                session_context=session_context,
+            )
         return await tool_executor.dispatch(tc.function.name, tc.function.arguments)
 
     async def _flush_group(items: list[tuple[int, ToolCall]], safe: bool) -> None:
@@ -157,6 +177,95 @@ async def dispatch_tool_calls(  # noqa: C901
         await _flush_group(group, group_safe)
 
     return [r for r in results if r is not None]
+
+
+async def _dispatch_root_primitive(
+    tc: ToolCall,
+    tool_registry: ToolRegistry,
+    tool_executor: ToolExecutor,
+    *,
+    session_context: SessionContext | None,
+) -> ToolResult:
+    """Fan out an LLM-visible primitive call to the selected adapter id."""
+
+    primitive = tc.function.name
+    try:
+        primitive_tool = tool_registry.find(primitive)
+    except ToolNotFoundError as exc:
+        return ToolResult(
+            tool_id=primitive,
+            success=False,
+            error=str(exc),
+            error_type="not_found",
+        )
+
+    try:
+        raw_args = json.loads(tc.function.arguments)
+        validated = primitive_tool.input_schema.model_validate(raw_args)
+    except (TypeError, json.JSONDecodeError, ValidationError) as exc:
+        return ToolResult(
+            tool_id=primitive,
+            success=False,
+            error=str(exc),
+            error_type="validation",
+        )
+
+    target_tool_id = getattr(validated, "tool_id", None)
+    params = getattr(validated, "params", None)
+    if not isinstance(target_tool_id, str) or not isinstance(params, dict):
+        return ToolResult(
+            tool_id=primitive,
+            success=False,
+            error=f"{primitive} requires tool_id and params.",
+            error_type="validation",
+        )
+    if target_tool_id == primitive:
+        return ToolResult(
+            tool_id=primitive,
+            success=False,
+            error=f"{primitive} cannot target itself.",
+            error_type="validation",
+        )
+
+    request_id = tc.id or f"{primitive}-call"
+    if primitive == "find":
+        output = await tool_executor.invoke(
+            target_tool_id,
+            params,
+            request_id=request_id,
+            session_identity=session_context,
+        )
+    else:
+        output = await tool_executor.invoke_raw(
+            target_tool_id,
+            params,
+            request_id=request_id,
+            session_identity=session_context,
+        )
+
+    data = _primitive_output_dict(output)
+    if data.get("kind") == "error":
+        return ToolResult(
+            tool_id=primitive,
+            success=False,
+            error=str(data.get("message") or data),
+            error_type="execution",
+        )
+    return ToolResult(tool_id=primitive, success=True, data=data)
+
+
+def _primitive_output_dict(output: object) -> dict[str, object]:
+    """Convert primitive facade output to ToolResult data."""
+
+    model_dump = getattr(output, "model_dump", None)
+    if callable(model_dump):
+        dumped = model_dump(mode="json")
+        if isinstance(dumped, dict):
+            return cast("dict[str, object]", dumped)
+        return {"result": dumped}
+    if isinstance(output, dict):
+        return output
+    return {"result": output}
 
 
 # ---------------------------------------------------------------------------
@@ -261,6 +370,12 @@ async def _query_inner(ctx: QueryContext) -> AsyncIterator[QueryEvent]:  # noqa:
 
         # --- Export tool definitions (sorted for cache stability) ---
         raw_defs = ctx.tool_registry.export_core_tools_openai()
+        if ctx.allowed_core_tool_ids is not None:
+            raw_defs = [
+                tool_def
+                for tool_def in raw_defs
+                if _tool_definition_name(tool_def) in ctx.allowed_core_tool_ids
+            ]
         tool_defs: list[ToolDefinition | dict[str, object]] | None = list(raw_defs) or None
 
         # --- Stream LLM completion ---

--- a/src/ummaya/llm/client.py
+++ b/src/ummaya/llm/client.py
@@ -1004,7 +1004,7 @@ class LLMClient:
         if stop is not None:
             payload["stop"] = stop
         if tools is not None:
-            tool_payloads = [t.model_dump() if isinstance(t, ToolDefinition) else t for t in tools]
+            tool_payloads = [self._serialize_tool_definition(t) for t in tools]
             payload["tools"] = tool_payloads
             if tool_payloads:
                 # UMMAYA citizen flows require one observed tool result before
@@ -1017,6 +1017,19 @@ class LLMClient:
             payload["stream"] = True
             payload["stream_options"] = {"include_usage": True}
         return payload
+
+    @staticmethod
+    def _serialize_tool_definition(tool: ToolDefinition | dict[str, object]) -> dict[str, object]:
+        """Return the provider-safe OpenAI tool payload.
+
+        Registry exports may carry UMMAYA-only metadata such as
+        ``function.trigger_phrase`` for system-prompt construction. Normalizing
+        through ``ToolDefinition`` applies field exclusions before the payload
+        reaches FriendliAI's strict OpenAI-compatible validator.
+        """
+        if isinstance(tool, ToolDefinition):
+            return cast(dict[str, object], tool.model_dump())
+        return cast(dict[str, object], ToolDefinition.model_validate(tool).model_dump())
 
     # ------------------------------------------------------------------
     # Private retry helpers (T015)

--- a/src/ummaya/tools/live_proxy.py
+++ b/src/ummaya/tools/live_proxy.py
@@ -26,8 +26,10 @@ _PROXYABLE_HOSTS = frozenset(
         "openapi.data.go.kr",
         "dapi.kakao.com",
         "business.juso.go.kr",
+        "bigdata.kepco.co.kr",
         "sgisapi.kostat.go.kr",
         "sgisapi.mods.go.kr",
+        "www.reb.or.kr",
     }
 )
 _PROXYABLE_PRIMITIVES = frozenset({"find", "locate"})

--- a/src/ummaya/tools/models.py
+++ b/src/ummaya/tools/models.py
@@ -49,6 +49,14 @@ Ministry = Literal[
     "KEC",  # 한국교통안전공단 — vehicle inspection / e-signature
     "MFDS",  # 식품의약품안전처 — food & drug safety
     "GOV24",  # 정부24 — citizen submission portal (OPAQUE per feedback_mock_evidence_based)
+    "FSC",  # 금융위원회 — financial services
+    "KECO",  # 한국환경공단 — environment / AirKorea
+    "FTC",  # 공정거래위원회 — fair trade
+    "KEPCO",  # 한국전력공사 — electricity / utility data
+    "PPS",  # 조달청 — public procurement
+    "REB",  # 한국부동산원 — real-estate statistics
+    "BFC",  # 부산시설공단 — Busan public facilities
+    "KCUE",  # 한국대학교육협의회 — university disclosure data
     "UMMAYA",  # harness-internal synthetic surface (locate, find, mvp_surface)
     "OTHER",  # transitional escape hatch — CI emits warning
 ]

--- a/src/ummaya/tools/register_all.py
+++ b/src/ummaya/tools/register_all.py
@@ -48,7 +48,8 @@ logger = logging.getLogger(__name__)
 def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> RoutingIndex:
     """Register all available government API tool adapters.
 
-    Registers the following 16 tools in order (Epic ε #2296: 2 new lookup mocks added):
+    Registers the following 52 tools in order after discovery bridging and
+    Spec #2797 verified public-data expansion:
       1. locate — MVP LLM core surface: location resolution (is_core=True)
       2. lookup — MVP LLM core surface: adapter discovery + invocation (is_core=True)
       3. koroad_accident_search — KOROAD accident hotspot search (by enum codes)
@@ -63,8 +64,9 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> Routin
      12. hira_hospital_search — HIRA hospital search by coordinates + radius
      13. nfa_emergency_info_service — NFA EMS statistics (Phase 2, Layer 3 gated stub)
      14. mohw_welfare_eligibility_search — SSIS welfare service list (Phase 2, real XML handler — T025)
-     15. mock_lookup_module_hometax_simplified — Hometax simplified data (Mock, Epic ε T028)
-     16. mock_lookup_module_gov24_certificate — Gov24 certificate lookup (Mock, Epic ε T029)
+     15-28. verified_data_go_kr — fourteen direct-curl verified public-data adapters
+     29. mock_lookup_module_hometax_simplified — Hometax simplified data (Mock, Epic ε T028)
+     30. mock_lookup_module_gov24_certificate — Gov24 certificate lookup (Mock, Epic ε T029)
 
     After registration, ``build_routing_index()`` validates every adapter against
     the six invariants in ``contracts/routing-consistency.md § 2``. Violations
@@ -111,6 +113,7 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> Routin
     from ummaya.tools.mvp_surface import register_mvp_surface
     from ummaya.tools.nfa119.emergency_info_service import register as reg_nfa
     from ummaya.tools.nmc.emergency_search import register as reg_nmc
+    from ummaya.tools.verified_data_go_kr import register as reg_verified_data_go_kr
 
     # Register MVP LLM-visible core surface first (FR-001, SC-003)
     register_mvp_surface(registry)
@@ -150,6 +153,11 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> Routin
     # Phase 2 adapters (spec 029 — NFA 119 + MOHW SSIS, Layer 3 gated stubs)
     reg_nfa(registry, executor)  # T014 — NFA EMS statistics (interface-only)
     reg_mohw(registry, executor)  # T025 — MOHW welfare eligibility search (real XML handler)
+
+    # Spec #2797 — direct-curl verified public-data adapters. These are real
+    # read-only find adapters backed by saved live-probe fixtures and direct
+    # HTTP handlers; newly applied but not-yet-authorized candidates stay out.
+    reg_verified_data_go_kr(registry, executor)
 
     # Epic ε #2296 T028/T029 — New lookup mock GovAPITools (main ToolRegistry,
     # not per-primitive sub-registry — lookup adapters use BM25 discovery).

--- a/src/ummaya/tools/verified_data_go_kr/__init__.py
+++ b/src/ummaya/tools/verified_data_go_kr/__init__.py
@@ -1,0 +1,52 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Verified public-data adapter wave registration."""
+
+from __future__ import annotations
+
+from importlib import import_module
+from types import ModuleType
+from typing import Protocol, cast
+
+from pydantic import BaseModel
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._manifest import (
+    VERIFIED_DATA_GO_KR_ADAPTERS,
+    require_spec,
+)
+from ummaya.tools.verified_data_go_kr._models import VerifiedAdapterSpec
+
+
+class VerifiedAdapterModule(Protocol):
+    """Public shape exposed by each thin adapter module."""
+
+    INPUT_SCHEMA: type[BaseModel]
+    TOOL: GovAPITool
+
+    def register(self, registry: ToolRegistry, executor: ToolExecutor) -> None:
+        """Register module-owned tool and executor binding."""
+
+
+def module_for_tool_id(tool_id: str) -> VerifiedAdapterModule:
+    """Import the module that owns *tool_id*."""
+
+    spec = require_spec(tool_id)
+    module: ModuleType = import_module(f"{__name__}.{spec.module_name}")
+    return cast(VerifiedAdapterModule, module)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register all direct-curl verified public-data adapters."""
+
+    for spec in VERIFIED_DATA_GO_KR_ADAPTERS:
+        module_for_tool_id(spec.tool_id).register(registry, executor)
+
+
+__all__ = [
+    "VERIFIED_DATA_GO_KR_ADAPTERS",
+    "VerifiedAdapterSpec",
+    "module_for_tool_id",
+    "register",
+]

--- a/src/ummaya/tools/verified_data_go_kr/_client.py
+++ b/src/ummaya/tools/verified_data_go_kr/_client.py
@@ -1,0 +1,53 @@
+# SPDX-License-Identifier: Apache-2.0
+"""HTTP client helpers for verified public-data adapters."""
+
+from __future__ import annotations
+
+import httpx
+from pydantic import BaseModel
+
+from ummaya.tools.errors import _require_env
+from ummaya.tools.verified_data_go_kr._models import (
+    VerifiedAdapterSpec,
+    VerifiedPublicDataOutput,
+)
+from ummaya.tools.verified_data_go_kr._parsing import parse_verified_payload
+
+_TIMEOUT_SECONDS = 10.0
+
+
+async def fetch_verified_output(
+    input_model: BaseModel,
+    spec: VerifiedAdapterSpec,
+    *,
+    fixture_body: bytes | None = None,
+) -> VerifiedPublicDataOutput:
+    """Fetch or fixture-replay one verified adapter response."""
+
+    if fixture_body is not None:
+        return parse_verified_payload(
+            fixture_body,
+            response_format=spec.response_format,
+            record_tag=spec.record_tag,
+        )
+
+    params = _build_query_params(input_model, spec)
+    async with httpx.AsyncClient(timeout=_TIMEOUT_SECONDS) as client:
+        response = await client.get(str(spec.endpoint), params=params)
+        response.raise_for_status()
+        return parse_verified_payload(
+            response.content,
+            response_format=spec.response_format,
+            record_tag=spec.record_tag,
+        )
+
+
+def _build_query_params(input_model: BaseModel, spec: VerifiedAdapterSpec) -> dict[str, str]:
+    dumped = input_model.model_dump(mode="python", exclude_none=True)
+    params = dict(spec.static_query_params)
+    params[spec.auth_query_param] = _require_env(spec.env_var)
+    for field_name, query_name in spec.query_param_map.items():
+        value = dumped.get(field_name)
+        if value is not None:
+            params[query_name] = str(value)
+    return params

--- a/src/ummaya/tools/verified_data_go_kr/_factory.py
+++ b/src/ummaya/tools/verified_data_go_kr/_factory.py
@@ -1,0 +1,85 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Factory helpers shared by verified public-data adapter modules."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from datetime import UTC
+
+from pydantic import BaseModel
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._client import fetch_verified_output
+from ummaya.tools.verified_data_go_kr._models import VerifiedAdapterSpec
+
+type AdapterHandle[InputT: BaseModel] = Callable[[InputT], Awaitable[dict[str, object]]]
+
+
+def build_tool(spec: VerifiedAdapterSpec, input_schema: type[BaseModel]) -> GovAPITool:
+    """Build the GovAPITool metadata object for one verified adapter."""
+
+    return GovAPITool(
+        id=spec.tool_id,
+        name_ko=spec.name_ko,
+        ministry=spec.ministry,
+        category=spec.category,
+        endpoint=str(spec.endpoint),
+        auth_type="api_key",
+        input_schema=input_schema,
+        output_schema=_VerifiedCollectionSchema,
+        search_hint=spec.search_hint,
+        policy=AdapterRealDomainPolicy(
+            real_classification_url=spec.policy_url,
+            real_classification_text=spec.policy_text,
+            citizen_facing_gate=spec.citizen_facing_gate,
+            last_verified=spec.last_verified.astimezone(UTC),
+        ),
+        is_concurrency_safe=True,
+        cache_ttl_seconds=300,
+        rate_limit_per_minute=20,
+        adapter_mode=spec.adapter_mode,
+        primitive=spec.primitive,
+        llm_description=spec.llm_description,
+        trigger_examples=spec.trigger_examples,
+    )
+
+
+async def handle_verified_input(
+    input_model: BaseModel,
+    spec: VerifiedAdapterSpec,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Return an executor-ready dict for one verified adapter call."""
+
+    output = await fetch_verified_output(input_model, spec, fixture_body=fixture_body)
+    return output.model_dump(mode="python")
+
+
+def register_module[InputT: BaseModel](
+    registry: ToolRegistry,
+    executor: ToolExecutor,
+    *,
+    tool: GovAPITool,
+    input_schema: type[InputT],
+    handler: AdapterHandle[InputT],
+) -> None:
+    """Register one verified module with the central registry and executor."""
+
+    registry.register(tool)
+
+    async def adapter(input_model: BaseModel) -> dict[str, object]:
+        validated = input_schema.model_validate(input_model)
+        return await handler(validated)
+
+    executor.register_adapter(tool.id, adapter)
+
+
+class _VerifiedCollectionSchema(BaseModel):
+    """Output schema used by legacy ToolExecutor.dispatch validation."""
+
+    kind: str
+    items: list[dict[str, object]]
+    total_count: int

--- a/src/ummaya/tools/verified_data_go_kr/_manifest.py
+++ b/src/ummaya/tools/verified_data_go_kr/_manifest.py
@@ -1,0 +1,394 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Manifest for direct-curl verified public-data adapters."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ummaya.tools.verified_data_go_kr._models import VerifiedAdapterSpec
+
+_LAST_VERIFIED = datetime(2026, 5, 16, tzinfo=UTC)
+_DATA_GO_KR_KEY = "UMMAYA_DATA_GO_KR_API_KEY"
+
+
+def _data_go_policy(dataset_id: str) -> str:
+    return f"https://www.data.go.kr/data/{dataset_id}/openapi.do"
+
+
+VERIFIED_DATA_GO_KR_ADAPTERS: tuple[VerifiedAdapterSpec, ...] = (
+    VerifiedAdapterSpec(
+        dataset_id="15043459",
+        tool_id="fsc_corporate_finance_summary",
+        module_name="fsc_corporate_finance",
+        name_ko="금융위원회 기업 재무요약 조회",
+        ministry="FSC",
+        category=["finance", "corporate", "public-data"],
+        endpoint="https://apis.data.go.kr/1160100/service/GetFinaStatInfoService_V2/getSummFinaStat_V2",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="json",
+        query_param_map={
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+            "crno": "crno",
+            "biz_year": "bizYear",
+        },
+        static_query_params={"resultType": "json"},
+        evidence_path="docs/api/data-go-kr-candidate-docs/15043459/probes/live-2026-05-16/corporate-finance-summary.body.json",
+        policy_url=_data_go_policy("15043459"),
+        policy_text="공공데이터포털 인증키 기반 금융위원회 기업 재무정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15043459 기업 재무정보 금융위원회 corporate finance crno bizYear find",
+        llm_description=(
+            "법인등록번호(crno)와 사업연도(biz_year)로 "
+            "금융위원회 기업 재무요약 공개 데이터를 조회한다."
+        ),
+        trigger_examples=["이 법인의 2019년 재무요약 조회해줘"],
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15073861",
+        tool_id="airkorea_ctprvn_air_quality",
+        module_name="airkorea_air_quality",
+        name_ko="에어코리아 시도별 실시간 대기질 조회",
+        ministry="KECO",
+        category=["environment", "air-quality", "public-data"],
+        endpoint="https://apis.data.go.kr/B552584/ArpltnInforInqireSvc/getCtprvnRltmMesureDnsty",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="json",
+        query_param_map={
+            "sido_name": "sidoName",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+            "ver": "ver",
+        },
+        static_query_params={"returnType": "json"},
+        evidence_path="docs/api/data-go-kr-candidate-docs/15073861/probes/live-2026-05-16/airkorea-ctprvn.body.json",
+        policy_url=_data_go_policy("15073861"),
+        policy_text="공공데이터포털 인증키 기반 한국환경공단 에어코리아 대기오염정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15073861 AirKorea 에어코리아 대기오염 시도별 대기질 미세먼지 find",
+        llm_description=(
+            "시도명(sido_name)으로 에어코리아 시도별 실시간 측정소 대기질 공개 데이터를 조회한다."
+        ),
+        trigger_examples=["서울 대기질 측정소 데이터 조회해줘"],
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15091886",
+        tool_id="ftc_large_group_status",
+        module_name="ftc_large_group",
+        name_ko="공정거래위원회 대규모기업집단 조회",
+        ministry="FTC",
+        category=["corporate", "fair-trade", "public-data"],
+        endpoint="https://apis.data.go.kr/1130000/appnGroupSttusList/appnGroupSttusListApi",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "presentn_year": "presentnYear",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        record_tag="appnGroupSttus",
+        evidence_path="docs/api/data-go-kr-candidate-docs/15091886/probes/live-2026-05-16/ftc-large-group.body.xml",
+        policy_url=_data_go_policy("15091886"),
+        policy_text="공공데이터포털 인증키 기반 공정거래위원회 대규모기업집단 현황 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15091886 공정위 대규모기업집단 상호출자제한집단 FTC large group find",
+        llm_description="공개년월(presentn_year) 기준 공정위 지정 대규모기업집단 현황을 조회한다.",
+        trigger_examples=["2021년 5월 대규모기업집단 목록 조회해줘"],
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15091910",
+        tool_id="ftc_public_ym_list",
+        module_name="ftc_public_ym",
+        name_ko="공정거래위원회 사용 가능 공개년월 조회",
+        ministry="FTC",
+        category=["corporate", "fair-trade", "public-data"],
+        endpoint="https://apis.data.go.kr/1130000/publicYmList/publicYmListApi",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "job_se_code": "jobSeCode",
+            "presentn_year": "presentnYear",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        record_tag="publicYm",
+        evidence_path="docs/api/data-go-kr-candidate-docs/15091910/probes/live-2026-05-16/ftc-public-ym.body.xml",
+        policy_url=_data_go_policy("15091910"),
+        policy_text="공공데이터포털 인증키 기반 공정거래위원회 공개년월 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15091910 공정위 공개년월 사용가능 공개년월 FTC public ym find",
+        llm_description=(
+            "업무구분코드(job_se_code)와 연도(presentn_year)로 사용 가능한 공개년월을 조회한다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15098529",
+        tool_id="tago_bus_route_search",
+        module_name="tago_bus_route",
+        name_ko="국토교통부 TAGO 버스노선 조회",
+        ministry="MOLIT",
+        category=["transport", "bus", "public-data"],
+        endpoint="https://apis.data.go.kr/1613000/BusRouteInfoInqireService/getRouteNoList",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "city_code": "cityCode",
+            "route_no": "routeNo",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        evidence_path="docs/api/data-go-kr-candidate-docs/15098529/probes/live-2026-05-16/tago-bus-route.body.xml",
+        policy_url=_data_go_policy("15098529"),
+        policy_text="공공데이터포털 인증키 기반 국토교통부 TAGO 버스노선정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15098529 TAGO 버스노선 cityCode routeNo bus route find",
+        llm_description=(
+            "도시코드(city_code)와 노선번호(route_no)로 TAGO 버스노선 공개 데이터를 조회한다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15098530",
+        tool_id="tago_bus_arrival_search",
+        module_name="tago_bus_arrival",
+        name_ko="국토교통부 TAGO 버스도착 조회",
+        ministry="MOLIT",
+        category=["transport", "bus", "public-data"],
+        endpoint="https://apis.data.go.kr/1613000/ArvlInfoInqireService/getSttnAcctoArvlPrearngeInfoList",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "city_code": "cityCode",
+            "node_id": "nodeId",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        evidence_path="docs/api/data-go-kr-candidate-docs/15098530/probes/live-2026-05-16/tago-bus-arrival.body.xml",
+        policy_url=_data_go_policy("15098530"),
+        policy_text="공공데이터포털 인증키 기반 국토교통부 TAGO 버스도착정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15098530 TAGO 버스도착 정류소 nodeId arrival bus find",
+        llm_description=(
+            "도시코드(city_code)와 정류소 ID(node_id)로 TAGO 버스도착 예정 정보를 조회한다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15098533",
+        tool_id="tago_bus_location_search",
+        module_name="tago_bus_location",
+        name_ko="국토교통부 TAGO 버스위치 조회",
+        ministry="MOLIT",
+        category=["transport", "bus", "public-data"],
+        endpoint="https://apis.data.go.kr/1613000/BusLcInfoInqireService/getRouteAcctoBusLcList",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "city_code": "cityCode",
+            "route_id": "routeId",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        evidence_path="docs/api/data-go-kr-candidate-docs/15098533/probes/live-2026-05-16/tago-bus-location.body.xml",
+        policy_url=_data_go_policy("15098533"),
+        policy_text="공공데이터포털 인증키 기반 국토교통부 TAGO 버스위치정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15098533 TAGO 버스위치 routeId bus location find",
+        llm_description="도시코드(city_code)와 노선 ID(route_id)로 TAGO 버스 위치 정보를 조회한다.",
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15098534",
+        tool_id="tago_bus_station_search",
+        module_name="tago_bus_station",
+        name_ko="국토교통부 TAGO 버스정류소 조회",
+        ministry="MOLIT",
+        category=["transport", "bus", "public-data"],
+        endpoint="https://apis.data.go.kr/1613000/BusSttnInfoInqireService/getSttnNoList",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "city_code": "cityCode",
+            "node_nm": "nodeNm",
+            "node_no": "nodeNo",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        evidence_path="docs/api/data-go-kr-candidate-docs/15098534/probes/live-2026-05-16/tago-bus-station.body.xml",
+        policy_url=_data_go_policy("15098534"),
+        policy_text="공공데이터포털 인증키 기반 국토교통부 TAGO 버스정류소정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15098534 TAGO 버스정류소 nodeNm nodeNo station find",
+        llm_description=(
+            "도시코드(city_code), 정류소명(node_nm), "
+            "정류소번호(node_no)로 TAGO 정류소 정보를 조회한다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15101360",
+        tool_id="kepco_contract_power_usage",
+        module_name="kepco_power_usage",
+        name_ko="한국전력 계약종별 전력사용량 조회",
+        ministry="KEPCO",
+        category=["energy", "utility", "public-data"],
+        endpoint="https://bigdata.kepco.co.kr/openapi/v1/powerUsage/contractType.do",
+        env_var="UMMAYA_KEPCO_POWER_DATA_API_KEY",
+        auth_query_param="apiKey",
+        response_format="json",
+        query_param_map={
+            "year": "year",
+            "month": "month",
+            "metro_cd": "metroCd",
+            "city_cd": "cityCd",
+            "cntr_cd": "cntrCd",
+        },
+        static_query_params={"returnType": "json"},
+        evidence_path="docs/api/data-go-kr-candidate-docs/15101360/probes/live-2026-05-16/kepco-contract-type.body.json",
+        policy_url="https://bigdata.kepco.co.kr/cmsmain.do?scode=S01&pcode=000493&pstate=cntr&redirect=Y",
+        policy_text="한국전력 전력데이터 개방포털 인증키 기반 계약종별 전력사용량 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15101360 KEPCO 한전 계약종별 전력사용량 power usage cntrCd find",
+        llm_description=(
+            "연월과 지역/계약종별 코드로 한국전력 계약종별 전력사용량 공개 데이터를 조회한다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15129394",
+        tool_id="pps_bid_public_info",
+        module_name="pps_bid_public_info",
+        name_ko="조달청 나라장터 입찰공고 조회",
+        ministry="PPS",
+        category=["procurement", "bid", "public-data"],
+        endpoint="https://apis.data.go.kr/1230000/ad/BidPublicInfoService/getBidPblancListInfoServc",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="json",
+        query_param_map={
+            "inqry_div": "inqryDiv",
+            "bid_ntce_no": "bidNtceNo",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        static_query_params={"type": "json"},
+        evidence_path="docs/api/data-go-kr-candidate-docs/15129394/probes/live-2026-05-16/pps-bid-service.body.json",
+        policy_url=_data_go_policy("15129394"),
+        policy_text="공공데이터포털 인증키 기반 조달청 나라장터 입찰공고정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15129394 조달청 나라장터 입찰공고 bid public info find",
+        llm_description=(
+            "조회구분(inqry_div)과 입찰공고번호(bid_ntce_no)로 "
+            "나라장터 입찰공고 공개 데이터를 조회한다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15134761",
+        tool_id="reb_real_estate_stat_table",
+        module_name="reb_real_estate_stats",
+        name_ko="한국부동산원 부동산 통계표 조회",
+        ministry="REB",
+        category=["real-estate", "statistics", "public-data"],
+        endpoint="https://www.reb.or.kr/r-one/openapi/SttsApiTbl.do",
+        env_var="UMMAYA_REB_REAL_ESTATE_STATS_API_KEY",
+        auth_query_param="KEY",
+        response_format="json",
+        query_param_map={"statbl_id": "STATBL_ID", "p_index": "pIndex", "p_size": "pSize"},
+        static_query_params={"Type": "json"},
+        evidence_path="docs/api/data-go-kr-candidate-docs/15134761/probes/live-2026-05-16/reb-stat-table.body.json",
+        policy_url="https://www.reb.or.kr/r-one/portal/openapi/openApiDevPage.do",
+        policy_text="한국부동산원 R-ONE OpenAPI 인증키 기반 부동산통계 조회 서비스.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15134761 한국부동산원 REB R-ONE 부동산통계 통계표 find",
+        llm_description=(
+            "한국부동산원 R-ONE 부동산 통계표 목록을 조회한다. 통계표 ID(statbl_id)는 선택 필터다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15157485",
+        tool_id="bfc_funeral_area_fee",
+        module_name="bfc_funeral_cost",
+        name_ko="부산시설공단 장례식장 시설사용료 조회",
+        ministry="BFC",
+        category=["funeral", "fee", "public-data"],
+        endpoint="https://apis.data.go.kr/B552587/FuneralCostsService_v2/getFCAreaList_v2",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="json",
+        query_param_map={"page_no": "pageNo", "num_of_rows": "numOfRows"},
+        static_query_params={"resultType": "json"},
+        evidence_path="docs/api/data-go-kr-candidate-docs/15157485/probes/live-2026-05-16/funeral-area-list.body.json",
+        policy_url=_data_go_policy("15157485"),
+        policy_text="공공데이터포털 인증키 기반 부산시설공단 장례비산출 정보 조회 OpenAPI.",
+        last_verified=_LAST_VERIFIED,
+        search_hint="15157485 부산시설공단 장례비 장례식장 시설사용료 funeral fee find",
+        llm_description="부산시설공단 장례비산출 서비스의 시설사용료 목록을 조회한다.",
+        trigger_examples=["부산 장례식장 시설사용료 조회해줘"],
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15158680",
+        tool_id="kcue_finance_regional_tuition",
+        module_name="kcue_finance_status",
+        name_ko="대학알리미 지역별 등록금 현황 조회",
+        ministry="KCUE",
+        category=["education", "university", "public-data"],
+        endpoint="https://apis.data.go.kr/B340014/FinancesService/getRegionalTuitionCrntSt",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "schl_div_cd": "schlDivCd",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        evidence_path="docs/api/data-go-kr-candidate-docs/15158680/probes/live-2026-05-16/finance-regional-tuition.body.xml",
+        policy_url=_data_go_policy("15158680"),
+        policy_text=(
+            "공공데이터포털 인증키 기반 한국대학교육협의회 대학알리미 재정 현황 조회 OpenAPI."
+        ),
+        last_verified=_LAST_VERIFIED,
+        search_hint="15158680 대학알리미 재정 등록금 지역별 KCUE tuition finance find",
+        llm_description=(
+            "학교구분코드(schl_div_cd)로 대학알리미 지역별 등록금 현황 공개 데이터를 조회한다."
+        ),
+    ),
+    VerifiedAdapterSpec(
+        dataset_id="15158684",
+        tool_id="kcue_student_regional_foreign",
+        module_name="kcue_student_status",
+        name_ko="대학알리미 지역별 외국인 유학생 현황 조회",
+        ministry="KCUE",
+        category=["education", "university", "public-data"],
+        endpoint="https://apis.data.go.kr/B340014/StudentService/getRegionalForeignStudentCrntSt",
+        env_var=_DATA_GO_KR_KEY,
+        auth_query_param="serviceKey",
+        response_format="xml",
+        query_param_map={
+            "schl_div_cd": "schlDivCd",
+            "page_no": "pageNo",
+            "num_of_rows": "numOfRows",
+        },
+        evidence_path="docs/api/data-go-kr-candidate-docs/15158684/probes/live-2026-05-16/student-regional-foreign.body.xml",
+        policy_url=_data_go_policy("15158684"),
+        policy_text=(
+            "공공데이터포털 인증키 기반 한국대학교육협의회 대학정보공시 학생 현황 조회 OpenAPI."
+        ),
+        last_verified=_LAST_VERIFIED,
+        search_hint="15158684 대학알리미 학생 외국인 유학생 지역별 KCUE student foreign find",
+        llm_description=(
+            "학교구분코드(schl_div_cd)로 "
+            "대학알리미 지역별 외국인 유학생 현황 공개 데이터를 조회한다."
+        ),
+    ),
+)
+
+_BY_TOOL_ID = {spec.tool_id: spec for spec in VERIFIED_DATA_GO_KR_ADAPTERS}
+
+
+def require_spec(tool_id: str) -> VerifiedAdapterSpec:
+    """Return the manifest entry for *tool_id*."""
+
+    return _BY_TOOL_ID[tool_id]

--- a/src/ummaya/tools/verified_data_go_kr/_models.py
+++ b/src/ummaya/tools/verified_data_go_kr/_models.py
@@ -1,0 +1,64 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Typed models for verified public-data adapter wrappers."""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.models import Ministry
+
+ResponseFormat = Literal["json", "xml"]
+
+
+class VerifiedPublicDataItem(BaseModel):
+    """One normalized upstream row."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    record: dict[str, object] = Field(
+        ...,
+        description="Provider row as a typed JSON-compatible object map.",
+    )
+
+
+class VerifiedPublicDataOutput(BaseModel):
+    """Envelope-ready collection output returned by verified adapters."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    kind: Literal["collection"] = "collection"
+    items: list[VerifiedPublicDataItem]
+    total_count: int = Field(ge=0)
+
+
+class VerifiedAdapterSpec(BaseModel):
+    """Static manifest entry for one direct-curl verified API."""
+
+    model_config = ConfigDict(extra="forbid", frozen=True)
+
+    dataset_id: str
+    tool_id: str
+    module_name: str
+    name_ko: str
+    ministry: Ministry
+    category: list[str]
+    endpoint: str = Field(pattern=r"^https://")
+    env_var: str
+    auth_query_param: str
+    response_format: ResponseFormat
+    query_param_map: dict[str, str]
+    static_query_params: dict[str, str] = Field(default_factory=dict)
+    record_tag: str | None = None
+    evidence_path: str
+    policy_url: str
+    policy_text: str
+    last_verified: datetime
+    search_hint: str
+    llm_description: str
+    trigger_examples: list[str] = Field(default_factory=list)
+    primitive: Literal["find"] = "find"
+    adapter_mode: Literal["live"] = "live"
+    citizen_facing_gate: Literal["read-only"] = "read-only"

--- a/src/ummaya/tools/verified_data_go_kr/_parsing.py
+++ b/src/ummaya/tools/verified_data_go_kr/_parsing.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Response parsers for verified data.go.kr-style adapters."""
+
+from __future__ import annotations
+
+import json
+import xml.etree.ElementTree as ET
+from collections.abc import Iterable, Mapping, Sequence
+from typing import cast
+
+from ummaya.tools.verified_data_go_kr._models import (
+    ResponseFormat,
+    VerifiedPublicDataItem,
+    VerifiedPublicDataOutput,
+)
+
+SUCCESS_CODES = frozenset({"0", "00", "INFO-000"})
+MAX_PAYLOAD_BYTES = 2_000_000
+
+
+class VerifiedUpstreamError(ValueError):
+    """Raised when an upstream payload is structurally valid but reports failure."""
+
+    def __init__(self, upstream_code: str, upstream_message: str) -> None:
+        super().__init__(f"Verified upstream returned {upstream_code}: {upstream_message}")
+        self.upstream_code = upstream_code
+        self.upstream_message = upstream_message
+
+
+def parse_verified_payload(
+    payload: bytes,
+    *,
+    response_format: ResponseFormat,
+    record_tag: str | None = None,
+) -> VerifiedPublicDataOutput:
+    """Parse a verified live-probe payload into a collection envelope."""
+
+    if len(payload) > MAX_PAYLOAD_BYTES:
+        raise VerifiedUpstreamError("PAYLOAD_TOO_LARGE", f"{len(payload)} bytes")
+
+    if response_format == "json":
+        raw: object = json.loads(payload.decode("utf-8-sig"))
+        return _parse_json_payload(raw)
+    root = ET.fromstring(payload.decode("utf-8-sig"))  # noqa: S314
+    return _parse_xml_payload(root, record_tag=record_tag)
+
+
+def _parse_json_payload(raw: object) -> VerifiedPublicDataOutput:
+    code, message = _find_json_status(raw)
+    if code is not None and code not in SUCCESS_CODES:
+        raise VerifiedUpstreamError(code, message or "")
+
+    records = _extract_json_records(raw)
+    total_count = _find_first_int(raw, ("totalCount", "totData", "list_total_count"))
+    return VerifiedPublicDataOutput(
+        items=[VerifiedPublicDataItem(record=record) for record in records],
+        total_count=total_count if total_count is not None else len(records),
+    )
+
+
+def _parse_xml_payload(
+    root: ET.Element,
+    *,
+    record_tag: str | None,
+) -> VerifiedPublicDataOutput:
+    code = _find_xml_text(root, "resultCode")
+    message = _find_xml_text(root, "resultMsg") or ""
+    if code is not None and code not in SUCCESS_CODES:
+        raise VerifiedUpstreamError(code, message)
+
+    if record_tag is not None:
+        elements = [_el for _el in root.iter() if _strip_namespace(_el.tag) == record_tag]
+    else:
+        elements = [_el for _el in root.iter() if _strip_namespace(_el.tag) == "item"]
+
+    records = [_xml_record(element) for element in elements]
+    total_count = _to_int(_find_xml_text(root, "totalCount"))
+    return VerifiedPublicDataOutput(
+        items=[VerifiedPublicDataItem(record=record) for record in records],
+        total_count=total_count if total_count is not None else len(records),
+    )
+
+
+def _find_json_status(raw: object) -> tuple[str | None, str | None]:
+    for mapping in _walk_mappings(raw):
+        result_code = _string_value(mapping.get("resultCode"))
+        if result_code is not None:
+            return result_code, _string_value(mapping.get("resultMsg"))
+        result = mapping.get("RESULT")
+        if isinstance(result, Mapping):
+            result_map = cast(Mapping[object, object], result)
+            code = _string_value(result_map.get("CODE"))
+            if code is not None:
+                return code, _string_value(result_map.get("MESSAGE"))
+    return None, None
+
+
+def _extract_json_records(raw: object) -> list[dict[str, object]]:
+    root = _as_mapping(raw)
+    if root is None:
+        return _coerce_records(raw)
+
+    response = _as_mapping(root.get("response"))
+    if response is not None:
+        body = _as_mapping(response.get("body"))
+        if body is not None:
+            items = body.get("items")
+            item_records = _extract_items_value(items)
+            if item_records:
+                return item_records
+
+    reb_rows = _extract_reb_rows(root)
+    if reb_rows:
+        return reb_rows
+
+    data_records = _coerce_records(root.get("data"))
+    if data_records:
+        return data_records
+
+    row_records = _coerce_records(root.get("row"))
+    if row_records:
+        return row_records
+
+    return _coerce_records(raw)
+
+
+def _extract_items_value(value: object) -> list[dict[str, object]]:
+    items = _as_mapping(value)
+    if items is not None:
+        nested = _coerce_records(items.get("item"))
+        if nested:
+            return nested
+        return _coerce_records(items)
+    return _coerce_records(value)
+
+
+def _extract_reb_rows(root: Mapping[object, object]) -> list[dict[str, object]]:
+    for value in root.values():
+        if not isinstance(value, Sequence) or isinstance(value, (str, bytes, bytearray)):
+            continue
+        for entry in value:
+            entry_map = _as_mapping(entry)
+            if entry_map is None:
+                continue
+            rows = _coerce_records(entry_map.get("row"))
+            if rows:
+                return rows
+    return []
+
+
+def _coerce_records(value: object) -> list[dict[str, object]]:
+    if value is None:
+        return []
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        records: list[dict[str, object]] = []
+        for item in value:
+            item_map = _as_mapping(item)
+            if item_map is not None:
+                records.append(_normalize_mapping(item_map))
+        return records
+    value_map = _as_mapping(value)
+    if value_map is not None:
+        return [_normalize_mapping(value_map)]
+    return []
+
+
+def _walk_mappings(value: object) -> Iterable[Mapping[object, object]]:
+    value_map = _as_mapping(value)
+    if value_map is not None:
+        yield value_map
+        for child in value_map.values():
+            yield from _walk_mappings(child)
+        return
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        for item in value:
+            yield from _walk_mappings(item)
+
+
+def _find_first_int(value: object, keys: tuple[str, ...]) -> int | None:
+    for mapping in _walk_mappings(value):
+        for key in keys:
+            parsed = _to_int(_string_value(mapping.get(key)))
+            if parsed is not None:
+                return parsed
+    return None
+
+
+def _normalize_mapping(mapping: Mapping[object, object]) -> dict[str, object]:
+    return {str(key): _normalize_value(value) for key, value in mapping.items()}
+
+
+def _normalize_value(value: object) -> object:
+    if isinstance(value, Mapping):
+        return _normalize_mapping(cast(Mapping[object, object], value))
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return [_normalize_value(item) for item in value]
+    if isinstance(value, bytes):
+        return value.decode("utf-8", errors="replace")
+    return value
+
+
+def _as_mapping(value: object) -> Mapping[object, object] | None:
+    if isinstance(value, Mapping):
+        return cast(Mapping[object, object], value)
+    return None
+
+
+def _string_value(value: object) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        text = value.strip()
+        return text if text else None
+    if isinstance(value, (int, float, bool)):
+        return str(value)
+    return None
+
+
+def _to_int(value: object) -> int | None:
+    if value is None:
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _find_xml_text(root: ET.Element, tag_name: str) -> str | None:
+    for element in root.iter():
+        if _strip_namespace(element.tag) == tag_name:
+            text = element.text.strip() if element.text is not None else ""
+            return text or None
+    return None
+
+
+def _xml_record(element: ET.Element) -> dict[str, object]:
+    record: dict[str, object] = {}
+    for child in list(element):
+        tag = _strip_namespace(child.tag)
+        if list(child):
+            record[tag] = _xml_record(child)
+        else:
+            record[tag] = child.text.strip() if child.text is not None else ""
+    if not record:
+        text = element.text.strip() if element.text is not None else ""
+        record[_strip_namespace(element.tag)] = text
+    return record
+
+
+def _strip_namespace(tag: str) -> str:
+    return tag.rsplit("}", maxsplit=1)[-1]

--- a/src/ummaya/tools/verified_data_go_kr/airkorea_air_quality.py
+++ b/src/ummaya/tools/verified_data_go_kr/airkorea_air_quality.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""AirKorea city/province real-time air quality adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class AirKoreaAirQualityInput(BaseModel):
+    """Input for AirKorea city/province air quality."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    sido_name: str = Field(..., min_length=1, description="Korean province/city name.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+    ver: str = Field(default="1.0", description="AirKorea response version.")
+
+
+SPEC = require_spec("airkorea_ctprvn_air_quality")
+INPUT_SCHEMA = AirKoreaAirQualityInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: AirKoreaAirQualityInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay AirKorea air quality rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/bfc_funeral_cost.py
+++ b/src/ummaya/tools/verified_data_go_kr/bfc_funeral_cost.py
@@ -1,0 +1,46 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Busan Facilities Corporation funeral area fee adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class BfcFuneralAreaFeeInput(BaseModel):
+    """Input for BFC funeral area fee list."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("bfc_funeral_area_fee")
+INPUT_SCHEMA = BfcFuneralAreaFeeInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: BfcFuneralAreaFeeInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay BFC funeral area fee rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/fsc_corporate_finance.py
+++ b/src/ummaya/tools/verified_data_go_kr/fsc_corporate_finance.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FSC corporate finance summary adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class FscCorporateFinanceInput(BaseModel):
+    """Input for FSC corporate finance summary."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    crno: str = Field(..., min_length=1, description="Corporate registration number.")
+    biz_year: str = Field(..., min_length=4, max_length=4, description="Business year.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("fsc_corporate_finance_summary")
+INPUT_SCHEMA = FscCorporateFinanceInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: FscCorporateFinanceInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay FSC corporate finance summary."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/ftc_large_group.py
+++ b/src/ummaya/tools/verified_data_go_kr/ftc_large_group.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FTC large corporate group status adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class FtcLargeGroupInput(BaseModel):
+    """Input for FTC large corporate group status."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    presentn_year: str = Field(..., min_length=4, description="Disclosure year/month.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("ftc_large_group_status")
+INPUT_SCHEMA = FtcLargeGroupInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: FtcLargeGroupInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay FTC large corporate group rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/ftc_public_ym.py
+++ b/src/ummaya/tools/verified_data_go_kr/ftc_public_ym.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""FTC public disclosure year/month adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class FtcPublicYmInput(BaseModel):
+    """Input for FTC public disclosure year/month."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    job_se_code: str = Field(..., min_length=1, description="FTC job section code.")
+    presentn_year: str = Field(..., min_length=4, description="Disclosure year.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("ftc_public_ym_list")
+INPUT_SCHEMA = FtcPublicYmInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: FtcPublicYmInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay FTC public year/month rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/kcue_finance_status.py
+++ b/src/ummaya/tools/verified_data_go_kr/kcue_finance_status.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KCUE regional tuition status adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class KcueFinanceStatusInput(BaseModel):
+    """Input for KCUE regional tuition status."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schl_div_cd: str = Field(..., min_length=1, description="School division code.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("kcue_finance_regional_tuition")
+INPUT_SCHEMA = KcueFinanceStatusInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: KcueFinanceStatusInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay KCUE regional tuition rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/kcue_student_status.py
+++ b/src/ummaya/tools/verified_data_go_kr/kcue_student_status.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KCUE regional foreign student status adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class KcueStudentStatusInput(BaseModel):
+    """Input for KCUE regional foreign student status."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    schl_div_cd: str = Field(..., min_length=1, description="School division code.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("kcue_student_regional_foreign")
+INPUT_SCHEMA = KcueStudentStatusInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: KcueStudentStatusInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay KCUE regional foreign student rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/kepco_power_usage.py
+++ b/src/ummaya/tools/verified_data_go_kr/kepco_power_usage.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KEPCO contract-type power usage adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class KepcoPowerUsageInput(BaseModel):
+    """Input for KEPCO contract-type power usage."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    year: str = Field(..., min_length=4, max_length=4, description="Usage year.")
+    month: str = Field(..., min_length=1, max_length=2, description="Usage month.")
+    metro_cd: str | None = Field(default=None, description="Metropolitan code.")
+    city_cd: str | None = Field(default=None, description="City/county/district code.")
+    cntr_cd: str | None = Field(default=None, description="Contract type code.")
+
+
+SPEC = require_spec("kepco_contract_power_usage")
+INPUT_SCHEMA = KepcoPowerUsageInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: KepcoPowerUsageInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay KEPCO power usage rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/pps_bid_public_info.py
+++ b/src/ummaya/tools/verified_data_go_kr/pps_bid_public_info.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""PPS bid public information adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class PpsBidPublicInfoInput(BaseModel):
+    """Input for PPS bid public information."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    inqry_div: str = Field(..., min_length=1, description="PPS inquiry division.")
+    bid_ntce_no: str | None = Field(default=None, description="Bid notice number.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("pps_bid_public_info")
+INPUT_SCHEMA = PpsBidPublicInfoInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: PpsBidPublicInfoInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay PPS bid public information rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/reb_real_estate_stats.py
+++ b/src/ummaya/tools/verified_data_go_kr/reb_real_estate_stats.py
@@ -1,0 +1,47 @@
+# SPDX-License-Identifier: Apache-2.0
+"""REB real-estate statistic table adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class RebRealEstateStatsInput(BaseModel):
+    """Input for REB statistic table search."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    statbl_id: str | None = Field(default=None, description="Optional statistic table ID.")
+    p_index: int = Field(default=1, ge=1, description="Page index.")
+    p_size: int = Field(default=100, ge=1, le=1000, description="Page size.")
+
+
+SPEC = require_spec("reb_real_estate_stat_table")
+INPUT_SCHEMA = RebRealEstateStatsInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: RebRealEstateStatsInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay REB real-estate statistic table rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/tago_bus_arrival.py
+++ b/src/ummaya/tools/verified_data_go_kr/tago_bus_arrival.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TAGO bus arrival search adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class TagoBusArrivalInput(BaseModel):
+    """Input for TAGO bus arrival search."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    city_code: str = Field(..., min_length=1, description="TAGO city code.")
+    node_id: str = Field(..., min_length=1, description="TAGO bus station ID.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("tago_bus_arrival_search")
+INPUT_SCHEMA = TagoBusArrivalInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: TagoBusArrivalInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay TAGO bus arrival rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/tago_bus_location.py
+++ b/src/ummaya/tools/verified_data_go_kr/tago_bus_location.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TAGO bus location search adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class TagoBusLocationInput(BaseModel):
+    """Input for TAGO bus location search."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    city_code: str = Field(..., min_length=1, description="TAGO city code.")
+    route_id: str = Field(..., min_length=1, description="TAGO route ID.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("tago_bus_location_search")
+INPUT_SCHEMA = TagoBusLocationInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: TagoBusLocationInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay TAGO bus location rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/tago_bus_route.py
+++ b/src/ummaya/tools/verified_data_go_kr/tago_bus_route.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TAGO bus route search adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class TagoBusRouteInput(BaseModel):
+    """Input for TAGO bus route search."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    city_code: str = Field(..., min_length=1, description="TAGO city code.")
+    route_no: str = Field(..., min_length=1, description="Bus route number.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("tago_bus_route_search")
+INPUT_SCHEMA = TagoBusRouteInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: TagoBusRouteInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay TAGO bus route rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/src/ummaya/tools/verified_data_go_kr/tago_bus_station.py
+++ b/src/ummaya/tools/verified_data_go_kr/tago_bus_station.py
@@ -1,0 +1,49 @@
+# SPDX-License-Identifier: Apache-2.0
+"""TAGO bus station search adapter."""
+
+from __future__ import annotations
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr._factory import (
+    build_tool,
+    handle_verified_input,
+    register_module,
+)
+from ummaya.tools.verified_data_go_kr._manifest import require_spec
+
+
+class TagoBusStationInput(BaseModel):
+    """Input for TAGO bus station search."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    city_code: str = Field(..., min_length=1, description="TAGO city code.")
+    node_nm: str | None = Field(default=None, description="Bus station name.")
+    node_no: str | None = Field(default=None, description="Bus station number.")
+    page_no: int = Field(default=1, ge=1, description="Page number.")
+    num_of_rows: int = Field(default=10, ge=1, le=100, description="Rows per page.")
+
+
+SPEC = require_spec("tago_bus_station_search")
+INPUT_SCHEMA = TagoBusStationInput
+TOOL: GovAPITool = build_tool(SPEC, INPUT_SCHEMA)
+
+
+async def handle(
+    input_model: TagoBusStationInput,
+    *,
+    fixture_body: bytes | None = None,
+) -> dict[str, object]:
+    """Fetch or replay TAGO bus station rows."""
+
+    return await handle_verified_input(input_model, SPEC, fixture_body=fixture_body)
+
+
+def register(registry: ToolRegistry, executor: ToolExecutor) -> None:
+    """Register this adapter."""
+
+    register_module(registry, executor, tool=TOOL, input_schema=INPUT_SCHEMA, handler=handle)

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -15,8 +15,10 @@ Covers the US1 acceptance scenarios:
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
+from datetime import UTC, datetime
 
 import pytest
+from pydantic import BaseModel
 
 from ummaya.context.builder import ContextBuilder
 from ummaya.context.models import SystemPromptConfig
@@ -29,9 +31,11 @@ from ummaya.engine.models import QueryContext, SessionBudget
 # QueryContext.model_rebuild() can resolve the forward reference and accept
 # mock objects for the llm_client field.
 from ummaya.llm.client import LLMClient  # noqa: F401
-from ummaya.llm.models import ChatMessage
+from ummaya.llm.models import ChatMessage, StreamEvent
 from ummaya.llm.usage import UsageTracker
 from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool
+from ummaya.tools.mvp_surface import register_mvp_surface
 from ummaya.tools.registry import ToolRegistry
 
 QueryContext.model_rebuild()
@@ -118,6 +122,115 @@ class _FailingMockClient(_MockLLMClientBase):
         """Raise immediately to simulate a catastrophic LLM failure."""
         raise RuntimeError("Simulated LLM failure")
         yield  # pragma: no cover — makes this an async generator
+
+
+class _CapturingToolsClient(_MockLLMClientBase):
+    """Mock LLM client that records provider tool definitions."""
+
+    def __init__(self) -> None:
+        self._usage = UsageTracker(budget=100_000)
+        self.tools_seen: object | None = None
+
+    @property
+    def usage(self) -> UsageTracker:  # type: ignore[override]
+        return self._usage
+
+    async def stream(  # type: ignore[override]
+        self,
+        messages: list[ChatMessage],
+        **kwargs: object,
+    ) -> AsyncIterator[object]:
+        self.tools_seen = kwargs.get("tools")
+        yield StreamEvent(type="content_delta", content="ok")
+
+
+class _AdapterContextInput(BaseModel):
+    page_no: int = 1
+
+
+class _AdapterContextOutput(BaseModel):
+    kind: str
+    items: list[dict[str, object]]
+
+
+def _adapter_context_tool() -> GovAPITool:
+    return GovAPITool(
+        id="bfc_funeral_area_fee",
+        name_ko="부산시설공단 장례식장 시설 사용료",
+        ministry="BFC",
+        category=["public-data", "funeral"],
+        endpoint="https://apis.data.go.kr/example",
+        auth_type="api_key",
+        input_schema=_AdapterContextInput,
+        output_schema=_AdapterContextOutput,
+        search_hint="부산 장례식장 시설 사용료 funeral area fee public data",
+        policy=AdapterRealDomainPolicy(
+            real_classification_url="https://www.data.go.kr/policy/privacyPolicy.do",
+            real_classification_text="test read-only policy",
+            citizen_facing_gate="read-only",
+            last_verified=datetime(2026, 5, 16, tzinfo=UTC),
+        ),
+        primitive="find",
+        llm_description="부산광역시 장례식장 시설 사용료 공개 데이터를 조회한다.",
+    )
+
+
+def test_available_adapters_context_includes_retrieved_adapter() -> None:
+    """Rich REPL QueryEngine must inject BM25 adapter candidates for the turn."""
+    registry = ToolRegistry()
+    register_mvp_surface(registry)
+    registry.register(_adapter_context_tool())
+    executor = ToolExecutor(registry)
+    engine = QueryEngine(
+        llm_client=_FailingMockClient(),
+        tool_registry=registry,
+        tool_executor=executor,
+    )
+
+    message = engine._build_available_adapters_message(  # noqa: SLF001
+        "부산광역시 장례식장 시설 사용료 목록을 조회해줘"
+    )
+
+    assert message is not None
+    assert message.role == "system"
+    assert "<available_adapters>" in (message.content or "")
+    assert "bfc_funeral_area_fee" in (message.content or "")
+    assert "find({tool_id, params})" in (message.content or "")
+    assert "Do not call locate just because" in (message.content or "")
+    assert "call_hint: find(" in (message.content or "")
+
+
+@pytest.mark.asyncio
+async def test_available_adapters_context_constrains_public_data_turn_to_find() -> None:
+    """Location-independent public data turns should not expose locate."""
+    registry = ToolRegistry()
+    register_mvp_surface(registry)
+    registry.register(_adapter_context_tool())
+    executor = ToolExecutor(registry)
+    client = _CapturingToolsClient()
+    engine = QueryEngine(
+        llm_client=client,
+        tool_registry=registry,
+        tool_executor=executor,
+    )
+
+    events = [
+        event async for event in engine.run("부산광역시 장례식장 시설 사용료 목록을 조회해줘")
+    ]
+
+    assert events[-1].type == "stop"
+    assert isinstance(client.tools_seen, list)
+    tool_names: list[str] = []
+    for tool in client.tools_seen:
+        if not isinstance(tool, dict):
+            continue
+        function = tool.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if isinstance(name, str):
+            tool_names.append(name)
+    assert tool_names == ["find"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/engine/test_engine_concurrent.py
+++ b/tests/engine/test_engine_concurrent.py
@@ -14,9 +14,12 @@ added for documentation clarity.
 
 from __future__ import annotations
 
+import json
 import time
+from datetime import UTC, datetime
 
 import pytest
+from pydantic import BaseModel, Field
 
 from ummaya.engine.config import QueryEngineConfig
 from ummaya.engine.events import StopReason
@@ -29,6 +32,8 @@ from ummaya.llm.client import LLMClient  # noqa: F401
 from ummaya.llm.models import ChatMessage, FunctionCall, ToolCall
 from ummaya.llm.usage import UsageTracker
 from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool
+from ummaya.tools.mvp_surface import register_mvp_surface
 from ummaya.tools.registry import ToolRegistry
 
 QueryContext.model_rebuild()
@@ -42,6 +47,42 @@ QueryContext.model_rebuild()
 def _tc(call_id: str, tool_name: str, args: str = '{"query": "test"}') -> ToolCall:
     """Shorthand to build a ToolCall."""
     return ToolCall(id=call_id, function=FunctionCall(name=tool_name, arguments=args))
+
+
+class _PrimitiveTargetInput(BaseModel):
+    query: str | None = None
+    page_no: int = Field(default=1, ge=1)
+
+
+class _PrimitiveTargetOutput(BaseModel):
+    kind: str
+    items: list[dict[str, object]]
+    total_count: int
+
+
+def _read_only_policy() -> AdapterRealDomainPolicy:
+    return AdapterRealDomainPolicy(
+        real_classification_url="https://www.data.go.kr/policy/privacyPolicy.do",
+        real_classification_text="test read-only policy",
+        citizen_facing_gate="read-only",
+        last_verified=datetime(2026, 5, 16, tzinfo=UTC),
+    )
+
+
+def _primitive_target_tool(tool_id: str, *, primitive: str) -> GovAPITool:
+    return GovAPITool(
+        id=tool_id,
+        name_ko=tool_id,
+        ministry="UMMAYA" if primitive == "locate" else "BFC",
+        category=[primitive, "test"],
+        endpoint=f"internal://{tool_id}",
+        auth_type="public",
+        input_schema=_PrimitiveTargetInput,
+        output_schema=_PrimitiveTargetOutput,
+        search_hint=f"{tool_id} {primitive}",
+        policy=_read_only_policy(),
+        primitive=primitive,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -114,6 +155,78 @@ class TestDispatchToolCallsSingleSafe:
         assert len(results) == 1
         assert results[0].tool_id == "traffic_accident_search"
         assert results[0].success is True
+
+
+class TestDispatchToolCallsRootPrimitives:
+    """Root primitive calls fan out to their selected adapter ids."""
+
+    @pytest.mark.asyncio
+    async def test_find_root_primitive_invokes_selected_lookup_adapter(self) -> None:
+        registry = ToolRegistry()
+        register_mvp_surface(registry)
+        registry.register(_primitive_target_tool("bfc_funeral_area_fee", primitive="find"))
+        executor = ToolExecutor(registry)
+
+        async def _adapter(inp: _PrimitiveTargetInput) -> dict[str, object]:
+            return {
+                "kind": "collection",
+                "items": [{"record": {"query": inp.query, "faName": "영락공원"}}],
+                "total_count": 1,
+            }
+
+        executor.register_adapter("bfc_funeral_area_fee", _adapter)
+        results = await dispatch_tool_calls(
+            [
+                _tc(
+                    "call_find",
+                    "find",
+                    '{"tool_id":"bfc_funeral_area_fee","params":{"query":"부산 장례식장"}}',
+                )
+            ],
+            registry,
+            executor,
+        )
+
+        assert len(results) == 1
+        assert results[0].tool_id == "find"
+        assert results[0].success is True
+        assert results[0].data is not None
+        assert results[0].data["kind"] == "collection"
+        json.dumps(results[0].data)
+
+    @pytest.mark.asyncio
+    async def test_locate_root_primitive_invokes_selected_locate_adapter(self) -> None:
+        registry = ToolRegistry()
+        register_mvp_surface(registry)
+        registry.register(_primitive_target_tool("kakao_keyword_search", primitive="locate"))
+        executor = ToolExecutor(registry)
+
+        async def _adapter(inp: _PrimitiveTargetInput) -> dict[str, object]:
+            return {
+                "kind": "collection",
+                "items": [{"record": {"query": inp.query, "lat": 35.18, "lon": 129.07}}],
+                "total_count": 1,
+            }
+
+        executor.register_adapter("kakao_keyword_search", _adapter)
+        results = await dispatch_tool_calls(
+            [
+                _tc(
+                    "call_locate",
+                    "locate",
+                    '{"tool_id":"kakao_keyword_search","params":{"query":"부산광역시"}}',
+                )
+            ],
+            registry,
+            executor,
+        )
+
+        assert len(results) == 1
+        assert results[0].tool_id == "locate"
+        assert results[0].success is True
+        assert results[0].data is not None
+        assert results[0].data["kind"] == "collection"
+        json.dumps(results[0].data)
 
 
 class TestDispatchToolCallsTwoSafe:

--- a/tests/integration/test_discovery_bridge_path_b.py
+++ b/tests/integration/test_discovery_bridge_path_b.py
@@ -41,12 +41,12 @@ def test_b1_total_tool_count_includes_mocks(
 ) -> None:
     """Path B-1: bridge registers active non-core mock adapters into main registry.
 
-    Expected total: 38 after locate provider adapters became first-class.
+    Expected total: 52 after the verified public-data adapter wave.
     """
     r, _ = loaded_registry
     total = len(r.all_tools())
-    assert total == 38, (
-        f"Expected 38 total tools after discovery_bridge runs; got {total}. "
+    assert total == 52, (
+        f"Expected 52 total tools after discovery_bridge runs; got {total}. "
         f"Verify the bridge registered the active mock adapters."
     )
 

--- a/tests/integration/test_mcp_otel_spans.py
+++ b/tests/integration/test_mcp_otel_spans.py
@@ -87,8 +87,8 @@ class TestMCPToolsListShape:
         tools = response["result"]["tools"]
         # Subscribe is deferred out of the active surface until UMMAYA owns an
         # app/push delivery runtime. The MCP tool list mirrors the active
-        # registry: 38 tools.
-        assert len(tools) == 38, f"Tool list count drift: got {len(tools)}, expected 38"
+        # registry: 52 tools.
+        assert len(tools) == 52, f"Tool list count drift: got {len(tools)}, expected 52"
 
     def test_tools_list_entries_have_required_keys(self, mcp_server: MCPServer) -> None:
         response = asyncio.run(

--- a/tests/llm/test_client.py
+++ b/tests/llm/test_client.py
@@ -261,6 +261,41 @@ async def test_complete_with_tools(
 
 
 @respx.mock
+async def test_complete_strips_internal_trigger_phrase_from_raw_tool_dict(
+    _clean_env: None,
+    sample_messages: list[ChatMessage],
+    mock_completion_response: dict,
+) -> None:
+    """Raw registry tool dicts must be normalized before sending to FriendliAI."""
+    captured_request: list[httpx.Request] = []
+
+    def _capture(request: httpx.Request) -> httpx.Response:
+        captured_request.append(request)
+        return httpx.Response(200, json=mock_completion_response)
+
+    respx.post(CHAT_COMPLETIONS_URL).mock(side_effect=_capture)
+
+    raw_tool = {
+        "type": "function",
+        "function": {
+            "name": "find",
+            "description": "Search and fetch public data adapters.",
+            "parameters": {"type": "object", "properties": {}},
+            "trigger_phrase": "UMMAYA-only routing hint for the system prompt.",
+        },
+    }
+
+    config = LLMClientConfig()
+    async with LLMClient(config) as client:
+        await client.complete(sample_messages, tools=[raw_tool])
+
+    assert len(captured_request) == 1
+    payload = json.loads(captured_request[0].content)
+    assert payload["tools"][0]["function"]["name"] == "find"
+    assert "trigger_phrase" not in payload["tools"][0]["function"]
+
+
+@respx.mock
 async def test_complete_tool_result_continuation(
     _clean_env: None,
 ) -> None:

--- a/tests/tools/test_live_proxy.py
+++ b/tests/tools/test_live_proxy.py
@@ -22,13 +22,15 @@ class _ProxyOutput(BaseModel):
     value: str
 
 
-def _make_proxyable_tool() -> GovAPITool:
+def _make_proxyable_tool(
+    endpoint: str = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtNcst",
+) -> GovAPITool:
     return GovAPITool(
         id="kma_current_observation",
         name_ko="기상청 현재 관측",
         ministry="KMA",
         category=["weather"],
-        endpoint="https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/getUltraSrtNcst",
+        endpoint=endpoint,
         auth_type="api_key",
         input_schema=_ProxyInput,
         output_schema=_ProxyOutput,
@@ -43,6 +45,23 @@ def test_auto_mode_routes_packaged_proxyable_tool(monkeypatch: pytest.MonkeyPatc
     monkeypatch.setenv("UMMAYA_PACKAGE_ROOT", "/opt/homebrew/Caskroom/ummaya/0.1.1/package")
 
     assert should_use_live_adapter_proxy(_make_proxyable_tool()) is True
+
+
+@pytest.mark.parametrize(
+    "endpoint",
+    [
+        "https://bigdata.kepco.co.kr/openapi/v1/powerUsage/contractType.do",
+        "https://www.reb.or.kr/r-one/openapi/SttsApiTbl.do",
+    ],
+)
+def test_auto_mode_routes_packaged_verified_non_data_go_hosts(
+    monkeypatch: pytest.MonkeyPatch,
+    endpoint: str,
+) -> None:
+    monkeypatch.delenv("UMMAYA_LIVE_ADAPTER_MODE", raising=False)
+    monkeypatch.setenv("UMMAYA_PACKAGE_ROOT", "/opt/homebrew/Caskroom/ummaya/0.1.1/package")
+
+    assert should_use_live_adapter_proxy(_make_proxyable_tool(endpoint=endpoint)) is True
 
 
 def test_auto_mode_keeps_source_tree_direct(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -35,10 +35,12 @@ class TestToolRegistration:
         # adapter wrappers (10 verify + 5 submit via discovery_bridge) = 33.
         # Locate adapter split: + 5 first-class locate provider adapters
         # (Kakao address/keyword/coord-region, JUSO adm_cd, SGIS adm_cd) = 38.
+        # Spec #2797 verified public-data wave: + 14 direct-curl verified
+        # data.go.kr/LINK adapters = 52.
         # is_core=False so the LLM's primary tool list stays at active
         # primitives + lookup-class; these participate in
         # lookup(mode="search") BM25 corpus only.
-        assert len(registry) == 38
+        assert len(registry) == 52
 
     def test_tool_ids_present(self) -> None:
         """Each expected tool_id is in the registry.
@@ -72,6 +74,21 @@ class TestToolRegistration:
             # Phase 2 adapters (spec 029)
             "nfa_emergency_info_service",
             "mohw_welfare_eligibility_search",
+            # Spec #2797 verified public-data adapters
+            "fsc_corporate_finance_summary",
+            "airkorea_ctprvn_air_quality",
+            "ftc_large_group_status",
+            "ftc_public_ym_list",
+            "tago_bus_route_search",
+            "tago_bus_arrival_search",
+            "tago_bus_location_search",
+            "tago_bus_station_search",
+            "kepco_contract_power_usage",
+            "pps_bid_public_info",
+            "reb_real_estate_stat_table",
+            "bfc_funeral_area_fee",
+            "kcue_finance_regional_tuition",
+            "kcue_student_regional_foreign",
         }
         for tool_id in expected:
             assert tool_id in registry, f"{tool_id} not found in registry"
@@ -99,6 +116,21 @@ class TestToolRegistration:
             # Phase 2 adapters (spec 029)
             "nfa_emergency_info_service",
             "mohw_welfare_eligibility_search",
+            # Spec #2797 verified public-data adapters
+            "fsc_corporate_finance_summary",
+            "airkorea_ctprvn_air_quality",
+            "ftc_large_group_status",
+            "ftc_public_ym_list",
+            "tago_bus_route_search",
+            "tago_bus_arrival_search",
+            "tago_bus_location_search",
+            "tago_bus_station_search",
+            "kepco_contract_power_usage",
+            "pps_bid_public_info",
+            "reb_real_estate_stat_table",
+            "bfc_funeral_area_fee",
+            "kcue_finance_regional_tuition",
+            "kcue_student_regional_foreign",
         }
         for tool_id in expected:
             assert tool_id in executor._adapters, f"No adapter for {tool_id}"

--- a/tests/tools/test_routing_consistency.py
+++ b/tests/tools/test_routing_consistency.py
@@ -163,15 +163,14 @@ class TestInvariant4UniqueToolId:
 
 # ---------------------------------------------------------------------------
 # Check 7 — Tool list closure
-# The Python-side registered tool set matches the 14-adapter closed set.
+# The Python-side registered tool set matches the active closed set.
 # LLM-visible primitive names (find/locate/send/check) and auxiliary
 # tools live on the TUI side and are validated by `bun test` CI.
 # ---------------------------------------------------------------------------
 
 
 class TestCheck7ToolListClosure:
-    """The Python-side registered tool set matches the 16-adapter registry
-    (Spec 2296 SC-003: 12 Live + 2 MVP-surface + 2 lookup mocks).
+    """The Python-side registered tool set matches the 52-entry registry.
 
     Divergence from this set indicates either an unauthorized addition or
     an inadvertent removal — both are CI failures.
@@ -233,11 +232,26 @@ class TestCheck7ToolListClosure:
             "mock_submit_module_public_mydata_action",
             "mock_traffic_fine_pay_v1",
             "mock_welfare_application_submit_v1",
+            # Spec #2797 — direct-curl verified public-data find adapters.
+            "fsc_corporate_finance_summary",
+            "airkorea_ctprvn_air_quality",
+            "ftc_large_group_status",
+            "ftc_public_ym_list",
+            "tago_bus_route_search",
+            "tago_bus_arrival_search",
+            "tago_bus_location_search",
+            "tago_bus_station_search",
+            "kepco_contract_power_usage",
+            "pps_bid_public_info",
+            "reb_real_estate_stat_table",
+            "bfc_funeral_area_fee",
+            "kcue_finance_regional_tuition",
+            "kcue_student_regional_foreign",
         }
     )
 
     def test_registered_set_matches_expected(self, live_registry):
-        """Registry tool set exactly matches the 14-entry closed set."""
+        """Registry tool set exactly matches the active closed set."""
         registry, _ = live_registry
         actual = frozenset(registry._tools.keys())
         assert actual == self.EXPECTED_REGISTERED_TOOL_IDS, (

--- a/tests/unit/tools/test_registry_count_breakdown.py
+++ b/tests/unit/tools/test_registry_count_breakdown.py
@@ -2,7 +2,7 @@
 """T035 — Registry count breakdown assertion (SC-003).
 
 Boots the registry and asserts the active count breakdown from spec.md SC-003:
-  - Main ToolRegistry: 38 entries
+  - Main ToolRegistry: 52 entries
   - ummaya.primitives.verify._VERIFY_ADAPTERS: 10 families
   - ummaya.primitives.submit._ADAPTER_REGISTRY: 5 families
 
@@ -16,7 +16,7 @@ do NOT silently adjust the expected values.
 from __future__ import annotations
 
 # ---------------------------------------------------------------------------
-# Main ToolRegistry count — 38 total
+# Main ToolRegistry count — 52 total
 # ---------------------------------------------------------------------------
 # Epic η #2298 — extended from 16 to 18 by adding `check` / `send`
 # to mvp_surface as `is_core=True` GovAPITool entries (FR-021).
@@ -38,10 +38,12 @@ from __future__ import annotations
 # Agentic locate refactor — extended from 33 to 38 by registering five
 # provider-specific locate adapters instead of hiding them behind a fused
 # locate primitive.
-_EXPECTED_MAIN_REGISTRY_COUNT = 38
+# Spec #2797 — extended from 38 to 52 by registering fourteen direct-curl
+# verified public-data adapters under src/ummaya/tools/verified_data_go_kr/.
+_EXPECTED_MAIN_REGISTRY_COUNT = 52
 
 _EXPECTED_MAIN_REGISTRY_BREAKDOWN = {
-    "live_adapters": 12,  # 12 Live: koroad ×2, kma ×6, hira ×1, nfa ×1, nmc ×1, mohw ×1
+    "live_adapters": 26,  # 12 existing Live + 14 verified public-data adapters
     "mvp_surface": 4,  # find + locate + check + send (main-verb surface)
     "locate_adapters": 5,  # kakao/juso/provider-specific locate adapters
     "lookup_mocks": 2,  # mock_lookup_module_hometax_simplified + mock_lookup_module_gov24_certificate  # noqa: E501
@@ -61,6 +63,20 @@ _EXPECTED_LIVE_TOOL_IDS = frozenset(
         "nfa_emergency_info_service",
         "nmc_emergency_search",
         "mohw_welfare_eligibility_search",
+        "fsc_corporate_finance_summary",
+        "airkorea_ctprvn_air_quality",
+        "ftc_large_group_status",
+        "ftc_public_ym_list",
+        "tago_bus_route_search",
+        "tago_bus_arrival_search",
+        "tago_bus_location_search",
+        "tago_bus_station_search",
+        "kepco_contract_power_usage",
+        "pps_bid_public_info",
+        "reb_real_estate_stat_table",
+        "bfc_funeral_area_fee",
+        "kcue_finance_regional_tuition",
+        "kcue_student_regional_foreign",
     }
 )
 
@@ -75,7 +91,7 @@ _EXPECTED_LOOKUP_MOCK_IDS = frozenset(
 
 
 def test_main_registry_total_count() -> None:
-    """Main ToolRegistry must have exactly 38 entries after register_all_tools()."""
+    """Main ToolRegistry must have exactly 52 entries after register_all_tools()."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.tools.executor import ToolExecutor
     from ummaya.tools.register_all import register_all_tools
@@ -94,7 +110,7 @@ def test_main_registry_total_count() -> None:
 
 
 def test_main_registry_live_tool_ids_present() -> None:
-    """All 12 expected Live tool IDs must be registered in the main ToolRegistry."""
+    """All 26 expected Live tool IDs must be registered in the main ToolRegistry."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.tools.executor import ToolExecutor
     from ummaya.tools.register_all import register_all_tools
@@ -309,7 +325,7 @@ def test_all_active_surface_counts_match_canonical() -> None:
         # corpus so find(mode="search") surfaces them. is_core=False so the
         # primary LLM tool list stays at active primitives + find-class Live.
         # Locate-provider adapters add five first-class registry entries.
-        "main_registry": 38,
+        "main_registry": 52,
         "verify_families": 10,
         "submit_adapters": 5,
     }

--- a/tests/unit/tools/verified_data_go_kr/__init__.py
+++ b/tests/unit/tools/verified_data_go_kr/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for verified public-data adapters."""

--- a/tests/unit/tools/verified_data_go_kr/test_fixture_replay.py
+++ b/tests/unit/tools/verified_data_go_kr/test_fixture_replay.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixture replay through adapter handles, without live network calls."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ummaya.tools.envelope import normalize
+from ummaya.tools.models import LookupCollection
+from ummaya.tools.verified_data_go_kr import (
+    VERIFIED_DATA_GO_KR_ADAPTERS,
+    module_for_tool_id,
+)
+
+ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = ROOT / "docs/api/data-go-kr-candidate-docs"
+
+FIXTURE_CASES = {
+    "fsc_corporate_finance_summary": (
+        {"crno": "1746110000741", "biz_year": "2019", "page_no": 1, "num_of_rows": 1},
+        "15043459/probes/live-2026-05-16/corporate-finance-summary.body.json",
+        "crno",
+    ),
+    "airkorea_ctprvn_air_quality": (
+        {"sido_name": "서울", "page_no": 1, "num_of_rows": 5, "ver": "1.0"},
+        "15073861/probes/live-2026-05-16/airkorea-ctprvn.body.json",
+        "stationName",
+    ),
+    "ftc_large_group_status": (
+        {"presentn_year": "202105", "page_no": 1, "num_of_rows": 10},
+        "15091886/probes/live-2026-05-16/ftc-large-group.body.xml",
+        "unityGrupNm",
+    ),
+    "ftc_public_ym_list": (
+        {"job_se_code": "0001", "presentn_year": "2021", "page_no": 1, "num_of_rows": 10},
+        "15091910/probes/live-2026-05-16/ftc-public-ym.body.xml",
+        "othbcYm",
+    ),
+    "tago_bus_route_search": (
+        {"city_code": "25", "route_no": "5", "page_no": 1, "num_of_rows": 10},
+        "15098529/probes/live-2026-05-16/tago-bus-route.body.xml",
+        "routeid",
+    ),
+    "tago_bus_arrival_search": (
+        {"city_code": "25", "node_id": "DJB8001793", "page_no": 1, "num_of_rows": 10},
+        "15098530/probes/live-2026-05-16/tago-bus-arrival.body.xml",
+        None,
+    ),
+    "tago_bus_location_search": (
+        {"city_code": "25", "route_id": "DJB30300052", "page_no": 1, "num_of_rows": 10},
+        "15098533/probes/live-2026-05-16/tago-bus-location.body.xml",
+        None,
+    ),
+    "tago_bus_station_search": (
+        {
+            "city_code": "25",
+            "node_nm": "전통시장",
+            "node_no": "44810",
+            "page_no": 1,
+            "num_of_rows": 10,
+        },
+        "15098534/probes/live-2026-05-16/tago-bus-station.body.xml",
+        "nodeid",
+    ),
+    "kepco_contract_power_usage": (
+        {
+            "year": "2020",
+            "month": "11",
+            "metro_cd": "11",
+            "city_cd": "110",
+            "cntr_cd": "100",
+        },
+        "15101360/probes/live-2026-05-16/kepco-contract-type.body.json",
+        "powerUsage",
+    ),
+    "pps_bid_public_info": (
+        {"inqry_div": "2", "bid_ntce_no": "R25BK00934017", "page_no": 1, "num_of_rows": 10},
+        "15129394/probes/live-2026-05-16/pps-bid-service.body.json",
+        "bidNtceNo",
+    ),
+    "reb_real_estate_stat_table": (
+        {"p_index": 1, "p_size": 5},
+        "15134761/probes/live-2026-05-16/reb-stat-table.body.json",
+        "STATBL_ID",
+    ),
+    "bfc_funeral_area_fee": (
+        {"page_no": 1, "num_of_rows": 5},
+        "15157485/probes/live-2026-05-16/funeral-area-list.body.json",
+        "faName",
+    ),
+    "kcue_finance_regional_tuition": (
+        {"schl_div_cd": "02", "page_no": 1, "num_of_rows": 5},
+        "15158680/probes/live-2026-05-16/finance-regional-tuition.body.xml",
+        "schlDivCd",
+    ),
+    "kcue_student_regional_foreign": (
+        {"schl_div_cd": "02", "page_no": 1, "num_of_rows": 5},
+        "15158684/probes/live-2026-05-16/student-regional-foreign.body.xml",
+        "schlDivCd",
+    ),
+}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("spec", VERIFIED_DATA_GO_KR_ADAPTERS, ids=lambda spec: spec.tool_id)
+async def test_adapter_handle_replays_live_probe_fixture(spec: object) -> None:
+    module = module_for_tool_id(spec.tool_id)
+    params, relpath, expected_field = FIXTURE_CASES[spec.tool_id]
+    fixture_body = (FIXTURES / relpath).read_bytes()
+
+    validated_input = module.INPUT_SCHEMA.model_validate(params)
+    raw = await module.handle(validated_input, fixture_body=fixture_body)
+
+    assert raw["kind"] == "collection"
+    assert raw["total_count"] >= 0
+    assert isinstance(raw["items"], list)
+    if expected_field is not None:
+        assert raw["items"]
+        assert expected_field in raw["items"][0]["record"]
+
+
+@pytest.mark.asyncio
+async def test_adapter_fixture_output_normalizes_to_lookup_collection() -> None:
+    spec = next(
+        item for item in VERIFIED_DATA_GO_KR_ADAPTERS if item.tool_id == "bfc_funeral_area_fee"
+    )
+    module = module_for_tool_id(spec.tool_id)
+    fixture_body = (
+        FIXTURES / "15157485/probes/live-2026-05-16/funeral-area-list.body.json"
+    ).read_bytes()
+
+    validated_input = module.INPUT_SCHEMA.model_validate({"page_no": 1, "num_of_rows": 5})
+    raw = await module.handle(validated_input, fixture_body=fixture_body)
+    validated = normalize(raw, module.TOOL, request_id="fixture-replay", elapsed_ms=5)
+
+    assert isinstance(validated, LookupCollection)
+    assert validated.meta.source == "bfc_funeral_area_fee"
+    assert validated.total_count == 4

--- a/tests/unit/tools/verified_data_go_kr/test_manifest.py
+++ b/tests/unit/tools/verified_data_go_kr/test_manifest.py
@@ -1,0 +1,92 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Manifest guards for the verified data.go.kr adapter wave."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from ummaya.tools.verified_data_go_kr import VERIFIED_DATA_GO_KR_ADAPTERS
+
+ROOT = Path(__file__).resolve().parents[4]
+SCOPED_NEW_30 = ROOT / "docs/api/data-go-kr-candidate-docs/SCOPED-NEW-30-manifest.json"
+
+EXPECTED_DATASET_IDS = frozenset(
+    {
+        "15043459",
+        "15073861",
+        "15091886",
+        "15091910",
+        "15098529",
+        "15098530",
+        "15098533",
+        "15098534",
+        "15101360",
+        "15129394",
+        "15134761",
+        "15157485",
+        "15158680",
+        "15158684",
+    }
+)
+
+EXPECTED_TOOL_IDS = frozenset(
+    {
+        "fsc_corporate_finance_summary",
+        "airkorea_ctprvn_air_quality",
+        "ftc_large_group_status",
+        "ftc_public_ym_list",
+        "tago_bus_route_search",
+        "tago_bus_arrival_search",
+        "tago_bus_location_search",
+        "tago_bus_station_search",
+        "kepco_contract_power_usage",
+        "pps_bid_public_info",
+        "reb_real_estate_stat_table",
+        "bfc_funeral_area_fee",
+        "kcue_finance_regional_tuition",
+        "kcue_student_regional_foreign",
+    }
+)
+
+
+def test_manifest_contains_only_live_probe_confirmed_candidates() -> None:
+    dataset_ids = frozenset(spec.dataset_id for spec in VERIFIED_DATA_GO_KR_ADAPTERS)
+    tool_ids = frozenset(spec.tool_id for spec in VERIFIED_DATA_GO_KR_ADAPTERS)
+
+    assert dataset_ids == EXPECTED_DATASET_IDS
+    assert tool_ids == EXPECTED_TOOL_IDS
+
+
+def test_manifest_excludes_scoped_new_30_candidates_pending_authorization() -> None:
+    raw = json.loads(SCOPED_NEW_30.read_text(encoding="utf-8"))
+    pending_ids = {str(entry["id"]) for entry in raw}
+    included_ids = {spec.dataset_id for spec in VERIFIED_DATA_GO_KR_ADAPTERS}
+
+    assert not included_ids & pending_ids
+
+
+def test_all_verified_candidates_are_find_live_read_only_adapters() -> None:
+    for spec in VERIFIED_DATA_GO_KR_ADAPTERS:
+        assert spec.primitive == "find", spec.tool_id
+        assert spec.adapter_mode == "live", spec.tool_id
+        assert spec.citizen_facing_gate == "read-only", spec.tool_id
+        assert spec.env_var, spec.tool_id
+        assert spec.evidence_path.endswith((".body.json", ".body.xml")), spec.tool_id
+
+
+def test_manifest_evidence_paths_exist_and_stay_inside_candidate_docs() -> None:
+    evidence_root = ROOT / "docs/api/data-go-kr-candidate-docs"
+
+    for spec in VERIFIED_DATA_GO_KR_ADAPTERS:
+        evidence = ROOT / spec.evidence_path
+        assert evidence.exists(), spec.tool_id
+        assert evidence.is_relative_to(evidence_root), spec.tool_id
+        assert f"/{spec.dataset_id}/" in evidence.as_posix(), spec.tool_id
+
+
+def test_generated_schema_exists_for_each_verified_adapter() -> None:
+    schema_root = ROOT / "docs/api/schemas"
+
+    for spec in VERIFIED_DATA_GO_KR_ADAPTERS:
+        assert (schema_root / f"{spec.tool_id}.json").exists(), spec.tool_id

--- a/tests/unit/tools/verified_data_go_kr/test_parsing.py
+++ b/tests/unit/tools/verified_data_go_kr/test_parsing.py
@@ -1,0 +1,83 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixture parser tests for verified public-data responses."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from ummaya.tools.verified_data_go_kr._models import ResponseFormat
+from ummaya.tools.verified_data_go_kr._parsing import (
+    VerifiedUpstreamError,
+    parse_verified_payload,
+)
+
+ROOT = Path(__file__).resolve().parents[4]
+FIXTURES = ROOT / "docs/api/data-go-kr-candidate-docs"
+
+
+def _read(relpath: str) -> bytes:
+    return (FIXTURES / relpath).read_bytes()
+
+
+def test_parse_data_go_kr_common_json_items() -> None:
+    parsed = parse_verified_payload(
+        _read("15043459/probes/live-2026-05-16/corporate-finance-summary.body.json"),
+        response_format="json",
+    )
+
+    assert parsed.kind == "collection"
+    assert parsed.total_count == 2
+    assert parsed.items
+    assert parsed.items[0].record["crno"] == "1746110000741"
+
+
+def test_parse_data_go_kr_common_xml_zero_result_shape() -> None:
+    parsed = parse_verified_payload(
+        _read("15098530/probes/live-2026-05-16/tago-bus-arrival.body.xml"),
+        response_format="xml",
+    )
+
+    assert parsed.kind == "collection"
+    assert parsed.total_count == 0
+    assert parsed.items == []
+
+
+def test_parse_xml_with_nonstandard_repeating_record_tag() -> None:
+    parsed = parse_verified_payload(
+        _read("15091886/probes/live-2026-05-16/ftc-large-group.body.xml"),
+        response_format="xml",
+        record_tag="appnGroupSttus",
+    )
+
+    assert parsed.total_count == 71
+    assert parsed.items[0].record["unityGrupNm"] == "삼성"
+
+
+def test_parse_reb_openapi_json_rows() -> None:
+    parsed = parse_verified_payload(
+        _read("15134761/probes/live-2026-05-16/reb-stat-table.body.json"),
+        response_format="json",
+    )
+
+    assert parsed.total_count == 738
+    assert parsed.items[0].record["STATBL_ID"] == "A_2024_00900"
+
+
+@pytest.mark.parametrize("response_format", ["json", "xml"])
+def test_non_success_result_code_raises(response_format: ResponseFormat) -> None:
+    payload = (
+        b'{"response":{"header":{"resultCode":"30","resultMsg":"SERVICE KEY ERROR"}}}'
+        if response_format == "json"
+        else (
+            b"<response><header><resultCode>30</resultCode>"
+            b"<resultMsg>SERVICE KEY ERROR</resultMsg></header></response>"
+        )
+    )
+
+    with pytest.raises(VerifiedUpstreamError) as exc_info:
+        parse_verified_payload(payload, response_format=response_format)
+
+    assert exc_info.value.upstream_code == "30"
+    assert "SERVICE KEY ERROR" in exc_info.value.upstream_message

--- a/tests/unit/tools/verified_data_go_kr/test_registration.py
+++ b/tests/unit/tools/verified_data_go_kr/test_registration.py
@@ -1,0 +1,40 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Registration tests for verified data.go.kr adapters."""
+
+from __future__ import annotations
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verified_data_go_kr import (
+    VERIFIED_DATA_GO_KR_ADAPTERS,
+)
+from ummaya.tools.verified_data_go_kr import (
+    register as register_verified_data_go_kr,
+)
+
+
+def test_register_verified_data_go_kr_tools_adds_all_adapters() -> None:
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry)
+
+    register_verified_data_go_kr(registry, executor)
+
+    expected_ids = {spec.tool_id for spec in VERIFIED_DATA_GO_KR_ADAPTERS}
+    assert set(registry._tools) == expected_ids
+    assert set(executor._adapters) == expected_ids
+
+
+def test_registered_tools_are_find_live_read_only_with_policy_citations() -> None:
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry)
+
+    register_verified_data_go_kr(registry, executor)
+
+    for spec in VERIFIED_DATA_GO_KR_ADAPTERS:
+        tool = registry.find(spec.tool_id)
+        assert tool.primitive == "find"
+        assert tool.adapter_mode == "live"
+        assert tool.policy is not None
+        assert tool.policy.citizen_facing_gate == "read-only"
+        assert tool.policy.real_classification_url == spec.policy_url
+        assert spec.dataset_id in tool.search_hint


### PR DESCRIPTION
## Summary

Adds the first direct-curl verified public-data adapter wave: fourteen credential-backed read-only `find` adapters registered into UMMAYA's central ToolRegistry and `lookup` primitive path.

This PR also fixes the Rich REPL primitive tool loop defects found during the required real `ummaya` terminal run, so the LLM can autonomously choose and execute the selected adapter through the visible root primitive surface.

## Motivation

Closes #2797

The 30 newly scoped candidates are intentionally excluded because their data.go.kr authorization window had not completed. This PR only wraps APIs already proven callable by direct live probe evidence.

## Changes

- Added `src/ummaya/tools/verified_data_go_kr/` with a shared manifest, HTTP client, fixture parser, adapter factory, and fourteen thin domain modules.
- Registered the verified adapters during `register_all_tools()` boot and updated registry closure/count tests from 38 to 52 tools.
- Added generated Draft 2020-12 JSON schemas and docs under `docs/api/verified-data-go-kr/`.
- Added spec-kit artifacts, task issue mapping, and real terminal verification notes under `specs/2797-data-go-kr-verified-adapters/`.
- Fixed Rich REPL provider payload/tool loop issues discovered by running `uv run ummaya`: provider-safe tool serialization, root primitive fan-out, JSON-safe primitive tool results, and per-turn `find` allow-listing for location-independent public-data requests.
- Added live proxy routing for verified non-data.go.kr hosts (`bigdata.kepco.co.kr`, `www.reb.or.kr`) so packaged auto mode does not require user-local operator credentials.
- TUI no-change.

## Affected components

- [x] Query Engine
- [x] Tool System / API adapter
- [ ] Permission Pipeline
- [ ] Agent Swarm / Coordinator
- [x] Context Assembly
- [ ] Error Recovery
- [x] Documentation
- [x] Tooling / CI

## How to test

```bash
uv run ruff check src tests
uv run ruff format --check src tests
uv run mypy src
uv run python scripts/build_schemas.py --check --quiet
uv run pytest
uv run ummaya --version
```

Real terminal verification was run locally with secrets loaded from `.env` but never printed:

```bash
UMMAYA_LIVE_ADAPTER_MODE=direct UMMAYA_K_EXAONE_THINKING=false uv run ummaya
```

Prompt typed into the live terminal:

```text
부산광역시 장례식장 시설 사용료 목록을 공공 API 도구로 조회해서 알려줘.
```

Clean terminal result:

- UMMAYA accepted the prompt in the interactive REPL.
- The LLM emitted a single visible tool call.
- The terminal rendered `도구 결과` with `성공  tool_id='find'`.
- The selected adapter was `bfc_funeral_area_fee`.
- The final Korean answer listed the four returned 부산시설공단 fee rows.
- No `도구 오류`, traceback, schema mismatch, fabricated fallback, or retry prompt appeared.

Direct adapter verification also ran locally with `UMMAYA_LIVE_ADAPTER_MODE=direct`:

- `registry_size=52`
- all fourteen adapters returned `kind=collection`
- `tago_bus_arrival_search` and `tago_bus_location_search` returned successful empty collections, matching probe evidence
- `lookup(mode="search", query="부산 장례식장 시설사용료")` ranked `bfc_funeral_area_fee` first
- `lookup(mode="fetch", tool_id="bfc_funeral_area_fee")` returned `items=4`, `total_count=4`

## Screenshots or logs

Not applicable. This PR does not touch `tui/src/**`; TUI verification is not required.

## Checklist

- [x] Commits follow Conventional Commits style
- [x] All source code text is in English (comments, logs, identifiers)
- [x] Tests added or updated (happy path + error path for new tool adapters and Rich REPL tool loop)
- [x] Documentation updated where behavior changed
- [x] No secrets, API keys, or personal data committed
- [x] `CHANGELOG.md` updated under the `Unreleased` section for user-visible changes
- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)

## Breaking changes

None
