### PR TITLE
fix(release): sync package versions

### DIFF
--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ummaya" do
-  version "0.1.11"
-  sha256 "8b749cf37e089b5be43e08e838bb7c3d9978c3cf0a10e1e35b3f6a4577fd5823"
+  version "0.1.12"
+  sha256 "0e5ab8132dba6958c4ca5431cce75b73dcea61ca08fceceb3736df5f0349b787"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.11",
+      "version": "0.1.12",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.11",
+  "version": "0.1.12",
   "description": "Conversational multi-agent harness for Korean public-service channels",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ummaya"
-version = "0.1.11"
+version = "0.1.12"
 description = "Conversational multi-agent platform for Korean public APIs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -314,7 +314,7 @@ min_confidence = 80
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.11"
+version = "0.1.12"
 tag_format = "v$version"
 
 # PyTorch CPU-only wheel for Docker image size discipline (SC-1: ≤ 2 GB).

--- a/scripts/check-npm-package.mjs
+++ b/scripts/check-npm-package.mjs
@@ -21,6 +21,87 @@ const maxEntries = Number(process.env.UMMAYA_NPM_MAX_ENTRIES ?? 2_700)
 const files = pack.files.map((entry) => entry.path)
 const fileSet = new Set(files)
 
+function readJsonVersion(path) {
+  return JSON.parse(readFileSync(path, 'utf8')).version
+}
+
+function readTomlTableVersion(path, tableName) {
+  const text = readFileSync(path, 'utf8')
+  const tableHeader = `[${tableName}]`
+  const start = text.indexOf(tableHeader)
+  if (start === -1) {
+    throw new Error(`${path} missing ${tableHeader}`)
+  }
+  const rest = text.slice(start + tableHeader.length)
+  const nextTable = rest.search(/\n\[/)
+  const section = nextTable === -1 ? rest : rest.slice(0, nextTable)
+  const match = section.match(/^version\s*=\s*"([^"]+)"\s*$/m)
+  if (!match) {
+    throw new Error(`${path} ${tableHeader} missing version`)
+  }
+  return match[1]
+}
+
+function readHomebrewCaskVersion(path) {
+  const text = readFileSync(path, 'utf8')
+  const match = text.match(/^\s*version\s+"([^"]+)"\s*$/m)
+  if (!match) {
+    throw new Error(`${path} missing cask version`)
+  }
+  return match[1]
+}
+
+function readHomebrewCaskSha256(path) {
+  const text = readFileSync(path, 'utf8')
+  const match = text.match(/^\s*sha256\s+"([^"]+)"\s*$/m)
+  if (!match) {
+    throw new Error(`${path} missing cask sha256`)
+  }
+  return match[1]
+}
+
+function assertSameVersion(label, actual, expected) {
+  if (actual !== expected) {
+    throw new Error(`${label} version ${actual} does not match package.json ${expected}`)
+  }
+}
+
+const rootPackageVersion = readJsonVersion('package.json')
+assertSameVersion('npm pack report', pack.version, rootPackageVersion)
+assertSameVersion('tui/package.json', readJsonVersion('tui/package.json'), rootPackageVersion)
+assertSameVersion(
+  'pyproject.toml [project]',
+  readTomlTableVersion('pyproject.toml', 'project'),
+  rootPackageVersion,
+)
+assertSameVersion(
+  'pyproject.toml [tool.commitizen]',
+  readTomlTableVersion('pyproject.toml', 'tool.commitizen'),
+  rootPackageVersion,
+)
+
+const npmShrinkwrap = JSON.parse(readFileSync('npm-shrinkwrap.json', 'utf8'))
+assertSameVersion('npm-shrinkwrap.json', npmShrinkwrap.version, rootPackageVersion)
+assertSameVersion(
+  'npm-shrinkwrap.json packages[""]',
+  npmShrinkwrap.packages?.['']?.version,
+  rootPackageVersion,
+)
+
+const packageLock = JSON.parse(readFileSync('package-lock.json', 'utf8'))
+assertSameVersion('package-lock.json', packageLock.version, rootPackageVersion)
+assertSameVersion(
+  'package-lock.json packages[""]',
+  packageLock.packages?.['']?.version,
+  rootPackageVersion,
+)
+
+const caskSha256 = readHomebrewCaskSha256('Casks/ummaya.rb')
+assertSameVersion('Casks/ummaya.rb', readHomebrewCaskVersion('Casks/ummaya.rb'), rootPackageVersion)
+if (!/^[0-9a-f]{64}$/.test(caskSha256)) {
+  throw new Error(`Casks/ummaya.rb sha256 is not a 64-character lowercase hex digest`)
+}
+
 const required = [
   'bin/ummaya',
   'package.json',

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.10",
+  "version": "0.1.12",
   "private": true,
   "type": "module",
   "engines": {

--- a/uv.lock
+++ b/uv.lock
@@ -2725,7 +2725,7 @@ wheels = [
 
 [[package]]
 name = "ummaya"
-version = "0.1.11"
+version = "0.1.12"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump release metadata to 0.1.12 after the 0.1.11 clean-install smoke exposed stale TUI version output
- sync tui/package.json with root package and Python metadata
- add npm package gate checks for root/TUI/Python/lockfile version drift

## Verification
- npm run package:check
- ./bin/ummaya --version
- local npm tarball install smoke: ummaya --version and --help
- uv run ruff format --check src tests
- uv run ruff check src tests
- uv run mypy src
- uv run pytest

TUI no-change: no tui/src/** modifications.