### PR TITLE
feat: add live BaroCert identity check

### DIFF
--- a/docs/api/verify/live_verify_ganpyeon_injeung.md
+++ b/docs/api/verify/live_verify_ganpyeon_injeung.md
@@ -1,0 +1,124 @@
+# live_verify_ganpyeon_injeung
+
+`live_verify_ganpyeon_injeung` is the explicit live BaroCert identity check
+adapter for the existing `ganpyeon_injeung` family. It is registered under the
+`check` primitive only and maps to the same canonical family as
+`mock_verify_ganpyeon_injeung`; explicit `tool_id` selection decides whether the
+mock adapter or the BaroCert-backed live adapter runs.
+
+## Provider Scope
+
+V1 live priority is Toss 본인확인. Kakao and Naver are represented through the
+same provider metadata and sanitized fixture parsing so future live expansion is
+additive.
+
+Official BaroCert references:
+
+- Toss 본인확인 API:
+  <https://developers.barocert.com/reference/toss/asp/userIdentity/api>
+- Kakao 본인인증 API:
+  <https://developers.barocert.com/reference/kakao/asp/identity/api>
+- Naver 본인인증 API:
+  <https://developers.barocert.com/reference/naver/asp/identity/api>
+- Python SDK setup:
+  <https://developers.barocert.com/guide/toss/identity/python/getting-started/sdk-configuration>
+
+The Toss contract uses:
+
+- `requestUserIdentity(clientCode, UserIdentity)`
+- `getUserIdentityStatus(clientCode, receiptID)`
+- `verifyUserIdentity(clientCode, receiptID)`
+
+Status values are normalized as `0=pending`, `1=complete`, and `2=expired`.
+Expired, failed, malformed, or provider-mismatched payloads fail closed as
+`VerifyMismatchError`.
+
+## Runtime Inputs
+
+Typical explicit check call:
+
+```json
+{
+  "tool_id": "live_verify_ganpyeon_injeung",
+  "params": {
+    "provider": "toss",
+    "receiptID": "TOSS_RECEIPT_FROM_PRIOR_REQUEST",
+    "scope_list": ["check:ganpyeon.identity"],
+    "purpose_ko": "본인확인",
+    "purpose_en": "Identity verification"
+  }
+}
+```
+
+UMMAYA does not accept raw phone number, name, birthday, CI, DI, or resident
+identifier values for this adapter. Request-start fields, when used by future
+flows, must already be encrypted placeholders matching BaroCert SDK input
+requirements:
+
+- `receiverHP`
+- `receiverName`
+- `receiverBirthday`
+- `token`
+- `expireIn`
+- `appUseYN`
+- `deviceOSType` and `returnURL` for Toss app-to-app requests
+
+## Environment
+
+Live execution is disabled unless the caller explicitly selects
+`live_verify_ganpyeon_injeung` and credentials are available:
+
+- `UMMAYA_BAROCERT_LINK_ID`
+- `UMMAYA_BAROCERT_SECRET_KEY`
+- `UMMAYA_BAROCERT_CLIENT_CODE`
+- `UMMAYA_BAROCERT_TEST_RECEIPT_ID` for the opt-in live pytest
+
+Optional SDK transport settings:
+
+- `UMMAYA_BAROCERT_IP_RESTRICT`
+- `UMMAYA_BAROCERT_USE_STATIC_IP`
+
+The Python SDK must be installed in the runtime environment for live execution.
+Default tests use sanitized fixture replay only.
+
+## Output Contract
+
+Successful live verification returns a `GanpyeonInjeungContext`-compatible
+result:
+
+```json
+{
+  "family": "ganpyeon_injeung",
+  "provider": "toss",
+  "external_session_ref": "barocert:toss:<receiptID>",
+  "published_tier": "ganpyeon_injeung_toss_aal2",
+  "nist_aal_hint": "AAL2",
+  "verified_at": "<provider verification time>"
+}
+```
+
+The adapter only records sanitized receipt metadata and booleans such as
+identity evidence present and signed data present. It never returns or persists
+raw CI, DI, phone, birthday, name, `signedData`, or encrypted identity payload
+values.
+
+## Testing
+
+Default non-live tests:
+
+```bash
+uv run pytest tests/unit/tools/live tests/integration/test_live_barocert_discovery.py -m "not live"
+```
+
+Opt-in live validation:
+
+```bash
+UMMAYA_BAROCERT_LINK_ID=... \
+UMMAYA_BAROCERT_SECRET_KEY=... \
+UMMAYA_BAROCERT_CLIENT_CODE=... \
+UMMAYA_BAROCERT_TEST_RECEIPT_ID=... \
+uv run pytest tests/live/test_live_barocert_identity.py -m live
+```
+
+Do not run live BaroCert tests in CI. Record sanitized direct evidence before
+claiming live readiness for a new provider or credential set.

--- a/specs/live-barocert-identity-check/checklists/requirements.md
+++ b/specs/live-barocert-identity-check/checklists/requirements.md
@@ -1,0 +1,35 @@
+# Specification Quality Checklist: Live BaroCert Identity Check
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No unresolved placeholders
+- [x] Focused on user value, privacy, and business needs
+- [x] All mandatory sections completed
+- [x] Technical details are limited to externally required API contracts and UMMAYA-owned acceptance boundaries
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria avoid default live network execution
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] Deferred work is explicitly represented with `NEEDS TRACKING` markers for `/speckit-taskstoissues`
+
+## Notes
+
+- Spec cites Epic #2887 as the originating Epic.
+- `NEEDS TRACKING` rows are intentional and must be resolved by `/speckit-taskstoissues` before implementation is considered issue-backed.

--- a/specs/live-barocert-identity-check/contracts/barocert-identity-client.md
+++ b/specs/live-barocert-identity-check/contracts/barocert-identity-client.md
@@ -1,0 +1,72 @@
+# Contract: BaroCert Identity Client
+
+## Purpose
+
+Defines the internal UMMAYA client boundary for BaroCert simple identity checks.
+The contract is provider-aware, fixture-testable, and redaction-first.
+
+## Provider Operations
+
+### `request_identity(request: BarocertIdentityRequest) -> BarocertIdentityReceipt`
+
+Starts a provider identity request.
+
+Rules:
+- Requires encrypted receiver fields and encrypted token placeholders.
+- Does not accept raw phone, name, birthday, CI, or DI.
+- For Toss live execution, calls the official `requestUserIdentity` SDK method.
+- Returns only receipt metadata.
+
+### `get_identity_status(provider: BarocertProvider, client_code: str, receipt_id: str) -> BarocertIdentityStatus`
+
+Reads provider status for an existing receipt.
+
+Rules:
+- Requires non-empty `receipt_id`.
+- For Toss live execution, calls the official `getUserIdentityStatus` SDK method.
+- Maps provider state codes into normalized states.
+- Non-complete states do not produce auth contexts.
+
+### `verify_identity(provider: BarocertProvider, client_code: str, receipt_id: str) -> BarocertIdentityVerification`
+
+Verifies a completed provider receipt.
+
+Rules:
+- Requires non-empty `receipt_id`.
+- For Toss live execution, calls the official `verifyUserIdentity` SDK method.
+- Provider result values such as `signedData`, `ci`, and `di` are reduced to
+  evidence-present booleans.
+- Repeated verify and provider exception paths produce sanitized fail-closed
+  errors.
+
+## Adapter Operation
+
+### `invoke(session_context: dict[str, object]) -> GanpyeonInjeungContext | VerifyMismatchError`
+
+Dispatches from the check primitive.
+
+Required session context:
+- `_tool_id` or `tool_id`: must be `live_verify_ganpyeon_injeung` for live path.
+- `provider`: defaults to `toss` for v1 live path.
+- `receiptID` or `receipt_id`: required for status/verify path.
+- `clientCode` or `client_code`: optional override; otherwise read from
+  `UMMAYA_BAROCERT_CLIENT_CODE`.
+
+Safe output:
+- `GanpyeonInjeungContext(provider="toss", published_tier="ganpyeon_injeung_toss_aal2")`
+- `external_session_ref="barocert:toss:<receipt_id>"`
+
+Unsafe fields forbidden in output:
+- `ci`
+- `di`
+- `signedData`
+- `receiverHP`
+- `receiverName`
+- `receiverBirthday`
+- `receiverYear`
+- `receiverDay`
+- `receiverGender`
+- `receiverForeign`
+- `receiverAgeGroup`
+- `receiverEmail`
+- `receiverTelcoType`

--- a/specs/live-barocert-identity-check/data-model.md
+++ b/specs/live-barocert-identity-check/data-model.md
@@ -1,0 +1,97 @@
+# Data Model: Live BaroCert Identity Check
+
+## BarocertProvider
+
+Provider selector for the BaroCert client.
+
+| Field | Type | Validation |
+|-------|------|------------|
+| `provider` | `Literal["toss", "kakao", "naver"]` | Required |
+
+## BarocertIdentityRequest
+
+Sanitized request-start input. Values are already encrypted or test placeholders;
+raw phone, name, birthday, CI, or DI are not accepted.
+
+| Field | Type | Validation |
+|-------|------|------------|
+| `provider` | `BarocertProvider` | Required |
+| `client_code` | `str` | 12 characters for BaroCert client code |
+| `receiver_hp_encrypted` | `str` | Non-empty encrypted placeholder |
+| `receiver_name_encrypted` | `str` | Non-empty encrypted placeholder |
+| `receiver_birthday_encrypted` | `str` | Non-empty encrypted placeholder |
+| `token_encrypted` | `str` | Non-empty encrypted placeholder |
+| `expire_in` | `int` | Positive; Toss maximum 1800 seconds |
+| `app_use_yn` | `bool` | Defaults false |
+| `device_os_type` | `Literal["ANDROID", "IOS"] \| None` | Required only for app-to-app provider variants that need it |
+| `return_url` | `str \| None` | Required only for app-to-app provider variants that need it |
+
+## BarocertIdentityReceipt
+
+Provider receipt metadata that can be returned safely.
+
+| Field | Type | Validation |
+|-------|------|------------|
+| `provider` | `BarocertProvider` | Required |
+| `receipt_id` | `str` | Required, non-empty |
+| `scheme` | `str \| None` | Optional app scheme |
+| `market_url` | `str \| None` | Optional Naver app market URL |
+
+## BarocertIdentityStatus
+
+Normalized provider status.
+
+| Field | Type | Validation |
+|-------|------|------------|
+| `provider` | `BarocertProvider` | Required |
+| `receipt_id` | `str` | Required, non-empty |
+| `state` | `Literal["pending", "complete", "expired", "rejected", "failed"]` | Required |
+| `expire_dt` | `str \| None` | Provider timestamp if present |
+| `complete_dt` | `str \| None` | Provider timestamp if present |
+
+### Status Mapping
+
+| Provider state code | Normalized state |
+|---------------------|------------------|
+| `0` | `pending` |
+| `1` | `complete` |
+| `2` | `expired` |
+| `3` | `rejected` |
+| `4` | `failed` |
+
+Providers that do not define `3` or `4` still reject those values if seen in a
+fixture or live response.
+
+## BarocertIdentityVerification
+
+Sanitized verification summary produced from provider result payloads.
+
+| Field | Type | Validation |
+|-------|------|------------|
+| `provider` | `BarocertProvider` | Required |
+| `receipt_id` | `str` | Required |
+| `state` | `Literal["complete"]` | Only complete results can verify |
+| `signed_data_present` | `bool` | Required |
+| `identity_evidence_present` | `bool` | Required; true if CI/DI or provider identity fields are present |
+| `verified_at` | `datetime` | UTC timestamp |
+
+### Redaction Rule
+
+Raw provider keys `ci`, `di`, `signedData`, `receiverHP`, `receiverName`,
+`receiverBirthday`, `receiverYear`, `receiverDay`, `receiverGender`,
+`receiverForeign`, `receiverAgeGroup`, `receiverEmail`, and `receiverTelcoType`
+are consumed only for evidence presence and must not appear in model dumps,
+logs, fixtures snapshots, or returned auth contexts.
+
+## GanpyeonInjeungContext Output
+
+The live adapter returns the existing `GanpyeonInjeungContext` shape:
+
+| Field | Value |
+|-------|-------|
+| `family` | `ganpyeon_injeung` |
+| `provider` | Provider literal, v1 live priority `toss` |
+| `published_tier` | `ganpyeon_injeung_toss_aal2` for Toss |
+| `nist_aal_hint` | `AAL2` |
+| `verified_at` | Provider verification time as UTC timestamp |
+| `external_session_ref` | Sanitized reference such as `barocert:toss:<receipt_id>` |

--- a/specs/live-barocert-identity-check/plan.md
+++ b/specs/live-barocert-identity-check/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Live BaroCert Identity Check
+
+**Branch**: `feat/live-barocert-identity-check` | **Date**: 2026-05-18 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `specs/live-barocert-identity-check/spec.md`
+
+## Summary
+
+Add an explicit live check tool id, `live_verify_ganpyeon_injeung`, for BaroCert
+simple identity verification. The implementation adds a small provider client,
+an opt-in live adapter that returns the existing `GanpyeonInjeungContext`, and
+registry/dispatch metadata so the live tool id is discoverable and maps to the
+canonical `ganpyeon_injeung` family. Default tests use sanitized fixtures only;
+live tests are gated by `@pytest.mark.live` and `UMMAYA_BAROCERT_*` credentials.
+
+## Technical Context
+
+**Language/Version**: Python 3.12
+**Primary Dependencies**: Existing Pydantic v2, pytest, httpx/respx for tests; optional official `barocert` SDK at live runtime
+**Storage**: None; no identity payload persistence
+**Testing**: pytest, pytest-asyncio, fixture replay, `@pytest.mark.live` opt-in tests
+**Target Platform**: UMMAYA Python backend and Codex desktop/local developer environment
+**Project Type**: Python package with primitive tool adapters
+**Performance Goals**: No default live calls; fixture tests complete within the normal targeted pytest budget
+**Constraints**: CI/DI and raw identity fields redacted; no default CI live traffic; check-only scope
+**Scale/Scope**: One live check adapter plus fixture-backed provider client variants
+
+## Constitution Check
+
+| Gate | Status | Notes |
+|------|--------|-------|
+| Spec-driven workflow | PASS | Epic #2887 created; spec, plan, tasks, analyze, taskstoissues precede implementation. |
+| Source code language | PASS | Source code and test strings will be English; Korean domain terms remain only where domain data requires them. |
+| Fail-closed security | PASS | Missing credentials, missing SDK, malformed provider responses, repeated verify, and upstream errors all fail closed. |
+| Pydantic v2 strict typing | PASS | Client request/status/result models use Pydantic v2 with `extra="forbid"` for external contract inputs. |
+| No live calls in CI | PASS | Live tests are `@pytest.mark.live` and skip without env credentials. |
+| Privacy | PASS | CI/DI, phone, birthday, name, signedData, and encrypted identity payloads are redacted. |
+| Primitive boundary | PASS | Changes touch only check adapter surfaces and supporting docs/tests. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/live-barocert-identity-check/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── barocert-identity-client.md
+├── tasks.md
+└── checklists/
+    └── requirements.md
+```
+
+### Source Code
+
+```text
+src/ummaya/tools/live/
+├── __init__.py
+├── barocert_identity_client.py
+└── verify_barocert_identity.py
+
+src/ummaya/tools/
+├── discovery_bridge.py
+├── register_all.py
+└── verify_canonical_map.py
+
+src/ummaya/ipc/
+└── stdio.py
+
+tests/unit/tools/live/
+├── test_barocert_identity_client.py
+└── test_verify_barocert_identity.py
+
+tests/integration/
+├── test_live_barocert_discovery.py
+└── test_tool_id_to_family_hint_translation.py
+
+tests/live/
+└── test_live_barocert_identity.py
+
+tests/fixtures/barocert/
+├── toss_request_receipt.json
+├── toss_status_complete.json
+├── toss_verify_complete.json
+├── kakao_status_complete.json
+└── naver_status_complete.json
+
+docs/api/verify/
+└── live_verify_ganpyeon_injeung.md
+```
+
+**Structure Decision**: Add a new `src/ummaya/tools/live/` package for live check
+adapters that are not public-data `find`/`locate` adapters. Keep BaroCert
+client logic separate from the adapter so fixture tests can validate provider
+parsing without dispatching through the check primitive.
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+## Phase 1: Design & Contracts
+
+See [data-model.md](./data-model.md), [contracts/barocert-identity-client.md](./contracts/barocert-identity-client.md), and [quickstart.md](./quickstart.md).
+
+## Implementation Notes
+
+- `live_verify_ganpyeon_injeung` and `mock_verify_ganpyeon_injeung` both resolve
+  to `family_hint="ganpyeon_injeung"`.
+- The stdio boundary must preserve selected `tool_id` in `session_context` so
+  the family adapter can distinguish explicit live selection from the existing
+  mock default.
+- The live adapter must not import the optional BaroCert SDK at module import
+  time. Runtime invocation may attempt the import and fail closed if unavailable.
+
+## Complexity Tracking
+
+No constitution violations require justification.

--- a/specs/live-barocert-identity-check/quickstart.md
+++ b/specs/live-barocert-identity-check/quickstart.md
@@ -1,0 +1,51 @@
+# Quickstart: Live BaroCert Identity Check
+
+## Fixture-only validation
+
+Run the default non-live BaroCert tests:
+
+```bash
+uv run pytest tests/unit/tools/live tests/integration/test_live_barocert_discovery.py -m "not live" -q
+```
+
+Expected:
+- Provider selection tests pass for `toss`, `kakao`, and `naver`.
+- Toss request/status/verify fixtures replay without network access.
+- Redaction assertions prove CI, DI, phone, birthday, name, signedData, and
+  encrypted identity payload fields are absent from output.
+
+## Registry validation
+
+```bash
+uv run pytest tests/integration/test_tool_id_to_family_hint_translation.py tests/integration/test_live_barocert_discovery.py -q
+```
+
+Expected:
+- `live_verify_ganpyeon_injeung` resolves to `family_hint="ganpyeon_injeung"`.
+- Existing mock tool-id mappings still pass.
+- Main registry contains the live adapter as primitive `check`.
+
+## Live validation
+
+Live validation is opt-in and must not run in CI.
+
+Required environment:
+
+```bash
+export UMMAYA_BAROCERT_LINK_ID=...
+export UMMAYA_BAROCERT_SECRET_KEY=...
+export UMMAYA_BAROCERT_CLIENT_CODE=...
+export UMMAYA_BAROCERT_TEST_RECEIPT_ID=...
+```
+
+Run:
+
+```bash
+uv run pytest tests/live/test_live_barocert_identity.py -m live -q
+```
+
+Expected:
+- The test skips when any required environment variable is absent.
+- With credentials, the adapter verifies only sanitized provider evidence.
+- The output contains no raw CI, DI, phone, birthday, name, signedData, or full
+  provider result payload.

--- a/specs/live-barocert-identity-check/research.md
+++ b/specs/live-barocert-identity-check/research.md
@@ -1,0 +1,88 @@
+# Research: Live BaroCert Identity Check
+
+## Decision 1: Use Toss `userIdentity` as the v1 live priority
+
+**Decision**: Implement the v1 live path around Toss 본인확인, using the official
+Python method sequence `requestUserIdentity`, `getUserIdentityStatus`, and
+`verifyUserIdentity`.
+
+**Rationale**: The feature request names Toss `userIdentity` as the first live
+priority. The official BaroCert Toss Python reference exposes the same three
+methods and documents required fields, status values, and returned result fields.
+
+**Alternatives considered**:
+- Kakao/Naver first: rejected because the user explicitly prioritizes Toss.
+- A provider-neutral live path first: rejected because it risks a shallow
+  abstraction before one live provider has concrete evidence.
+
+## Decision 2: Keep raw identity evidence out of UMMAYA models
+
+**Decision**: Parse provider result payloads into a sanitized verification
+summary that records only evidence-presence booleans, provider, receipt
+reference, status, and timestamps. Do not retain CI, DI, phone, birthday, name,
+signedData, or encrypted identity attributes.
+
+**Rationale**: BaroCert result models include identity-bearing fields such as CI,
+DI, receiver attributes, and signedData. This Epic's acceptance criteria require
+that UMMAYA returns `AuthContext` or external session references, not raw identity
+payloads.
+
+**Alternatives considered**:
+- Store encrypted result fields for later comparison: rejected because encrypted
+  identity payload retention violates this feature's privacy boundary.
+- Return signedData to downstream submit adapters: rejected because there is no
+  documented UMMAYA delegation-token exchange for this provider in v1.
+
+## Decision 3: Explicit live tool id maps to the existing family
+
+**Decision**: Register `live_verify_ganpyeon_injeung` as a check tool id whose
+canonical family is `ganpyeon_injeung`. Preserve `mock_verify_ganpyeon_injeung`
+mapping and behavior.
+
+**Rationale**: Existing dispatcher and auth context models use family as the
+identity mechanism discriminator, not runtime mode. The live and mock BaroCert
+surfaces are two tool ids for the same identity family.
+
+**Alternatives considered**:
+- Add a new `ganpyeon_injeung_live` family: rejected because it would extend the
+  auth union with runtime mode rather than identity semantics.
+- Replace the mock adapter: rejected by FR-002.
+
+## Decision 4: Optional SDK runtime, no default live dependency path
+
+**Decision**: The adapter may use the official BaroCert Python SDK at live
+runtime when installed, but default imports and fixture tests do not require it.
+
+**Rationale**: The official guide instructs Python users to install `barocert`,
+`pycryptodome`, and `cffi`, while UMMAYA default CI must remain fixture-only.
+Optional runtime loading lets the live test fail closed when a human has not
+prepared the SDK and credentials, without adding network behavior to default
+tests.
+
+**Alternatives considered**:
+- Add a mandatory runtime dependency immediately: rejected for v1 because the
+  adapter can be tested and reviewed through fixtures before live credentials
+  are available.
+- Reimplement Linkhub token and BaroCert HTTP calls directly with `httpx`:
+  rejected because official docs expose an SDK contract and token/IP policy that
+  should not be reverse-engineered in UMMAYA.
+
+## Decision 5: Deferred items are tracked before implementation
+
+**Decision**: Kakao live execution, Naver live execution, and provider-side raw
+identity comparison are deferred and must receive tracking issues before
+implementation starts.
+
+**Rationale**: Constitution Principle VI forbids untracked ghost work. These
+items are mentioned in the feature description but intentionally outside v1.
+
+**Deferred validation summary**: 3 deferred items in spec.md, all marked
+`NEEDS TRACKING` pending `/speckit-taskstoissues`.
+
+## Official Sources Consulted
+
+- `https://developers.barocert.com/reference/toss/python/userIdentity/api`
+- `https://developers.barocert.com/reference/kakao/asp/identity/api`
+- `https://developers.barocert.com/reference/naver/asp/identity/api`
+- `https://developers.barocert.com/guide/toss/identity/python/getting-started/sdk-configuration`
+- `https://developers.barocert.com/guide/toss/identity/python/getting-started/tutorial`

--- a/specs/live-barocert-identity-check/spec.md
+++ b/specs/live-barocert-identity-check/spec.md
@@ -1,0 +1,202 @@
+# Feature Specification: Live BaroCert Identity Check
+
+**Feature Branch**: `feat/live-barocert-identity-check`
+**Created**: 2026-05-18
+**Status**: Ready for implementation
+**Originating Epic**: #2887
+**Input**: Worktree 2 from "신원검증 Live Check 1·2·3 병렬 구현 설계도"
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Toss-backed identity check returns a redacted auth context (Priority: P1)
+
+A citizen or operator explicitly selects `live_verify_ganpyeon_injeung` for a
+BaroCert Toss 본인확인 ceremony. UMMAYA starts or resumes the provider session,
+verifies the provider receipt, and returns a `GanpyeonInjeungContext`-compatible
+auth result containing only provider name, external session reference,
+verification time, published tier, and AAL hint.
+
+**Why this priority**: This is the MVP value: moving the existing
+`mock_verify_ganpyeon_injeung` shape to an explicit live check adapter without
+changing mock behavior or leaking identity payloads.
+
+**Independent Test**: Unit tests can replay sanitized Toss request/status/verify
+fixtures and assert the resulting context has `provider="toss"`,
+`external_session_ref`, `verified_at`, `published_tier`, and `nist_aal_hint`,
+with no CI, DI, phone, birthday, name, or signedData in the output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a completed Toss `receiptID`, **When** UMMAYA invokes
+   `live_verify_ganpyeon_injeung`, **Then** the result is a verified
+   `ganpyeon_injeung` context with `provider="toss"` and only a sanitized
+   external session reference.
+2. **Given** a Toss response containing CI, DI, encrypted identity attributes,
+   or signedData, **When** the adapter parses the response, **Then** those fields
+   are used only to decide that expected identity evidence exists and are not
+   returned, logged, snapshotted, or persisted.
+
+---
+
+### User Story 2 - Provider client supports fixture-backed Kakao and Naver variants (Priority: P2)
+
+An engineer can exercise the same BaroCert client interface for `toss`, `kakao`,
+and `naver` using sanitized fixtures. Toss is the only v1 live priority, but the
+client interface must make Kakao and Naver extension work additive rather than a
+new architecture.
+
+**Why this priority**: Kakao and Naver share request/status/verify semantics
+with different method names and response fields. Capturing that interface now
+prevents a Toss-only implementation from hard-coding the wrong boundary.
+
+**Independent Test**: Fixture tests instantiate the provider enum for all three
+providers and assert provider-specific method names, request-body validation,
+status parsing, and sensitive-field redaction.
+
+**Acceptance Scenarios**:
+
+1. **Given** a provider value of `kakao` or `naver`, **When** fixture replay runs,
+   **Then** the client validates required request fields and parses receipt/status
+   shapes without any live network call.
+2. **Given** a provider mismatch between request and verify metadata, **When** the
+   result is parsed, **Then** the adapter fails closed with a structured check
+   error instead of coercing it into a successful context.
+
+---
+
+### User Story 3 - Live validation is opt-in and safe by default (Priority: P3)
+
+CI and default local tests must never call BaroCert or transmit identity data.
+Live validation runs only when a human explicitly selects live tests and provides
+BaroCert credentials and test receipt inputs.
+
+**Why this priority**: Identity providers are high-risk external systems. A
+default test run must prove fixture behavior and redaction without touching a
+government or identity service.
+
+**Independent Test**: `uv run pytest -m "not live"` completes without BaroCert
+network calls. `tests/live/...barocert...` is marked `@pytest.mark.live` and
+skips unless all required `UMMAYA_BAROCERT_*` variables are present.
+
+**Acceptance Scenarios**:
+
+1. **Given** no BaroCert environment variables, **When** the default test suite
+   runs, **Then** live BaroCert tests are skipped or excluded and no network call
+   is attempted.
+2. **Given** all live credentials and a sanitized Toss test receipt, **When** a
+   human runs the live test marker, **Then** the test validates provider status
+   and redaction without printing or storing raw identity values.
+
+### Edge Cases
+
+- Missing `receiptID` must fail closed before provider invocation.
+- Expired, rejected, failed, or pending receipts must return a non-verified check
+  error and must not produce an auth context.
+- Repeated verify calls after provider one-shot or two-shot limits must surface a
+  provider error as fail-closed, not as a retry loop.
+- Missing encrypted input placeholders for live request start must fail validation.
+- Upstream non-2xx responses, SDK exceptions, malformed response objects, provider
+  mismatch, and missing required result fields must all produce sanitized errors.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST add a new explicit live check tool id
+  `live_verify_ganpyeon_injeung`.
+- **FR-002**: System MUST keep existing `mock_verify_ganpyeon_injeung` behavior,
+  registration, output shape, and tests unchanged unless docs reference the new
+  live alternative.
+- **FR-003**: System MUST model a BaroCert provider enum with `toss`, `kakao`,
+  and `naver`.
+- **FR-004**: System MUST prioritize Toss 본인확인 using
+  `requestUserIdentity(clientCode, UserIdentity)`,
+  `getUserIdentityStatus(clientCode, receiptID)`, and
+  `verifyUserIdentity(clientCode, receiptID)`.
+- **FR-005**: System MUST require encrypted placeholders for live identity request
+  start inputs: receiver phone, receiver name, receiver birthday, and token.
+- **FR-006**: System MUST require `receiptID` before status or verify lookup.
+- **FR-007**: System MUST return a `GanpyeonInjeungContext`-compatible result
+  with `provider`, `external_session_ref`, `verified_at`, `published_tier`, and
+  `nist_aal_hint` when the provider result is complete.
+- **FR-008**: System MUST NOT return, log, persist, snapshot, or expose raw CI,
+  DI, phone number, birthday, name, signedData, or encrypted identity result
+  payloads.
+- **FR-009**: System MUST record only sanitized receipt metadata such as provider,
+  receipt reference, status code, evidence-present booleans, and timestamps.
+- **FR-010**: System MUST register the new live adapter under primitive `check`
+  only; it MUST NOT modify `find`, `locate`, or `send` behavior.
+- **FR-011**: System MUST map `live_verify_ganpyeon_injeung` to the canonical
+  `ganpyeon_injeung` family without changing mock tool-id mapping.
+- **FR-012**: System MUST make default tests fixture-only and ensure CI does not
+  call BaroCert.
+- **FR-013**: System MUST mark live BaroCert tests with `@pytest.mark.live` and
+  skip them unless required credentials are present.
+- **FR-014**: System MUST document required environment variables:
+  `UMMAYA_BAROCERT_LINK_ID`, `UMMAYA_BAROCERT_SECRET_KEY`,
+  `UMMAYA_BAROCERT_CLIENT_CODE`, and provider/test receipt variables used by
+  live tests.
+
+### Key Entities *(include if feature involves data)*
+
+- **BarocertProvider**: Provider selector with `toss`, `kakao`, and `naver`.
+- **BarocertIdentityRequest**: Sanitized request-start input carrying provider,
+  client code, encrypted receiver fields, token, expiry, app-to-app options, and
+  optional return URL.
+- **BarocertIdentityReceipt**: Provider receipt metadata containing provider,
+  receipt reference, optional app scheme, and no raw identity attributes.
+- **BarocertIdentityStatus**: Provider status metadata normalized to pending,
+  complete, expired, rejected, or failed.
+- **BarocertIdentityVerification**: Sanitized verification summary recording
+  whether identity evidence and signed data were present, without storing those
+  values.
+- **GanpyeonInjeungContext**: Existing UMMAYA auth context consumed by the
+  check/submit chain.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `uv run pytest tests/...barocert... -m "not live"` passes without
+  network access.
+- **SC-002**: Registry tests prove `live_verify_ganpyeon_injeung` is discoverable
+  under primitive `check`.
+- **SC-003**: Fixture tests prove CI, DI, phone, birthday, name, signedData, and
+  encrypted identity payload fields are redacted from returned models and logs.
+- **SC-004**: Negative tests cover missing `receiptID`, expired receipt, repeated
+  verify, provider mismatch, missing encrypted placeholders, and upstream error.
+- **SC-005**: With credentials and explicit `-m live`, a sanitized Toss live check
+  records direct evidence before docs claim live readiness.
+
+## Assumptions
+
+- BaroCert live execution uses the official Python SDK surface when present; the
+  adapter fails closed with a configuration error if credentials or SDK runtime
+  are missing during a live invocation.
+- Toss is the only live-priority provider for v1. Kakao and Naver share the
+  client interface but are covered by sanitized fixture replay in this Epic.
+- UMMAYA does not decrypt or compare CI/DI inside the harness. It records that
+  provider identity evidence was returned and leaves raw identity comparison to
+  the upstream relying-party boundary.
+- The explicit live tool id and existing mock tool id both resolve to
+  `family_hint="ganpyeon_injeung"`; explicit `tool_id` selection determines
+  whether the family adapter uses live or mock behavior.
+
+## Scope Boundaries & Deferred Items *(mandatory)*
+
+### Out of Scope (Permanent)
+
+- Government24 submit live integration — no public submission API is available
+  for this workstream, and this Epic is check-only.
+- Raw resident identifiers, phone numbers, CI/DI, signedData, and full provider
+  result storage — prohibited by the feature's privacy boundary.
+- Replacing the existing mock adapter — the mock remains a fixture-backed
+  reference surface.
+
+### Deferred to Future Work
+
+| Item | Reason for Deferral | Target Epic/Phase | Tracking Issue |
+|------|---------------------|-------------------|----------------|
+| Full Kakao live identity execution | v1 priority is Toss; Kakao shares interface but needs its own credential and live evidence pass. | BaroCert provider expansion | #2945 |
+| Full Naver live identity execution | v1 priority is Toss; Naver has provider-specific statuses and return URL constraints needing separate live evidence. | BaroCert provider expansion | #2946 |
+| Provider-side decrypted identity comparison workflow | UMMAYA v1 only records evidence presence and sanitized receipt metadata; comparison policy belongs at relying-party boundary. | Identity evidence policy | #2947 |

--- a/specs/live-barocert-identity-check/tasks.md
+++ b/specs/live-barocert-identity-check/tasks.md
@@ -1,0 +1,127 @@
+# Tasks: Live BaroCert Identity Check
+
+**Input**: Design documents from `specs/live-barocert-identity-check/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/
+**Tests**: Required. Use TDD: write tests first, confirm RED, then implement.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Establish feature package, fixtures, and docs scaffold.
+
+- [X] T001 (#2924) Create live tools package scaffold in `src/ummaya/tools/live/__init__.py`
+- [X] T002 (#2925) [P] Add sanitized BaroCert fixture files in `tests/fixtures/barocert/`
+- [X] T003 (#2926) [P] Add adapter docs scaffold in `docs/api/verify/live_verify_ganpyeon_injeung.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Provider client models and redaction helpers needed by all stories.
+
+- [X] T004 (#2927) [P] [US1] Write failing provider model and redaction tests in `tests/unit/tools/live/test_barocert_identity_client.py`
+- [X] T005 (#2928) [US1] Implement provider models and redaction helpers in `src/ummaya/tools/live/barocert_identity_client.py`
+- [X] T006 (#2929) [P] [US1] Write failing Toss fixture parsing tests in `tests/unit/tools/live/test_barocert_identity_client.py`
+- [X] T007 (#2930) [US1] Implement Toss request/status/verify fixture parsing in `src/ummaya/tools/live/barocert_identity_client.py`
+
+**Checkpoint**: Provider client parses sanitized fixtures and redacts sensitive fields.
+
+---
+
+## Phase 3: User Story 1 - Toss-backed identity check (Priority: P1) MVP
+
+**Goal**: Explicit live tool id returns a redacted `GanpyeonInjeungContext`.
+
+**Independent Test**: Direct adapter unit tests produce a context for a complete
+Toss fixture and fail closed for incomplete or malformed provider states.
+
+### Tests for User Story 1
+
+- [X] T008 (#2931) [P] [US1] Write failing live adapter context tests in `tests/unit/tools/live/test_verify_barocert_identity.py`
+- [X] T009 (#2932) [P] [US1] Write failing negative-path tests in `tests/unit/tools/live/test_verify_barocert_identity.py`
+
+### Implementation for User Story 1
+
+- [X] T010 (#2933) [US1] Implement `live_verify_ganpyeon_injeung` adapter in `src/ummaya/tools/live/verify_barocert_identity.py`
+- [X] T011 (#2934) [US1] Preserve selected check `tool_id` in session context in `src/ummaya/ipc/stdio.py`
+
+**Checkpoint**: Explicit live adapter path works through direct unit tests.
+
+---
+
+## Phase 4: User Story 2 - Provider variants and discovery metadata (Priority: P2)
+
+**Goal**: The client and registry expose Toss live plus Kakao/Naver fixture variants.
+
+**Independent Test**: Registry and mapping tests prove the live tool is
+discoverable under `check` and maps to `ganpyeon_injeung` without breaking mock
+tool ids.
+
+### Tests for User Story 2
+
+- [X] T012 (#2935) [P] [US2] Write failing provider selection tests in `tests/unit/tools/live/test_barocert_identity_client.py`
+- [X] T013 (#2936) [P] [US2] Write failing registry and mapping tests in `tests/integration/test_live_barocert_discovery.py` and `tests/integration/test_tool_id_to_family_hint_translation.py`
+
+### Implementation for User Story 2
+
+- [X] T014 (#2937) [US2] Add live check metadata to `src/ummaya/tools/discovery_bridge.py` and `src/ummaya/tools/verify_canonical_map.py`
+- [X] T015 (#2938) [US2] Import/register live BaroCert adapter from `src/ummaya/tools/register_all.py`
+
+**Checkpoint**: Live tool id is discoverable; existing mock ids still resolve.
+
+---
+
+## Phase 5: User Story 3 - Live validation and documentation (Priority: P3)
+
+**Goal**: Live tests are opt-in and docs state credential/redaction boundaries.
+
+**Independent Test**: Live test skips without env and default non-live tests do
+not touch BaroCert.
+
+### Tests for User Story 3
+
+- [X] T016 (#2939) [P] [US3] Add live skip-gated test in `tests/live/test_live_barocert_identity.py`
+- [X] T017 (#2940) [P] [US3] Add or update no-live-network regression coverage for BaroCert in `tests/agents/test_zero_live_api.py`
+
+### Implementation for User Story 3
+
+- [X] T018 (#2941) [US3] Complete BaroCert live adapter documentation in `docs/api/verify/live_verify_ganpyeon_injeung.md`
+
+**Checkpoint**: Live validation is opt-in and documented.
+
+---
+
+## Final Phase: Polish & Cross-Cutting Concerns
+
+**Purpose**: Verification and PR readiness.
+
+- [X] T019 (#2942) Run targeted non-live BaroCert and verify-registry tests
+- [X] T020 (#2943) Run `uv run pytest -m "not live"` or document any pre-existing blocker
+- [ ] T021 (#2944) Open PR with `Closes #2887` only and monitor CI with `gh pr checks --watch --interval 10`
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- Phase 1 has no dependencies.
+- Phase 2 depends on fixture scaffold from Phase 1.
+- Phase 3 depends on provider client models and parsing from Phase 2.
+- Phase 4 depends on adapter implementation from Phase 3.
+- Phase 5 depends on adapter and registry behavior from Phases 3-4.
+- Final verification depends on all selected user stories.
+
+### Parallel Opportunities
+
+- T002 and T003 can run in parallel.
+- T004 and T006 can be authored together before T005/T007 implementation.
+- T008 and T009 can run in parallel after the client foundation exists.
+- T012 and T013 can run in parallel.
+- T016 and T017 can run in parallel after adapter registration exists.
+
+### Implementation Strategy
+
+1. MVP first: complete T001-T011 so Toss fixture verification returns a redacted context.
+2. Add discovery and provider variants: complete T012-T015.
+3. Add live skip-gated validation and docs: complete T016-T018.
+4. Run T019-T021 before reporting completion.

--- a/src/ummaya/ipc/stdio.py
+++ b/src/ummaya/ipc/stdio.py
@@ -1026,6 +1026,11 @@ def _build_verify_session_context(
     raw_scope_list = session_context.get("scope_list")
     if isinstance(raw_scope_list, list):
         session_context["scope_list"] = _normalize_verify_scope_list(raw_scope_list)
+    raw_tool_id = args_obj.get("tool_id")
+    if isinstance(raw_tool_id, str) and raw_tool_id.strip():
+        selected_tool_id = raw_tool_id.strip()
+        session_context.setdefault("_tool_id", selected_tool_id)
+        session_context.setdefault("tool_id", selected_tool_id)
     session_context.setdefault("session_id", session_id)
     return session_context
 

--- a/src/ummaya/tools/discovery_bridge.py
+++ b/src/ummaya/tools/discovery_bridge.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import importlib
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
@@ -211,6 +211,36 @@ _VERIFY_FAMILIES: list[dict[str, Any]] = [
         ),
     },
     {
+        "tool_id": "live_verify_ganpyeon_injeung",
+        "family": "ganpyeon_injeung",
+        "name_ko": "BaroCert 간편인증 본인확인",
+        "search_hint_ko": [
+            "BaroCert Toss Kakao Naver 간편인증 본인확인",
+            "토스 본인확인",
+            "카카오 본인인증",
+            "네이버 본인인증",
+            "CI DI 검증",
+        ],
+        "search_hint_en": [
+            "BaroCert identity check",
+            "Toss user identity",
+            "Kakao identity",
+            "Naver identity",
+            "simple auth identity proof",
+        ],
+        "endpoint": "https://barocert.linkhub.co.kr",
+        "policy_authority": "https://developers.barocert.com/reference/toss/asp/userIdentity/api",
+        "adapter_mode": "live",
+        "auth_type": "api_key",
+        "last_verified": datetime(2026, 5, 18, tzinfo=UTC),
+        "scope_rules": (
+            "Scope rule: BaroCert identity check returns a sanitized "
+            "ganpyeon_injeung AuthContext only. Use scope_list "
+            "['check:ganpyeon.identity']; do not request submit delegation "
+            "from this live adapter."
+        ),
+    },
+    {
         "tool_id": "mock_verify_mobile_id",
         "family": "mobile_id",
         "name_ko": "모바일 신분증 (mDL)",
@@ -293,13 +323,21 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
     """Build a GovAPITool wrapper for one verify family mock adapter."""
     scope_rules = str(entry.get("scope_rules", "")).strip()
     scope_clause = f"{scope_rules}\n\n" if scope_rules else ""
+    adapter_mode = str(entry.get("adapter_mode", "mock"))
+    if adapter_mode not in {"live", "mock"}:
+        adapter_mode = "mock"
+    adapter_mode_value = cast(Literal["live", "mock"], adapter_mode)
+    auth_type = str(entry.get("auth_type", "api_key"))
+    if auth_type not in {"public", "api_key", "oauth"}:
+        auth_type = "api_key"
+    auth_type_value = cast(Literal["public", "api_key", "oauth"], auth_type)
     return GovAPITool(
         id=entry["tool_id"],
         name_ko=entry["name_ko"],
         ministry="UMMAYA",
-        category=["check", "mock", "delegation"],
+        category=["check", adapter_mode, "delegation"],
         endpoint=entry["endpoint"],
-        auth_type="api_key",
+        auth_type=auth_type_value,
         input_schema=_VerifyParamsShell,
         output_schema=_OpaqueOutput,
         llm_description=(
@@ -323,13 +361,14 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
                 "see AGENTS.md § Hard rules)."
             ),
             citizen_facing_gate="login",
-            last_verified=datetime(2026, 4, 30, tzinfo=UTC),
+            last_verified=entry.get("last_verified", datetime(2026, 4, 30, tzinfo=UTC)),
         ),
         is_concurrency_safe=False,
         cache_ttl_seconds=0,
         rate_limit_per_minute=30,
         is_core=False,  # Discoverable via lookup search; NOT in primary LLM tool list
         primitive="check",
+        adapter_mode=adapter_mode_value,
     )
 
 

--- a/src/ummaya/tools/live/__init__.py
+++ b/src/ummaya/tools/live/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live check adapters.
+
+Modules in this package must not perform network calls at import time. Runtime
+live calls are opt-in and gated by explicit tool id selection plus credentials.
+"""
+
+__all__ = []

--- a/src/ummaya/tools/live/barocert_identity_client.py
+++ b/src/ummaya/tools/live/barocert_identity_client.py
@@ -1,0 +1,512 @@
+# SPDX-License-Identifier: Apache-2.0
+"""BaroCert identity-check client boundary and sanitized parsers."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+
+class BarocertProvider(StrEnum):
+    """Supported BaroCert identity providers for this adapter family."""
+
+    toss = "toss"
+    kakao = "kakao"
+    naver = "naver"
+
+
+class BarocertProviderError(ValueError):
+    """Fail-closed provider parsing/runtime error with a stable reason code."""
+
+    def __init__(self, reason: str, message: str) -> None:
+        super().__init__(f"{reason}: {message}")
+        self.reason = reason
+        self.message = message
+
+
+class BarocertProviderMetadata(BaseModel):
+    """Provider-specific SDK method names."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    provider: BarocertProvider
+    service_class: str
+    request_object_class: str
+    request_method: str
+    status_method: str
+    verify_method: str
+    request_method_aliases: tuple[str, ...] = ()
+    status_method_aliases: tuple[str, ...] = ()
+    verify_method_aliases: tuple[str, ...] = ()
+
+
+_PROVIDER_METADATA: dict[BarocertProvider, BarocertProviderMetadata] = {
+    BarocertProvider.toss: BarocertProviderMetadata(
+        provider=BarocertProvider.toss,
+        service_class="TosscertService",
+        request_object_class="TossUserIdentity",
+        request_method="requestUserIdentity",
+        status_method="getUserIdentityStatus",
+        verify_method="verifyUserIdentity",
+        request_method_aliases=("requestIdentity",),
+        status_method_aliases=("getIdentityStatus",),
+        verify_method_aliases=("verifyIdentity",),
+    ),
+    BarocertProvider.kakao: BarocertProviderMetadata(
+        provider=BarocertProvider.kakao,
+        service_class="KakaocertService",
+        request_object_class="KakaoIdentity",
+        request_method="requestIdentity",
+        status_method="getIdentityStatus",
+        verify_method="verifyIdentity",
+    ),
+    BarocertProvider.naver: BarocertProviderMetadata(
+        provider=BarocertProvider.naver,
+        service_class="NavercertService",
+        request_object_class="NaverIdentity",
+        request_method="requestIdentity",
+        status_method="getIdentityStatus",
+        verify_method="verifyIdentity",
+    ),
+}
+
+
+def _coerce_provider(provider: BarocertProvider | str) -> BarocertProvider:
+    try:
+        return provider if isinstance(provider, BarocertProvider) else BarocertProvider(provider)
+    except ValueError as exc:
+        raise BarocertProviderError(
+            "unsupported_provider",
+            f"unsupported provider {provider!r}",
+        ) from exc
+
+
+def provider_metadata(provider: BarocertProvider | str) -> BarocertProviderMetadata:
+    """Return provider-specific method metadata."""
+
+    return _PROVIDER_METADATA[_coerce_provider(provider)]
+
+
+_SENSITIVE_KEYS = frozenset(
+    {
+        "ci",
+        "di",
+        "signeddata",
+        "receiverhp",
+        "receiverphone",
+        "receivername",
+        "receiverbirthday",
+        "receiverbirth",
+        "receiveryear",
+        "receiverday",
+        "receivergender",
+        "receiverforeign",
+        "receiveragegroup",
+        "name",
+        "birthday",
+        "birthdate",
+        "phone",
+        "hp",
+    }
+)
+
+
+def _normalize_key(key: object) -> str:
+    return "".join(ch for ch in str(key).lower() if ch.isalnum())
+
+
+def redact_barocert_payload(payload: Any) -> Any:
+    """Return a recursively redacted copy of a BaroCert payload."""
+
+    if isinstance(payload, dict):
+        redacted: dict[str, Any] = {}
+        for key, value in payload.items():
+            if _normalize_key(key) in _SENSITIVE_KEYS:
+                redacted[str(key)] = "<redacted>"
+            else:
+                redacted[str(key)] = redact_barocert_payload(value)
+        return redacted
+    if isinstance(payload, list):
+        return [redact_barocert_payload(item) for item in payload]
+    if isinstance(payload, tuple):
+        return tuple(redact_barocert_payload(item) for item in payload)
+    return payload
+
+
+class BarocertIdentityRequest(BaseModel):
+    """Sanitized request-start model.
+
+    Values for receiver fields and token must already be encrypted placeholders
+    when supplied to this model. The model deliberately does not expose helpers
+    that accept raw phone, name, birthday, CI, or DI.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    provider: BarocertProvider
+    client_code: str = Field(min_length=1)
+    receiver_hp_encrypted: str = Field(min_length=1)
+    receiver_name_encrypted: str = Field(min_length=1)
+    receiver_birthday_encrypted: str = Field(min_length=1)
+    token: str = Field(min_length=1)
+    expire_in: int = Field(default=300, ge=1, le=1800)
+    app_use_yn: bool = False
+    device_os_type: Literal["ANDROID", "IOS"] | None = None
+    return_url: str | None = None
+
+    @model_validator(mode="after")
+    def _validate_app_to_app_fields(self) -> BarocertIdentityRequest:
+        if self.app_use_yn and not self.return_url:
+            raise ValueError("return_url is required when app_use_yn=True")
+        if self.app_use_yn and self.provider is BarocertProvider.toss and not self.device_os_type:
+            raise ValueError("device_os_type is required for Toss app-to-app requests")
+        return self
+
+    def to_user_identity_payload(self) -> dict[str, object]:
+        """Return the provider SDK payload with encrypted-placeholder values only."""
+
+        payload: dict[str, object] = {
+            "receiverHP": self.receiver_hp_encrypted,
+            "receiverName": self.receiver_name_encrypted,
+            "receiverBirthday": self.receiver_birthday_encrypted,
+            "token": self.token,
+            "expireIn": self.expire_in,
+            "appUseYN": self.app_use_yn,
+        }
+        if self.device_os_type is not None:
+            payload["deviceOSType"] = self.device_os_type
+        if self.return_url is not None:
+            payload["returnURL"] = self.return_url
+        return payload
+
+
+class BarocertIdentityReceipt(BaseModel):
+    """Sanitized request receipt metadata."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    provider: BarocertProvider
+    receipt_id: str = Field(min_length=1)
+    scheme: str | None = None
+
+
+BarocertStatusState = Literal["pending", "complete", "expired", "failed"]
+
+
+class BarocertIdentityStatus(BaseModel):
+    """Normalized BaroCert identity status metadata."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    provider: BarocertProvider
+    receipt_id: str = Field(min_length=1)
+    state: BarocertStatusState
+    raw_state: int | str
+    expire_dt: str | None = None
+
+    @property
+    def is_complete(self) -> bool:
+        return self.state == "complete"
+
+
+class BarocertIdentityVerification(BaseModel):
+    """Sanitized verification summary."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    provider: BarocertProvider
+    receipt_id: str = Field(min_length=1)
+    state: Literal["complete"]
+    identity_evidence_present: bool
+    signed_data_present: bool
+    verified_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    sanitized_receipt_metadata: dict[str, object] = Field(default_factory=dict)
+
+
+def _payload_to_dict(payload: Any) -> dict[str, object]:
+    if isinstance(payload, BaseModel):
+        return payload.model_dump(by_alias=True)
+    if isinstance(payload, dict):
+        return {str(k): v for k, v in payload.items()}
+    if hasattr(payload, "__dict__"):
+        return {str(k): v for k, v in vars(payload).items() if not str(k).startswith("_")}
+    raise BarocertProviderError("malformed_payload", "provider payload is not object-like")
+
+
+def _raise_for_upstream_error(payload: dict[str, object]) -> None:
+    code = payload.get("Code", payload.get("code"))
+    if code is None:
+        return
+    try:
+        code_value = int(str(code))
+    except ValueError:
+        code_value = -1
+    if code_value != 0:
+        message = str(payload.get("message", payload.get("Message", "provider error")))
+        raise BarocertProviderError("upstream_error", message)
+
+
+def _require_matching_provider(
+    expected_provider: BarocertProvider,
+    payload: dict[str, object],
+) -> None:
+    raw_provider = payload.get("provider")
+    if raw_provider is None:
+        return
+    try:
+        observed = _coerce_provider(str(raw_provider))
+    except BarocertProviderError as exc:
+        raise BarocertProviderError("provider_mismatch", str(raw_provider)) from exc
+    if observed is not expected_provider:
+        raise BarocertProviderError(
+            "provider_mismatch",
+            f"expected {expected_provider.value}, got {observed.value}",
+        )
+
+
+def _extract_receipt_id(payload: dict[str, object]) -> str:
+    receipt = payload.get("receiptID", payload.get("receiptId", payload.get("receipt_id")))
+    if not isinstance(receipt, str) or not receipt.strip():
+        raise BarocertProviderError("missing_receipt_id", "receiptID is required")
+    return receipt.strip()
+
+
+def _require_receipt(receipt_id: str, payload: dict[str, object]) -> None:
+    observed = _extract_receipt_id(payload)
+    if observed != receipt_id:
+        raise BarocertProviderError("receipt_mismatch", f"expected {receipt_id}, got {observed}")
+
+
+def _state_from_payload(payload: dict[str, object]) -> tuple[int | str, BarocertStatusState]:
+    raw_state_obj = payload.get("state")
+    if raw_state_obj is None:
+        raise BarocertProviderError("missing_state", "state is required")
+    if not isinstance(raw_state_obj, int | str):
+        raise BarocertProviderError("malformed_state", "state must be integer or string")
+    raw_state: int | str = raw_state_obj
+    if isinstance(raw_state, str):
+        stripped = raw_state.strip().lower()
+        state_by_name: dict[str, BarocertStatusState] = {
+            "pending": "pending",
+            "complete": "complete",
+            "completed": "complete",
+            "verified": "complete",
+            "expired": "expired",
+            "failed": "failed",
+            "rejected": "failed",
+        }
+        named = state_by_name.get(stripped)
+        if named is not None:
+            return raw_state, named
+        if stripped.isdigit():
+            raw_state = int(stripped)
+    if raw_state == 0:
+        return raw_state, "pending"
+    if raw_state == 1:
+        return raw_state, "complete"
+    if raw_state == 2:
+        return raw_state, "expired"
+    return raw_state, "failed"
+
+
+def parse_identity_receipt(
+    provider: BarocertProvider | str,
+    payload: Any,
+) -> BarocertIdentityReceipt:
+    """Parse a request receipt into sanitized metadata."""
+
+    provider_value = _coerce_provider(provider)
+    data = _payload_to_dict(payload)
+    _raise_for_upstream_error(data)
+    _require_matching_provider(provider_value, data)
+    scheme_value = data.get("scheme")
+    return BarocertIdentityReceipt(
+        provider=provider_value,
+        receipt_id=_extract_receipt_id(data),
+        scheme=scheme_value if isinstance(scheme_value, str) else None,
+    )
+
+
+def parse_identity_status(
+    provider: BarocertProvider | str,
+    receipt_id: str,
+    payload: Any,
+) -> BarocertIdentityStatus:
+    """Parse a provider status payload into normalized metadata."""
+
+    provider_value = _coerce_provider(provider)
+    data = _payload_to_dict(payload)
+    _raise_for_upstream_error(data)
+    _require_matching_provider(provider_value, data)
+    _require_receipt(receipt_id, data)
+    raw_state, state = _state_from_payload(data)
+    if state == "expired":
+        raise BarocertProviderError("expired", "BaroCert receipt has expired")
+    if state == "failed":
+        raise BarocertProviderError("failed", f"BaroCert receipt state is {raw_state!r}")
+    expire_dt_value = data.get("expireDT")
+    return BarocertIdentityStatus(
+        provider=provider_value,
+        receipt_id=receipt_id,
+        state=state,
+        raw_state=raw_state,
+        expire_dt=expire_dt_value if isinstance(expire_dt_value, str) else None,
+    )
+
+
+def parse_identity_verification(
+    provider: BarocertProvider | str,
+    receipt_id: str,
+    payload: Any,
+) -> BarocertIdentityVerification:
+    """Parse a provider verification payload into a redacted summary."""
+
+    provider_value = _coerce_provider(provider)
+    data = _payload_to_dict(payload)
+    _raise_for_upstream_error(data)
+    _require_matching_provider(provider_value, data)
+    _require_receipt(receipt_id, data)
+    _, state = _state_from_payload(data)
+    if state != "complete":
+        raise BarocertProviderError(state, f"BaroCert verification state is {state}")
+
+    signed_data_present = bool(data.get("signedData"))
+    evidence_keys = (
+        "ci",
+        "di",
+        "receiverName",
+        "receiverYear",
+        "receiverDay",
+        "receiverGender",
+        "receiverForeign",
+        "receiverAgeGroup",
+    )
+    identity_evidence_present = any(bool(data.get(key)) for key in evidence_keys)
+    if not identity_evidence_present:
+        raise BarocertProviderError(
+            "missing_identity_evidence",
+            "no identity evidence fields found",
+        )
+    if not signed_data_present:
+        raise BarocertProviderError("missing_signed_data", "signedData is required")
+
+    return BarocertIdentityVerification(
+        provider=provider_value,
+        receipt_id=receipt_id,
+        state="complete",
+        identity_evidence_present=True,
+        signed_data_present=True,
+        sanitized_receipt_metadata={
+            "provider": provider_value.value,
+            "receiptID": receipt_id,
+            "state": "complete",
+            "identity_evidence_present": True,
+            "signed_data_present": True,
+        },
+    )
+
+
+@dataclass(frozen=True)
+class BarocertIdentityClient:
+    """Thin wrapper around the official BaroCert SDK.
+
+    The SDK is imported only when a live invocation occurs. Tests use the parser
+    functions above with fixtures and never instantiate this client.
+    """
+
+    provider: BarocertProvider
+    link_id: str
+    secret_key: str
+    client_code: str
+    ip_restrict_on_off: bool = True
+    use_static_ip: bool = False
+
+    @classmethod
+    def from_env(cls, provider: BarocertProvider | str) -> BarocertIdentityClient:
+        provider_value = _coerce_provider(provider)
+        link_id = os.environ.get("UMMAYA_BAROCERT_LINK_ID", "").strip()
+        secret_key = os.environ.get("UMMAYA_BAROCERT_SECRET_KEY", "").strip()
+        client_code = os.environ.get("UMMAYA_BAROCERT_CLIENT_CODE", "").strip()
+        missing = [
+            name
+            for name, value in (
+                ("UMMAYA_BAROCERT_LINK_ID", link_id),
+                ("UMMAYA_BAROCERT_SECRET_KEY", secret_key),
+                ("UMMAYA_BAROCERT_CLIENT_CODE", client_code),
+            )
+            if not value
+        ]
+        if missing:
+            raise BarocertProviderError("missing_credentials", ",".join(missing))
+        return cls(
+            provider=provider_value,
+            link_id=link_id,
+            secret_key=secret_key,
+            client_code=client_code,
+            ip_restrict_on_off=os.environ.get("UMMAYA_BAROCERT_IP_RESTRICT", "true").lower()
+            not in {"0", "false", "no"},
+            use_static_ip=os.environ.get("UMMAYA_BAROCERT_USE_STATIC_IP", "false").lower()
+            in {"1", "true", "yes"},
+        )
+
+    def _service(self) -> object:
+        metadata = provider_metadata(self.provider)
+        try:
+            barocert = importlib.import_module("barocert")
+        except ImportError as exc:
+            raise BarocertProviderError("sdk_unavailable", "install barocert SDK") from exc
+
+        service_cls = getattr(barocert, metadata.service_class, None)
+        if service_cls is None:
+            raise BarocertProviderError("sdk_unavailable", f"{metadata.service_class} not found")
+        service = service_cls(self.link_id, self.secret_key)
+        if hasattr(service, "IPRestrictOnOff"):
+            service.IPRestrictOnOff = self.ip_restrict_on_off
+        if hasattr(service, "UseStaticIP"):
+            service.UseStaticIP = self.use_static_ip
+        return service
+
+    def _call_service(
+        self,
+        method_name: str,
+        aliases: tuple[str, ...],
+        receipt_id: str,
+    ) -> dict[str, object]:
+        service = self._service()
+        method = None
+        for candidate in (method_name, *aliases):
+            method = getattr(service, candidate, None)
+            if method is not None:
+                break
+        if method is None:
+            raise BarocertProviderError("sdk_unavailable", f"{method_name} not found")
+        try:
+            return _payload_to_dict(method(self.client_code, receipt_id))
+        except Exception as exc:  # noqa: BLE001
+            code = getattr(exc, "code", getattr(exc, "Code", ""))
+            message = getattr(exc, "message", str(exc))
+            raise BarocertProviderError("upstream_error", f"{code}:{message}") from exc
+
+    def get_status(self, receipt_id: str) -> BarocertIdentityStatus:
+        metadata = provider_metadata(self.provider)
+        payload = self._call_service(
+            metadata.status_method,
+            metadata.status_method_aliases,
+            receipt_id,
+        )
+        return parse_identity_status(self.provider, receipt_id, payload)
+
+    def verify_identity(self, receipt_id: str) -> BarocertIdentityVerification:
+        metadata = provider_metadata(self.provider)
+        payload = self._call_service(
+            metadata.verify_method,
+            metadata.verify_method_aliases,
+            receipt_id,
+        )
+        return parse_identity_verification(self.provider, receipt_id, payload)

--- a/src/ummaya/tools/live/verify_barocert_identity.py
+++ b/src/ummaya/tools/live/verify_barocert_identity.py
@@ -1,0 +1,143 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live BaroCert identity check adapter for the ganpyeon_injeung family."""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Callable
+
+import ummaya.tools.mock.verify_ganpyeon_injeung  # noqa: F401
+from ummaya.primitives.verify import (
+    _VERIFY_ADAPTERS,
+    GanpyeonInjeungContext,
+    VerifyMismatchError,
+    register_verify_adapter,
+)
+from ummaya.tools.live.barocert_identity_client import (
+    BarocertIdentityClient,
+    BarocertIdentityStatus,
+    BarocertIdentityVerification,
+    BarocertProviderError,
+    parse_identity_status,
+    parse_identity_verification,
+)
+
+logger = logging.getLogger(__name__)
+
+LIVE_TOOL_ID = "live_verify_ganpyeon_injeung"
+FAMILY = "ganpyeon_injeung"
+
+Adapter = Callable[[dict[str, object]], object]
+
+
+def _current_previous_adapter() -> Adapter | None:
+    current = _VERIFY_ADAPTERS.get(FAMILY)
+    if getattr(current, "_barocert_live_adapter", False):
+        previous = getattr(current, "_previous_adapter", None)
+        return previous if callable(previous) else None
+    return current if callable(current) else None
+
+
+_PREVIOUS_ADAPTER = _current_previous_adapter()
+
+
+def _selected_tool_id(session_context: dict[str, object]) -> str:
+    tool_id = session_context.get("_tool_id") or session_context.get("tool_id")
+    return str(tool_id or "")
+
+
+def _is_live_selection(session_context: dict[str, object]) -> bool:
+    return _selected_tool_id(session_context) == LIVE_TOOL_ID
+
+
+def _call_previous_adapter(session_context: dict[str, object]) -> object:
+    if _PREVIOUS_ADAPTER is None:
+        return VerifyMismatchError(
+            expected_family=FAMILY,
+            observed_family="barocert_identity:no_previous_adapter",
+            message="No previous ganpyeon_injeung adapter is registered.",
+        )
+    result = _PREVIOUS_ADAPTER(session_context)
+    if inspect.isawaitable(result):
+        return _fail("async_previous_adapter", "previous ganpyeon adapter returned awaitable")
+    return result
+
+
+def _fail(reason: str, message: str) -> VerifyMismatchError:
+    return VerifyMismatchError(
+        expected_family=FAMILY,
+        observed_family=f"barocert_identity:{reason}",
+        message=f"BaroCert identity check failed ({reason}): {message}",
+    )
+
+
+def _receipt_id(session_context: dict[str, object]) -> str:
+    raw = (
+        session_context.get("receiptID")
+        or session_context.get("receipt_id")
+        or session_context.get("external_session_ref")
+    )
+    if isinstance(raw, str) and raw.startswith("barocert:"):
+        parts = raw.split(":", 2)
+        raw = parts[-1] if len(parts) == 3 else raw
+    if not isinstance(raw, str) or not raw.strip():
+        raise BarocertProviderError("missing_receipt_id", "receiptID is required")
+    return raw.strip()
+
+
+def _parse_or_call_live(
+    provider: str,
+    receipt_id: str,
+    session_context: dict[str, object],
+) -> tuple[BarocertIdentityStatus, BarocertIdentityVerification]:
+    status_fixture = session_context.get("_fixture_status")
+    verify_fixture = session_context.get("_fixture_verify")
+    if isinstance(status_fixture, dict) and isinstance(verify_fixture, dict):
+        status = parse_identity_status(provider, receipt_id, status_fixture)
+        verification = parse_identity_verification(provider, receipt_id, verify_fixture)
+        return status, verification
+
+    client = BarocertIdentityClient.from_env(provider)
+    status = client.get_status(receipt_id)
+    verification = client.verify_identity(receipt_id)
+    return status, verification
+
+
+def invoke(
+    session_context: dict[str, object],
+) -> GanpyeonInjeungContext | VerifyMismatchError:
+    """Route explicit live selection to BaroCert; otherwise preserve the mock adapter."""
+
+    if not _is_live_selection(session_context):
+        return _call_previous_adapter(session_context)  # type: ignore[return-value]
+
+    provider = str(session_context.get("provider") or "toss").strip().lower()
+    try:
+        receipt_id = _receipt_id(session_context)
+        status, verification = _parse_or_call_live(provider, receipt_id, session_context)
+        if not status.is_complete:
+            return _fail("status_not_complete", f"status={status.state}")
+        if not verification.identity_evidence_present or not verification.signed_data_present:
+            return _fail("missing_identity_evidence", "identity evidence or signedData missing")
+    except BarocertProviderError as exc:
+        logger.info("BaroCert identity check failed closed: %s", exc.reason)
+        return _fail(exc.reason, exc.message)
+
+    return GanpyeonInjeungContext.model_validate(
+        {
+            "family": FAMILY,
+            "published_tier": f"ganpyeon_injeung_{provider}_aal2",
+            "nist_aal_hint": "AAL2",
+            "verified_at": verification.verified_at,
+            "external_session_ref": f"barocert:{provider}:{receipt_id}",
+            "provider": provider,
+        }
+    )
+
+
+invoke._barocert_live_adapter = True  # type: ignore[attr-defined]
+invoke._previous_adapter = _PREVIOUS_ADAPTER  # type: ignore[attr-defined]
+register_verify_adapter(FAMILY, invoke)
+
+__all__ = ["FAMILY", "LIVE_TOOL_ID", "invoke"]

--- a/src/ummaya/tools/register_all.py
+++ b/src/ummaya/tools/register_all.py
@@ -117,6 +117,7 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> Routin
 
     # Register MVP LLM-visible core surface first (FR-001, SC-003)
     register_mvp_surface(registry)
+    import ummaya.tools.live.verify_barocert_identity  # noqa: F401 — registers live check wrapper
     import ummaya.tools.mock  # noqa: F401 — registers all mock surfaces in production
 
     # Locate provider endpoints are first-class adapters under the central
@@ -173,7 +174,7 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> Routin
 
     bridge_count = bridge_per_primitive_registries(registry)
     logger.info(
-        "discovery_bridge: bridged %d non-core mock adapters into BM25 corpus",
+        "discovery_bridge: bridged %d non-core primitive adapters into BM25 corpus",
         bridge_count,
     )
 

--- a/src/ummaya/tools/verify_canonical_map.py
+++ b/src/ummaya/tools/verify_canonical_map.py
@@ -74,7 +74,7 @@ def _load_map() -> Mapping[str, str]:
     from ummaya.tools.discovery_bridge import _VERIFY_FAMILIES  # noqa: PLC0415
 
     mapping: dict[str, str] = {
-        str(entry["tool_id"]): _tool_id_to_family(str(entry["tool_id"]))
+        str(entry["tool_id"]): str(entry.get("family") or _tool_id_to_family(str(entry["tool_id"])))
         for entry in _VERIFY_FAMILIES
         if isinstance(entry, dict) and isinstance(entry.get("tool_id"), str)
     }

--- a/tests/agents/test_zero_live_api.py
+++ b/tests/agents/test_zero_live_api.py
@@ -33,6 +33,8 @@ _BANNED_HOSTS = frozenset(
         "api.friendli.ai",
         "friendli.ai",
         "apis.data.go.kr",
+        "developers.barocert.com",
+        "barocert.com",
     ]
 )
 

--- a/tests/fixtures/barocert/kakao_status_complete.json
+++ b/tests/fixtures/barocert/kakao_status_complete.json
@@ -1,0 +1,7 @@
+{
+  "provider": "kakao",
+  "receiptID": "KAKAO_RECEIPT_SANITIZED_001",
+  "clientCode": "TESTCLIENT01",
+  "state": 1,
+  "expireDT": "20260518235959"
+}

--- a/tests/fixtures/barocert/naver_status_complete.json
+++ b/tests/fixtures/barocert/naver_status_complete.json
@@ -1,0 +1,7 @@
+{
+  "provider": "naver",
+  "receiptID": "NAVER_RECEIPT_SANITIZED_001",
+  "clientCode": "TESTCLIENT01",
+  "state": 1,
+  "expireDT": "20260518235959"
+}

--- a/tests/fixtures/barocert/toss_request_receipt.json
+++ b/tests/fixtures/barocert/toss_request_receipt.json
@@ -1,0 +1,5 @@
+{
+  "provider": "toss",
+  "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+  "scheme": "barocert-toss://identity/SANITIZED"
+}

--- a/tests/fixtures/barocert/toss_status_complete.json
+++ b/tests/fixtures/barocert/toss_status_complete.json
@@ -1,0 +1,7 @@
+{
+  "provider": "toss",
+  "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+  "clientCode": "TESTCLIENT01",
+  "state": 1,
+  "expireDT": "20260518235959"
+}

--- a/tests/fixtures/barocert/toss_status_expired.json
+++ b/tests/fixtures/barocert/toss_status_expired.json
@@ -1,0 +1,7 @@
+{
+  "provider": "toss",
+  "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+  "clientCode": "TESTCLIENT01",
+  "state": 2,
+  "expireDT": "20260518000000"
+}

--- a/tests/fixtures/barocert/toss_verify_complete.json
+++ b/tests/fixtures/barocert/toss_verify_complete.json
@@ -1,0 +1,14 @@
+{
+  "provider": "toss",
+  "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+  "state": 1,
+  "receiverName": "ENCRYPTED_NAME_PLACEHOLDER",
+  "receiverYear": "ENCRYPTED_YEAR_PLACEHOLDER",
+  "receiverDay": "ENCRYPTED_DAY_PLACEHOLDER",
+  "receiverGender": "ENCRYPTED_GENDER_PLACEHOLDER",
+  "receiverForeign": "ENCRYPTED_FOREIGN_PLACEHOLDER",
+  "receiverAgeGroup": "ENCRYPTED_AGE_PLACEHOLDER",
+  "signedData": "SYNTHETIC_SIGNED_DATA_PLACEHOLDER",
+  "ci": "SYNTHETIC_CI_PLACEHOLDER",
+  "di": "SYNTHETIC_DI_PLACEHOLDER"
+}

--- a/tests/fixtures/barocert/toss_verify_repeated.json
+++ b/tests/fixtures/barocert/toss_verify_repeated.json
@@ -1,0 +1,6 @@
+{
+  "provider": "toss",
+  "Code": -99999999,
+  "message": "Synthetic repeated verification error",
+  "receiptID": "TOSS_RECEIPT_SANITIZED_001"
+}

--- a/tests/integration/test_discovery_bridge_path_b.py
+++ b/tests/integration/test_discovery_bridge_path_b.py
@@ -41,13 +41,13 @@ def test_b1_total_tool_count_includes_mocks(
 ) -> None:
     """Path B-1: bridge registers active non-core mock adapters into main registry.
 
-    Expected total: 68 after both verified public-data adapter waves.
+    Expected total: 69 after both verified public-data waves plus BaroCert live check.
     """
     r, _ = loaded_registry
     total = len(r.all_tools())
-    assert total == 68, (
-        f"Expected 68 total tools after discovery_bridge runs; got {total}. "
-        f"Verify the bridge registered the active mock adapters."
+    assert total == 69, (
+        f"Expected 69 total tools after discovery_bridge runs; got {total}. "
+        f"Verify the bridge registered the active primitive adapters."
     )
 
 

--- a/tests/integration/test_live_barocert_discovery.py
+++ b/tests/integration/test_live_barocert_discovery.py
@@ -1,0 +1,28 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Integration coverage for live BaroCert check discovery metadata."""
+
+from __future__ import annotations
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.register_all import register_all_tools
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verify_canonical_map import resolve_family
+
+
+def test_live_barocert_check_is_discoverable_and_check_only() -> None:
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry)
+    register_all_tools(registry, executor)
+
+    tool = registry.find("live_verify_ganpyeon_injeung")
+
+    assert tool.primitive == "check"
+    assert tool.adapter_mode == "live"
+    assert "check" in tool.category
+    assert "live" in tool.category
+    assert resolve_family("live_verify_ganpyeon_injeung") == "ganpyeon_injeung"
+
+
+def test_mock_and_live_ganpyeon_ids_resolve_to_same_family() -> None:
+    assert resolve_family("mock_verify_ganpyeon_injeung") == "ganpyeon_injeung"
+    assert resolve_family("live_verify_ganpyeon_injeung") == "ganpyeon_injeung"

--- a/tests/integration/test_mcp_otel_spans.py
+++ b/tests/integration/test_mcp_otel_spans.py
@@ -87,8 +87,8 @@ class TestMCPToolsListShape:
         tools = response["result"]["tools"]
         # Subscribe is deferred out of the active surface until UMMAYA owns an
         # app/push delivery runtime. The MCP tool list mirrors the active
-        # registry: 68 tools after Spec #2798's 16-adapter live expansion.
-        assert len(tools) == 68, f"Tool list count drift: got {len(tools)}, expected 68"
+        # registry: 69 tools after Spec #2798 plus BaroCert live check.
+        assert len(tools) == 69, f"Tool list count drift: got {len(tools)}, expected 69"
 
     def test_tools_list_entries_have_required_keys(self, mcp_server: MCPServer) -> None:
         response = asyncio.run(

--- a/tests/integration/test_tool_id_to_family_hint_translation.py
+++ b/tests/integration/test_tool_id_to_family_hint_translation.py
@@ -28,13 +28,15 @@ from ummaya.tools.mvp_surface import _VerifyInputForLLM
 
 # ---------------------------------------------------------------------------
 # Parametrised canonical-family cases (I-V1)
-# One case per canonical family; 10 total.
+# One case per canonical tool id. Live BaroCert deliberately shares the
+# existing ganpyeon_injeung family while preserving explicit tool selection.
 # ---------------------------------------------------------------------------
 
 _CANONICAL_CASES: list[tuple[str, str]] = [
     ("mock_verify_gongdong_injeungseo", "gongdong_injeungseo"),
     ("mock_verify_geumyung_injeungseo", "geumyung_injeungseo"),
     ("mock_verify_ganpyeon_injeung", "ganpyeon_injeung"),
+    ("live_verify_ganpyeon_injeung", "ganpyeon_injeung"),
     ("mock_verify_mobile_id", "mobile_id"),
     ("mock_verify_mydata", "mydata"),
     ("mock_verify_module_simple_auth", "simple_auth_module"),

--- a/tests/live/test_live_barocert_identity.py
+++ b/tests/live/test_live_barocert_identity.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in live validation for the BaroCert Toss identity check adapter."""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ummaya.primitives.verify import GanpyeonInjeungContext, verify
+
+pytestmark = pytest.mark.live
+
+_REQUIRED_ENV = (
+    "UMMAYA_BAROCERT_LINK_ID",
+    "UMMAYA_BAROCERT_SECRET_KEY",
+    "UMMAYA_BAROCERT_CLIENT_CODE",
+    "UMMAYA_BAROCERT_TEST_RECEIPT_ID",
+)
+
+
+def _missing_env() -> list[str]:
+    return [name for name in _REQUIRED_ENV if not os.environ.get(name, "").strip()]
+
+
+@pytest.mark.skipif(bool(_missing_env()), reason="BaroCert live credentials are not configured")
+@pytest.mark.asyncio
+async def test_live_barocert_toss_receipt_verifies_without_identity_payload() -> None:
+    import ummaya.tools.live.verify_barocert_identity  # noqa: F401
+
+    result = await verify(
+        "ganpyeon_injeung",
+        {
+            "_tool_id": "live_verify_ganpyeon_injeung",
+            "provider": "toss",
+            "receiptID": os.environ["UMMAYA_BAROCERT_TEST_RECEIPT_ID"],
+        },
+    )
+
+    assert isinstance(result, GanpyeonInjeungContext)
+    assert result.provider == "toss"
+    dumped = result.model_dump_json()
+    assert "ci" not in dumped.lower()
+    assert "di" not in dumped.lower()
+    assert "signedData" not in dumped

--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -38,10 +38,11 @@ class TestToolRegistration:
         # Spec #2797 verified public-data wave: + 14 direct-curl verified
         # data.go.kr/LINK adapters = 52.
         # Spec #2798 live expansion: + 16 approved data.go.kr adapters = 68.
+        # Spec live-barocert-identity-check: + 1 live check adapter = 69.
         # is_core=False so the LLM's primary tool list stays at active
         # primitives + lookup-class; these participate in
         # lookup(mode="search") BM25 corpus only.
-        assert len(registry) == 68
+        assert len(registry) == 69
 
     def test_tool_ids_present(self) -> None:
         """Each expected tool_id is in the registry.
@@ -107,6 +108,7 @@ class TestToolRegistration:
             "ccourt_publication_documents",
             "moj_stay_person_counter",
             "msit_business_announcement_lookup",
+            "live_verify_ganpyeon_injeung",
         }
         for tool_id in expected:
             assert tool_id in registry, f"{tool_id} not found in registry"

--- a/tests/tools/test_routing_consistency.py
+++ b/tests/tools/test_routing_consistency.py
@@ -170,7 +170,7 @@ class TestInvariant4UniqueToolId:
 
 
 class TestCheck7ToolListClosure:
-    """The Python-side registered tool set matches the 68-entry registry.
+    """The Python-side registered tool set matches the 69-entry registry.
 
     Divergence from this set indicates either an unauthorized addition or
     an inadvertent removal — both are CI failures.
@@ -226,6 +226,9 @@ class TestCheck7ToolListClosure:
             "mock_verify_ganpyeon_injeung",
             "mock_verify_mobile_id",
             "mock_verify_mydata",
+            # Spec live-barocert-identity-check — explicit BaroCert live check
+            # adapter sharing the canonical ganpyeon_injeung family.
+            "live_verify_ganpyeon_injeung",
             # 5 submit wrappers
             "mock_submit_module_hometax_taxreturn",
             "mock_submit_module_gov24_minwon",

--- a/tests/unit/test_verify_canonical_map_parser.py
+++ b/tests/unit/test_verify_canonical_map_parser.py
@@ -38,6 +38,7 @@ EXPECTED_MAPPING: dict[str, str] = {
     "mock_verify_module_kec": "kec",
     "mock_verify_module_geumyung": "geumyung_module",
     "mock_verify_module_any_id_sso": "any_id_sso",
+    "live_verify_ganpyeon_injeung": "ganpyeon_injeung",
 }
 
 
@@ -120,8 +121,12 @@ def test_canonical_family_hint_values_are_all_present() -> None:
     assert not missing_families, f"Missing family_hint values in canonical map: {missing_families}"
 
 
-def test_canonical_map_tool_ids_start_with_mock_verify() -> None:
-    """All canonical tool_id keys MUST start with 'mock_verify_'."""
+def test_canonical_map_tool_ids_use_verify_prefix() -> None:
+    """All canonical tool_id keys MUST use an explicit verify adapter prefix."""
     mapping = get_canonical_map()
-    invalid = [tid for tid in mapping if not tid.startswith("mock_verify_")]
-    assert not invalid, f"tool_ids NOT starting with 'mock_verify_': {invalid}"
+    invalid = [
+        tid
+        for tid in mapping
+        if not (tid.startswith("mock_verify_") or tid.startswith("live_verify_"))
+    ]
+    assert not invalid, f"tool_ids NOT using verify adapter prefix: {invalid}"

--- a/tests/unit/tools/live/test_barocert_identity_client.py
+++ b/tests/unit/tools/live/test_barocert_identity_client.py
@@ -1,0 +1,158 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the live BaroCert identity client boundary."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+from pydantic import ValidationError
+
+from ummaya.tools.live.barocert_identity_client import (
+    BarocertIdentityRequest,
+    BarocertProvider,
+    BarocertProviderError,
+    parse_identity_receipt,
+    parse_identity_status,
+    parse_identity_verification,
+    provider_metadata,
+    redact_barocert_payload,
+)
+
+FIXTURE_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "barocert"
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+def test_provider_metadata_covers_toss_kakao_naver() -> None:
+    assert {provider.value for provider in BarocertProvider} == {"toss", "kakao", "naver"}
+
+    assert provider_metadata(BarocertProvider.toss).request_method == "requestUserIdentity"
+    assert provider_metadata("toss").status_method == "getUserIdentityStatus"
+    assert provider_metadata("toss").verify_method == "verifyUserIdentity"
+
+    assert provider_metadata("kakao").request_method == "requestIdentity"
+    assert provider_metadata("naver").verify_method == "verifyIdentity"
+
+
+def test_identity_request_requires_encrypted_placeholders() -> None:
+    request = BarocertIdentityRequest(
+        provider="toss",
+        client_code="TESTCLIENT01",
+        receiver_hp_encrypted="ENCRYPTED_HP_PLACEHOLDER",
+        receiver_name_encrypted="ENCRYPTED_NAME_PLACEHOLDER",
+        receiver_birthday_encrypted="ENCRYPTED_BIRTHDAY_PLACEHOLDER",
+        token="ENCRYPTED_TOKEN_PLACEHOLDER",
+        expire_in=300,
+        app_use_yn=True,
+        device_os_type="IOS",
+        return_url="ummaya://barocert/callback",
+    )
+
+    assert request.to_user_identity_payload() == {
+        "receiverHP": "ENCRYPTED_HP_PLACEHOLDER",
+        "receiverName": "ENCRYPTED_NAME_PLACEHOLDER",
+        "receiverBirthday": "ENCRYPTED_BIRTHDAY_PLACEHOLDER",
+        "token": "ENCRYPTED_TOKEN_PLACEHOLDER",
+        "expireIn": 300,
+        "appUseYN": True,
+        "deviceOSType": "IOS",
+        "returnURL": "ummaya://barocert/callback",
+    }
+
+    with pytest.raises(ValidationError):
+        BarocertIdentityRequest(
+            provider="toss",
+            client_code="TESTCLIENT01",
+            receiver_hp_encrypted="ENCRYPTED_HP_PLACEHOLDER",
+            receiver_name_encrypted="ENCRYPTED_NAME_PLACEHOLDER",
+            receiver_birthday_encrypted="ENCRYPTED_BIRTHDAY_PLACEHOLDER",
+            token="",
+        )
+
+
+def test_redaction_removes_identity_fields_recursively() -> None:
+    redacted = redact_barocert_payload(
+        {
+            "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+            "ci": "SYNTHETIC_CI_PLACEHOLDER",
+            "di": "SYNTHETIC_DI_PLACEHOLDER",
+            "signedData": "SYNTHETIC_SIGNED_DATA_PLACEHOLDER",
+            "receiverHP": "ENCRYPTED_HP_PLACEHOLDER",
+            "nested": [{"receiverName": "ENCRYPTED_NAME_PLACEHOLDER", "safe": "keep"}],
+        }
+    )
+
+    assert redacted["receiptID"] == "TOSS_RECEIPT_SANITIZED_001"
+    assert redacted["ci"] == "<redacted>"
+    assert redacted["di"] == "<redacted>"
+    assert redacted["signedData"] == "<redacted>"
+    assert redacted["receiverHP"] == "<redacted>"
+    assert redacted["nested"] == [{"receiverName": "<redacted>", "safe": "keep"}]
+
+
+def test_toss_receipt_status_and_verify_fixture_parsing() -> None:
+    receipt = parse_identity_receipt("toss", _fixture("toss_request_receipt.json"))
+    assert receipt.provider == BarocertProvider.toss
+    assert receipt.receipt_id == "TOSS_RECEIPT_SANITIZED_001"
+
+    status = parse_identity_status(
+        "toss",
+        receipt.receipt_id,
+        _fixture("toss_status_complete.json"),
+    )
+    assert status.state == "complete"
+    assert status.is_complete is True
+
+    verification = parse_identity_verification(
+        "toss",
+        receipt.receipt_id,
+        _fixture("toss_verify_complete.json"),
+    )
+    assert verification.identity_evidence_present is True
+    assert verification.signed_data_present is True
+    dumped = verification.model_dump()
+    assert "SYNTHETIC_CI_PLACEHOLDER" not in str(dumped)
+    assert "SYNTHETIC_DI_PLACEHOLDER" not in str(dumped)
+    assert "SYNTHETIC_SIGNED_DATA_PLACEHOLDER" not in str(dumped)
+
+
+@pytest.mark.parametrize("provider", ["toss", "kakao", "naver"])
+def test_provider_status_fixture_variants_parse(provider: str) -> None:
+    fixture_name = f"{provider}_status_complete.json"
+    receipt_id = f"{provider.upper()}_RECEIPT_SANITIZED_001"
+
+    status = parse_identity_status(provider, receipt_id, _fixture(fixture_name))
+
+    assert status.provider.value == provider
+    assert status.receipt_id == receipt_id
+    assert status.is_complete is True
+
+
+def test_negative_provider_states_fail_closed() -> None:
+    with pytest.raises(BarocertProviderError, match="missing_receipt_id"):
+        parse_identity_receipt("toss", {"scheme": "barocert-toss://identity/SANITIZED"})
+
+    with pytest.raises(BarocertProviderError, match="expired"):
+        parse_identity_status(
+            "toss",
+            "TOSS_RECEIPT_SANITIZED_001",
+            _fixture("toss_status_expired.json"),
+        )
+
+    with pytest.raises(BarocertProviderError, match="provider_mismatch"):
+        parse_identity_verification(
+            "toss",
+            "TOSS_RECEIPT_SANITIZED_001",
+            {"provider": "kakao", "receiptID": "TOSS_RECEIPT_SANITIZED_001", "state": 1},
+        )
+
+    with pytest.raises(BarocertProviderError, match="upstream_error"):
+        parse_identity_verification(
+            "toss",
+            "TOSS_RECEIPT_SANITIZED_001",
+            _fixture("toss_verify_repeated.json"),
+        )

--- a/tests/unit/tools/live/test_verify_barocert_identity.py
+++ b/tests/unit/tools/live/test_verify_barocert_identity.py
@@ -1,0 +1,111 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the live BaroCert verify adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from ummaya.primitives.verify import GanpyeonInjeungContext, VerifyMismatchError, verify
+
+FIXTURE_DIR = Path(__file__).resolve().parents[3] / "fixtures" / "barocert"
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text(encoding="utf-8"))
+
+
+@pytest.mark.asyncio
+async def test_explicit_live_tool_returns_redacted_ganpyeon_context() -> None:
+    import ummaya.tools.live.verify_barocert_identity  # noqa: F401
+
+    result = await verify(
+        "ganpyeon_injeung",
+        {
+            "_tool_id": "live_verify_ganpyeon_injeung",
+            "provider": "toss",
+            "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+            "_fixture_status": _fixture("toss_status_complete.json"),
+            "_fixture_verify": _fixture("toss_verify_complete.json"),
+        },
+    )
+
+    assert isinstance(result, GanpyeonInjeungContext)
+    assert result.family == "ganpyeon_injeung"
+    assert result.provider == "toss"
+    assert result.published_tier == "ganpyeon_injeung_toss_aal2"
+    assert result.nist_aal_hint == "AAL2"
+    assert result.external_session_ref == "barocert:toss:TOSS_RECEIPT_SANITIZED_001"
+    assert result.transparency_mode is None
+    assert "SYNTHETIC_CI_PLACEHOLDER" not in result.model_dump_json()
+    assert "SYNTHETIC_DI_PLACEHOLDER" not in result.model_dump_json()
+    assert "SYNTHETIC_SIGNED_DATA_PLACEHOLDER" not in result.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_non_live_ganpyeon_selection_still_uses_existing_mock() -> None:
+    import ummaya.tools.live.verify_barocert_identity  # noqa: F401
+
+    result = await verify("ganpyeon_injeung", {"_tool_id": "mock_verify_ganpyeon_injeung"})
+
+    assert isinstance(result, GanpyeonInjeungContext)
+    assert result.provider == "kakao"
+    assert result.external_session_ref == "mock-ganpyeon-ref-001"
+    assert result.transparency_mode == "mock"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("session_context", "expected_fragment"),
+    [
+        ({"provider": "toss"}, "missing_receipt_id"),
+        (
+            {
+                "provider": "toss",
+                "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+                "_fixture_status": _fixture("toss_status_expired.json"),
+                "_fixture_verify": _fixture("toss_verify_complete.json"),
+            },
+            "expired",
+        ),
+        (
+            {
+                "provider": "toss",
+                "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+                "_fixture_status": _fixture("toss_status_complete.json"),
+                "_fixture_verify": _fixture("toss_verify_repeated.json"),
+            },
+            "upstream_error",
+        ),
+        (
+            {
+                "provider": "toss",
+                "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+                "_fixture_status": _fixture("toss_status_complete.json"),
+                "_fixture_verify": {
+                    "provider": "naver",
+                    "receiptID": "TOSS_RECEIPT_SANITIZED_001",
+                    "state": 1,
+                },
+            },
+            "provider_mismatch",
+        ),
+    ],
+)
+async def test_live_adapter_negative_paths_fail_closed(
+    session_context: dict[str, object],
+    expected_fragment: str,
+) -> None:
+    import ummaya.tools.live.verify_barocert_identity  # noqa: F401
+
+    result = await verify(
+        "ganpyeon_injeung",
+        {"_tool_id": "live_verify_ganpyeon_injeung", **session_context},
+    )
+
+    assert isinstance(result, VerifyMismatchError)
+    assert result.expected_family == "ganpyeon_injeung"
+    assert result.observed_family.startswith("barocert_identity:")
+    assert expected_fragment in result.message

--- a/tests/unit/tools/test_registry_count_breakdown.py
+++ b/tests/unit/tools/test_registry_count_breakdown.py
@@ -2,7 +2,7 @@
 """T035 — Registry count breakdown assertion (SC-003).
 
 Boots the registry and asserts the active count breakdown from spec.md SC-003:
-  - Main ToolRegistry: 68 entries
+  - Main ToolRegistry: 69 entries
   - ummaya.primitives.verify._VERIFY_ADAPTERS: 10 families
   - ummaya.primitives.submit._ADAPTER_REGISTRY: 5 families
 
@@ -16,7 +16,7 @@ do NOT silently adjust the expected values.
 from __future__ import annotations
 
 # ---------------------------------------------------------------------------
-# Main ToolRegistry count — 68 total
+# Main ToolRegistry count — 69 total
 # ---------------------------------------------------------------------------
 # Epic η #2298 — extended from 16 to 18 by adding `check` / `send`
 # to mvp_surface as `is_core=True` GovAPITool entries (FR-021).
@@ -42,10 +42,11 @@ from __future__ import annotations
 # verified public-data adapters under src/ummaya/tools/verified_data_go_kr/.
 # Spec #2798 — extended from 52 to 68 by registering sixteen additional
 # approved live public-data adapters from the 2026-05-16 direct evidence batch.
-_EXPECTED_MAIN_REGISTRY_COUNT = 68
+# Spec live-barocert-identity-check adds one live check adapter.
+_EXPECTED_MAIN_REGISTRY_COUNT = 69
 
 _EXPECTED_MAIN_REGISTRY_BREAKDOWN = {
-    "live_adapters": 42,  # 12 existing Live + 30 verified public-data adapters
+    "live_adapters": 43,  # 12 existing Live + 30 public-data + 1 live check adapter
     "mvp_surface": 4,  # find + locate + check + send (main-verb surface)
     "locate_adapters": 5,  # kakao/juso/provider-specific locate adapters
     "lookup_mocks": 2,  # mock_lookup_module_hometax_simplified + mock_lookup_module_gov24_certificate  # noqa: E501
@@ -95,6 +96,7 @@ _EXPECTED_LIVE_TOOL_IDS = frozenset(
         "ccourt_publication_documents",
         "moj_stay_person_counter",
         "msit_business_announcement_lookup",
+        "live_verify_ganpyeon_injeung",
     }
 )
 
@@ -109,7 +111,7 @@ _EXPECTED_LOOKUP_MOCK_IDS = frozenset(
 
 
 def test_main_registry_total_count() -> None:
-    """Main ToolRegistry must have exactly 68 entries after register_all_tools()."""
+    """Main ToolRegistry must have exactly 69 entries after register_all_tools()."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.tools.executor import ToolExecutor
     from ummaya.tools.register_all import register_all_tools
@@ -128,7 +130,7 @@ def test_main_registry_total_count() -> None:
 
 
 def test_main_registry_live_tool_ids_present() -> None:
-    """All 42 expected Live tool IDs must be registered in the main ToolRegistry."""
+    """All 43 expected Live tool IDs must be registered in the main ToolRegistry."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.tools.executor import ToolExecutor
     from ummaya.tools.register_all import register_all_tools
@@ -344,8 +346,9 @@ def test_all_active_surface_counts_match_canonical() -> None:
         # primary LLM tool list stays at active primitives + find-class Live.
         # Locate-provider adapters add five first-class registry entries.
         # Spec #2798 adds sixteen approved live data.go.kr adapters, bringing
-        # the main ToolRegistry from 52 to 68.
-        "main_registry": 68,
+        # the main ToolRegistry from 52 to 68. The BaroCert live check adapter
+        # brings the main ToolRegistry from 68 to 69.
+        "main_registry": 69,
         "verify_families": 10,
         "submit_adapters": 5,
     }


### PR DESCRIPTION
## Summary
- add Spec Kit artifacts for live BaroCert Toss/Kakao/Naver identity check scope
- add fixture-first BaroCert client parsing, redaction, and explicit `live_verify_ganpyeon_injeung` check adapter
- register live check discovery/canonical mapping while preserving `mock_verify_ganpyeon_injeung` behavior

## Verification
- `uv run pytest tests/unit/tools/live tests/integration/test_live_barocert_discovery.py tests/integration/test_tool_id_to_family_hint_translation.py tests/unit/tools/test_registry_count_breakdown.py tests/tools/test_registration.py tests/agents/test_zero_live_api.py -q`
- `uv run pytest -m "not live"`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run --all-extras --dev mypy src`
- `uv run pytest tests/live/test_live_barocert_identity.py -m live -q` (skips without credentials)

Closes #2887