### PR TITLE
feat: add live KB identity check

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,1 @@
-{"feature_directory": "specs/2798-data-go-kr-live-expansion"}
+{"feature_directory": "specs/live-kbcert-identity-check"}

--- a/docs-site/public/_llm/generated/adapters.json
+++ b/docs-site/public/_llm/generated/adapters.json
@@ -234,6 +234,14 @@
     "tool_id": "ksd_financial_term_lookup"
   },
   {
+    "docs_path": "docs/api/verify/live-kb-identity.md",
+    "permission_tier": 2,
+    "primitive": "check",
+    "schema_path": null,
+    "tier": "live",
+    "tool_id": "live_verify_kb_identity"
+  },
+  {
     "docs_path": "docs/api/locate/index.md",
     "permission_tier": 1,
     "primitive": "locate",

--- a/docs-site/src/data/generated/adapters.json
+++ b/docs-site/src/data/generated/adapters.json
@@ -234,6 +234,14 @@
     "tool_id": "ksd_financial_term_lookup"
   },
   {
+    "docs_path": "docs/api/verify/live-kb-identity.md",
+    "permission_tier": 2,
+    "primitive": "check",
+    "schema_path": null,
+    "tier": "live",
+    "tool_id": "live_verify_kb_identity"
+  },
+  {
     "docs_path": "docs/api/locate/index.md",
     "permission_tier": 1,
     "primitive": "locate",

--- a/docs/api/verify/live-kb-identity.md
+++ b/docs/api/verify/live-kb-identity.md
@@ -1,0 +1,165 @@
+---
+tool_id: live_verify_kb_identity
+primitive: check
+tier: live
+permission_tier: 2
+---
+
+# live_verify_kb_identity
+
+## Overview
+
+Wraps KB국민인증서 identity verification as an opt-in live `check` adapter. The
+adapter starts a KB certificate identity transaction or polls a transaction
+result, then returns only a `KbIdentityContext` with an opaque
+`external_session_ref`.
+
+| Field | Value |
+|---|---|
+| Classification | Live · Permission tier 2 |
+| Source | KB국민인증서 identity API docs |
+| Primitive | `check` |
+| Family | `kb_identity` |
+| Module | `src/ummaya/tools/live/verify_kb_identity.py` |
+
+Official KB source pages:
+
+- Identity flow: <https://cert.kbstar.com/quics?page=C112279>
+- Common OpenAPI guidance: <https://cert.kbstar.com/quics?page=C112276>
+- Test procedure guidance: <https://cert.kbstar.com/quics?page=C112283>
+
+## Runtime Configuration
+
+The adapter is inert unless all required credentials are configured:
+
+| Env var | Required | Description |
+|---|---:|---|
+| `UMMAYA_KBCERT_BASE_URL` | yes | KB OpenAPI base URL. Staging is `https://stg-openapi.kbstar.com:8443/`; production is `https://openapi.kbstar.com:8443/`. |
+| `UMMAYA_KBCERT_API_KEY` | yes | KB `apiKey` request header value. |
+| `UMMAYA_KBCERT_HS_KEY` | yes | KB `hsKey` request header value. |
+| `UMMAYA_KBCERT_COMPANY_CD` | yes | KB `dataBody.companyCd`. |
+| `UMMAYA_KBCERT_REQUEST_TYPE` | no | KB `dataBody.requestType`; defaults to `NONE` until a partner profile defines a stricter value. |
+
+Default CI must not set these values and must not run live-marked tests.
+
+## KB Contract
+
+Base URLs:
+
+- Staging: `https://stg-openapi.kbstar.com:8443/`
+- Production: `https://openapi.kbstar.com:8443/`
+
+Endpoints:
+
+| Flow | Method | Path |
+|---|---|---|
+| Start request | `POST` | `/kbsign/api/sign_request2` |
+| Result lookup | `POST` | `/kbsign/api/sign_result` |
+
+Headers:
+
+```http
+apiKey: <UMMAYA_KBCERT_API_KEY>
+hsKey: <UMMAYA_KBCERT_HS_KEY>
+Content-Type: application/json; charset=UTF-8
+```
+
+Request body shape:
+
+```json
+{
+  "dataHeader": {},
+  "dataBody": {
+    "companyCd": "TEST0000",
+    "reqTxId": "synthetic-req-tx-id",
+    "requestType": "NONE"
+  }
+}
+```
+
+Result lookup adds `certTxId`:
+
+```json
+{
+  "dataHeader": {},
+  "dataBody": {
+    "companyCd": "TEST0000",
+    "reqTxId": "synthetic-req-tx-id",
+    "certTxId": "synthetic-cert-tx-id",
+    "requestType": "NONE"
+  }
+}
+```
+
+## Input Envelope
+
+Call only through the `check` primitive:
+
+```json
+{
+  "tool_id": "live_verify_kb_identity",
+  "params": {
+    "mode": "request",
+    "reqTxId": "synthetic-req-tx-id"
+  }
+}
+```
+
+Supported params:
+
+| Field | Type | Required | Description |
+|---|---|---:|---|
+| `mode` | `"auto" \| "request" \| "result"` | no | `auto` starts a request unless `certTxId` is present. |
+| `reqTxId` | `str` | result: yes | External request transaction id. Generated when omitted in request mode. |
+| `certTxId` | `str` | result: yes | KB certificate transaction id returned by request mode. |
+| `requestType` | `str` | no | Overrides `UMMAYA_KBCERT_REQUEST_TYPE` for a single call. |
+
+## Output Envelope
+
+`KbIdentityContext` contains only sanitized metadata:
+
+```json
+{
+  "family": "kb_identity",
+  "provider": "kb",
+  "published_tier": "kb_identity_aal2",
+  "nist_aal_hint": "AAL2",
+  "verified_at": "2026-05-18T00:00:00+00:00",
+  "external_session_ref": "kbcert:reqTxId=synthetic-req-tx-id;certTxId=synthetic-cert-tx-id"
+}
+```
+
+The adapter never returns or logs raw identity fields such as name, birthdate,
+phone number, CI, DI, gender, nationality, or encrypted identity payloads.
+
+## Evidence Requirement
+
+Before claiming live readiness for a partner environment, record sanitized curl
+evidence outside CI:
+
+1. `sign_request2` request/response against the configured KB test endpoint.
+2. `sign_result` request/response for the same `reqTxId` and `certTxId`.
+3. Redaction check showing no raw CI, DI, name, birthdate, phone, gender,
+   nationality, API key, or `hsKey` appears in the saved evidence.
+
+Evidence files must contain only sanitized transaction metadata. Do not commit
+partner credentials or identity-bearing payloads.
+
+## Tests
+
+Default tests use synthetic fixtures only:
+
+```bash
+uv run pytest tests/unit/tools/live/test_kb_identity_client.py tests/unit/tools/live/test_verify_kb_identity.py -m "not live"
+uv run pytest tests/live/test_live_kb_identity.py -m "not live"
+```
+
+Credentialed smoke tests are opt-in:
+
+```bash
+UMMAYA_KBCERT_BASE_URL=https://stg-openapi.kbstar.com:8443/ \
+UMMAYA_KBCERT_API_KEY=... \
+UMMAYA_KBCERT_HS_KEY=... \
+UMMAYA_KBCERT_COMPANY_CD=... \
+uv run pytest tests/live/test_live_kb_identity.py -m live
+```

--- a/specs/1636-plugin-dx-5tier/contracts/manifest.schema.json
+++ b/specs/1636-plugin-dx-5tier/contracts/manifest.schema.json
@@ -106,7 +106,8 @@
                 "modid_aal3",
                 "kec_aal3",
                 "geumyung_module_aal3",
-                "any_id_sso_aal2"
+                "any_id_sso_aal2",
+                "kb_identity_aal2"
               ],
               "type": "string"
             },

--- a/specs/live-kbcert-identity-check/checklists/requirements.md
+++ b/specs/live-kbcert-identity-check/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: Live KB Identity Check Adapter
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-05-18
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details beyond external contract constraints required by the adapter feature
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders where possible
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic except for repository acceptance commands explicitly required by the project workflow
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No unresolved implementation choices leak into specification
+
+## Notes
+
+- The spec includes official KB endpoint and credential field names because the feature is an external adapter and the user explicitly required source-contract citation.

--- a/specs/live-kbcert-identity-check/contracts/kb-identity-check.md
+++ b/specs/live-kbcert-identity-check/contracts/kb-identity-check.md
@@ -1,0 +1,82 @@
+# Contract: Live KB Identity Check Adapter
+
+## Tool Contract
+
+Tool id: `live_verify_kb_identity`
+
+Primitive: `check`
+
+Family hint: `kb_identity`
+
+Invocation shape:
+
+```json
+{
+  "tool_id": "live_verify_kb_identity",
+  "params": {
+    "mode": "request",
+    "reqTxId": "synthetic-req-tx-id",
+    "requestType": "NONE"
+  }
+}
+```
+
+Result lookup shape:
+
+```json
+{
+  "tool_id": "live_verify_kb_identity",
+  "params": {
+    "mode": "result",
+    "reqTxId": "synthetic-req-tx-id",
+    "certTxId": "synthetic-cert-tx-id",
+    "requestType": "NONE"
+  }
+}
+```
+
+## Environment Contract
+
+| Variable | Required for live | Purpose |
+|----------|-------------------|---------|
+| `UMMAYA_KBCERT_BASE_URL` | yes | KB staging or production base URL |
+| `UMMAYA_KBCERT_API_KEY` | yes | KB `apiKey` header |
+| `UMMAYA_KBCERT_HS_KEY` | yes | KB `hsKey` header |
+| `UMMAYA_KBCERT_COMPANY_CD` | yes | KB `companyCd` body field |
+| `UMMAYA_KBCERT_REQUEST_TYPE` | no | Defaults to `NONE` |
+
+## KB Wire Contract
+
+Request endpoint: `POST /kbsign/api/sign_request2`
+
+Result endpoint: `POST /kbsign/api/sign_result`
+
+Headers:
+
+```text
+apiKey: <UMMAYA_KBCERT_API_KEY>
+hsKey: <UMMAYA_KBCERT_HS_KEY>
+Content-Type: application/json; charset=UTF-8
+Accept: application/json
+```
+
+## Success Contract
+
+A KB response is successful only when all available success indicators agree:
+
+- `dataHeader.resultCode == "0000"`
+- `dataHeader.successCode == "0"`
+- `dataBody.result-code == "ok"`
+- required transaction ids are present
+- result lookup response `reqTxId` matches the requested `reqTxId`
+
+## Redaction Contract
+
+The adapter must recursively drop identity keys before building model outputs, log messages, error messages, or docs snippets:
+
+```text
+CI, DI, userNm, birthday, receiverHP, receiverName, receiverBirthday,
+gender, krnFrgnDstcd, phone, name, birthdate
+```
+
+Tests use sentinel values for these keys and assert they never appear in returned context dumps.

--- a/specs/live-kbcert-identity-check/data-model.md
+++ b/specs/live-kbcert-identity-check/data-model.md
@@ -1,0 +1,105 @@
+# Data Model: Live KB Identity Check Adapter
+
+## KbIdentityCheckInput
+
+Caller-facing `check` params accepted by `live_verify_kb_identity`.
+
+| Field | Type | Required | Validation |
+|-------|------|----------|------------|
+| `reqTxId` | string | no for request mode, yes for result mode | Non-empty synthetic/caller transaction id; generated when omitted in request mode |
+| `certTxId` | string | no for request mode, yes for result mode | Non-empty KB transaction id returned by request API |
+| `requestType` | string | no | Defaults to `NONE`; non-empty |
+| `mode` | string | no | `request`, `result`, or `auto`; defaults to `auto` |
+
+`companyCd`, `apiKey`, `hsKey`, and `base_url` come from environment configuration, not LLM params.
+
+## KbIdentityRequestBody
+
+KB request API body.
+
+```json
+{
+  "dataHeader": {},
+  "dataBody": {
+    "companyCd": "TEST0000",
+    "reqTxId": "synthetic-req-tx-id",
+    "requestType": "NONE"
+  }
+}
+```
+
+Validation:
+
+- `companyCd`, `reqTxId`, and `requestType` must be non-empty strings.
+- Headers must include `apiKey` and `hsKey`.
+
+## KbIdentityResultBody
+
+KB result lookup API body.
+
+```json
+{
+  "dataHeader": {},
+  "dataBody": {
+    "companyCd": "TEST0000",
+    "reqTxId": "synthetic-req-tx-id",
+    "certTxId": "synthetic-cert-tx-id",
+    "requestType": "NONE"
+  }
+}
+```
+
+Validation:
+
+- `certTxId` is required for result lookup.
+- `reqTxId` returned by KB must match the requested `reqTxId` when both are present.
+
+## KbIdentityReceipt
+
+Sanitized receipt metadata.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `req_tx_id` | string | Opaque institution transaction id |
+| `cert_tx_id` | string | Opaque KB transaction id |
+| `call_url` | string or null | Present after request API when KB returns it |
+| `result_code` | string | Normalized from KB `result-code` |
+| `client_message` | string or null | Sanitized user-facing KB status text |
+| `system_message` | string or null | Sanitized KB system status text |
+| `identity_evidence_present` | boolean | True when KB result body contained expected identity evidence keys; individual values are dropped |
+
+## KbIdentityContext
+
+AuthContext variant returned by the check primitive.
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `family` | literal `kb_identity` | Verify dispatcher discriminator |
+| `provider` | literal `kb` | Provider marker |
+| `published_tier` | literal `kb_identity_aal2` | UMMAYA registry tier label |
+| `nist_aal_hint` | literal `AAL2` | Advisory hint |
+| `verified_at` | datetime | UTC completion timestamp |
+| `external_session_ref` | string | Opaque `kbcert:` reference containing only `reqTxId` and `certTxId` |
+| `status` | literal `verified` | Inherited AuthContext success discriminator |
+
+Forbidden fields:
+
+- `CI`
+- `DI`
+- `userNm`
+- `birthday`
+- `receiverHP`
+- `receiverName`
+- `receiverBirthday`
+- `gender`
+- `krnFrgnDstcd`
+- raw KB result payload
+
+## State Transitions
+
+```text
+missing credentials -> sanitized VerifyMismatchError
+request mode -> request API -> KbIdentityContext with external_session_ref
+result mode -> result API -> status validation -> KbIdentityContext
+result mode -> failed/malformed response -> sanitized VerifyMismatchError
+```

--- a/specs/live-kbcert-identity-check/plan.md
+++ b/specs/live-kbcert-identity-check/plan.md
@@ -1,0 +1,150 @@
+# Implementation Plan: Live KB Identity Check Adapter
+
+**Branch**: `feat/live-kbcert-identity-check` | **Date**: 2026-05-18 | **Spec**: [spec.md](./spec.md)
+**Input**: Feature specification from `/specs/live-kbcert-identity-check/spec.md`
+**Epic**: #2888
+
+## Summary
+
+Add a KB국민인증서 live `check` adapter that wraps the KB identity request and result lookup flow. The adapter exposes `live_verify_kb_identity`, stores no raw identity attributes, and returns an AuthContext-compatible result whose only external reference is an opaque combination of `reqTxId` and `certTxId`. Default tests use sanitized fixtures only; credentialed KB calls are isolated behind `@pytest.mark.live`.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+
+**Primary Dependencies**: httpx, pydantic v2, pytest, pytest-asyncio
+**Storage**: N/A for adapter state; sanitized fixtures under `tests/fixtures/kbcert/`
+**Testing**: pytest, `@pytest.mark.live` for credentialed KB calls, default `-m "not live"` fixture replay
+**Target Platform**: macOS/Linux CLI and backend runtime
+**Project Type**: CLI/backend adapter in UMMAYA Tool System Layer 2
+**Performance Goals**: One request call and one result lookup per identity ceremony; no caching of identity results
+**Constraints**: No live KB calls in CI; all credentials via `UMMAYA_KBCERT_*`; no CI/DI/name/birthday/gender/nationality in outputs, logs, or snapshots; fail closed on upstream or schema errors
+**Scale/Scope**: One live check adapter, one KB-specific client module, focused unit/registry/live tests, one adapter doc
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Reference-Driven Development | PASS | KB official guide pages are the source for flow, request/result fields, headers, domains, and content type. `docs/vision.md` confirms active primitives are `find` / `locate` / `send` / `check`, and this feature binds only to `check`. |
+| II. Fail-Closed Security | PASS | Adapter drops identity attributes, rejects incomplete or failed KB responses, and uses no hardcoded credentials. |
+| III. Pydantic v2 Strict Typing | PASS | New input/output/client payloads are Pydantic v2 models; no `Any` in public I/O schemas. |
+| IV. Government API Compliance | PASS | Live tests are opt-in via `@pytest.mark.live`; fixtures are sanitized; credentials use `UMMAYA_` environment names. |
+| V. Policy Alignment | PASS | Identity verification supports consent-based public-service execution while keeping personal identifiers out of UMMAYA persistence. |
+| VI. Deferred Work Accountability | PASS | Spec declares zero deferred items and scopes out KB device/window automation as excluded from this adapter. |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/live-kbcert-identity-check/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── contracts/
+│   └── kb-identity-check.md
+├── checklists/
+│   └── requirements.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/ummaya/primitives/verify.py                  # additive kb_identity context
+src/ummaya/tools/registry.py                     # additive KB published tier literal
+src/ummaya/tools/models.py                       # additive GovAPITool tier literal if needed
+src/ummaya/tools/live/__init__.py                # import side-effect package
+src/ummaya/tools/live/kb_identity_client.py      # KB request/result HTTP client
+src/ummaya/tools/live/verify_kb_identity.py      # live check adapter registration/invoke
+src/ummaya/tools/discovery_bridge.py             # live check discovery metadata
+src/ummaya/tools/verify_canonical_map.py         # live tool id mapping compatibility
+src/ummaya/tools/mvp_surface.py                  # check primitive description update
+src/ummaya/tools/register_all.py                 # import live check package before bridging
+docs/api/verify/live-kb-identity.md              # adapter usage and evidence requirements
+tests/fixtures/kbcert/                           # sanitized KB request/result fixtures
+tests/unit/tools/live/test_kb_identity_client.py # client and redaction unit tests
+tests/unit/tools/live/test_verify_kb_identity.py # adapter and registry unit tests
+tests/live/test_live_kb_identity.py              # opt-in credentialed smoke tests
+```
+
+**Structure Decision**: KB receives its own `src/ummaya/tools/live/` client and adapter to avoid touching BaroCert or MobileID implementation files. `verify.py` changes are additive only: a new `kb_identity` family and typed context. Central discovery changes are limited to metadata needed for `live_verify_kb_identity` to be selectable through the existing `check(tool_id=..., params=...)` path.
+
+## Complexity Tracking
+
+> No constitution violations. No complexity tracking required.
+
+---
+
+## Phase 0: Research
+
+See [research.md](./research.md).
+
+### Key Decisions
+
+1. **New `kb_identity` family instead of overloading `ganpyeon_injeung`**: The KB flow has separate headers, endpoint names, transaction semantics, and result fields. Reusing BaroCert/Ganpyeon would either overwrite the mock family adapter or hide KB-specific failure modes.
+2. **Opaque external reference only**: `external_session_ref` uses `kbcert:reqTxId=<redacted-or-synthetic>;certTxId=<redacted-or-synthetic>` style metadata. Identity result fields are recognized only to record `identity_evidence_present=True` internally during parsing; they are not copied into AuthContext.
+3. **Direct local adapter only**: The live adapter gateway currently permits `find` and `locate` live adapters only. KB is a `check` identity ceremony and must not be proxyable through the existing public-data gateway path.
+4. **Environment contract**: `UMMAYA_KBCERT_BASE_URL`, `UMMAYA_KBCERT_API_KEY`, `UMMAYA_KBCERT_HS_KEY`, and `UMMAYA_KBCERT_COMPANY_CD` are required for live tests. Optional `UMMAYA_KBCERT_REQUEST_TYPE` defaults to `NONE`.
+5. **Credentialed evidence policy**: Documentation includes official curl templates and requires sanitized direct-curl evidence before live-readiness claims, but fixture replay remains the default acceptance path.
+
+### Deferred Items Validation
+
+The spec has no `NEEDS TRACKING` entries. Excluded items are scoped as permanent exclusions for this adapter and do not create deferred feature work.
+
+---
+
+## Phase 1: Design
+
+See [data-model.md](./data-model.md), [contracts/kb-identity-check.md](./contracts/kb-identity-check.md), and [quickstart.md](./quickstart.md).
+
+### Design Decisions
+
+#### D1: Client boundary
+
+`kb_identity_client.py` owns:
+
+- base URL normalization
+- `apiKey` / `hsKey` header construction
+- request body construction for `/kbsign/api/sign_request2`
+- result body construction for `/kbsign/api/sign_result`
+- response status normalization
+- fail-closed exceptions with sanitized messages
+
+It never logs or returns KB identity fields.
+
+#### D2: Adapter boundary
+
+`verify_kb_identity.py` owns:
+
+- session context parsing from `check(tool_id="live_verify_kb_identity", params={...})`
+- environment configuration
+- request-only and result-lookup modes
+- conversion to `KbIdentityContext`
+- registration via `register_verify_adapter("kb_identity", invoke)`
+
+#### D3: Redaction contract
+
+The sanitizer drops these keys recursively from response bodies before any error or receipt construction: `CI`, `DI`, `userNm`, `birthday`, `receiverHP`, `receiverName`, `receiverBirthday`, `gender`, `krnFrgnDstcd`, `phone`, `name`, `birthdate`, and lowercase variants. Tests use sentinel values and assert absence from returned model dumps and log records.
+
+#### D4: Failure contract
+
+The adapter returns `VerifyMismatchError` for check-layer failures instead of raising raw transport or parsing errors through the primitive dispatcher. The observed family is `kb_identity_error`, and messages are sanitized.
+
+#### D5: Registry/discovery contract
+
+`live_verify_kb_identity` is non-core, `primitive="check"`, `adapter_mode="live"`, `auth_type="api_key"`, `source_mode=OOS`, and `cache_ttl_seconds=0`. It is discoverable via Korean/English KB identity keywords but only invoked through the core `check` primitive.
+
+### Post-Design Constitution Re-Check
+
+| Principle | Status | Notes |
+|-----------|--------|-------|
+| I. Reference-Driven Development | PASS | Official KB docs and `docs/vision.md` are cited in research and docs. |
+| II. Fail-Closed Security | PASS | All parser/transport failures become sanitized check errors; identity fields are dropped recursively. |
+| III. Pydantic v2 Strict Typing | PASS | Public input/output and internal response models are Pydantic v2. |
+| IV. Government API Compliance | PASS | Live tests require env credentials and marker opt-in; fixture replay is default. |
+| V. Policy Alignment | PASS | The adapter supports identity verification without storing personal identifiers. |
+| VI. Deferred Work Accountability | PASS | Zero deferred items. |

--- a/specs/live-kbcert-identity-check/quickstart.md
+++ b/specs/live-kbcert-identity-check/quickstart.md
@@ -1,0 +1,41 @@
+# Quickstart: Live KB Identity Check Adapter
+
+## Default Fixture Tests
+
+Run the non-live KB test slice:
+
+```bash
+uv run pytest tests/unit/tools/live/test_kb_identity_client.py tests/unit/tools/live/test_verify_kb_identity.py -m "not live"
+```
+
+Run the broader non-live check/registry slice:
+
+```bash
+uv run pytest tests/unit/primitives/verify tests/unit/test_verify_canonical_map_parser.py tests/integration/test_discovery_bridge_path_b.py -m "not live"
+```
+
+## Live Smoke
+
+Live smoke requires KB partner credentials and allowlisted network access.
+
+```bash
+export UMMAYA_KBCERT_BASE_URL="https://stg-openapi.kbstar.com:8443/"
+export UMMAYA_KBCERT_API_KEY="<issued apiKey>"
+export UMMAYA_KBCERT_HS_KEY="<generated hsKey>"
+export UMMAYA_KBCERT_COMPANY_CD="<companyCd>"
+uv run pytest tests/live/test_live_kb_identity.py -m live -v
+```
+
+## Sanitized Curl Evidence Template
+
+Before claiming live readiness, record sanitized direct-curl evidence outside CI:
+
+```bash
+curl --request POST "$UMMAYA_KBCERT_BASE_URL/kbsign/api/sign_request2" \
+  --header "apiKey: <redacted>" \
+  --header "hsKey: <redacted>" \
+  --header "Content-Type: application/json; charset=UTF-8" \
+  --data '{"dataHeader":{},"dataBody":{"companyCd":"<redacted>","reqTxId":"synthetic-req-tx-id","requestType":"NONE"}}'
+```
+
+Redact `apiKey`, `hsKey`, `companyCd`, CI, DI, name, birthday, phone number, gender, nationality, and any encrypted identity values from saved evidence.

--- a/specs/live-kbcert-identity-check/research.md
+++ b/specs/live-kbcert-identity-check/research.md
@@ -1,0 +1,78 @@
+# Research: Live KB Identity Check Adapter
+
+## Official Source Findings
+
+### KB identity flow
+
+**Decision**: Implement the two API server-side flow documented by KB: identity request followed by identity result lookup.
+
+**Rationale**: KB describes a service flow where the institution server calls the identity request API, receives `certTxId` and `callUrl`, the user completes KB app/standard-window authentication, and the institution server calls the result API. The guide identifies request fields `companyCd`, `reqTxId`, and `requestType`, and result lookup fields `reqTxId`, `certTxId`, `companyCd`, and `requestType`.
+
+**Primary source**: `https://cert.kbstar.com/quics?page=C112279`
+
+**Alternatives considered**:
+
+- Browser/device automation of the standard window: rejected as outside adapter scope because KB owns the app/window ceremony.
+- BaroCert-style provider wrapper: rejected because KB has distinct endpoint/header semantics.
+
+### KB common API information
+
+**Decision**: Use `https://stg-openapi.kbstar.com:8443/` and `https://openapi.kbstar.com:8443/` as allowed base URLs, with `Content-Type: application/json; charset=UTF-8`.
+
+**Rationale**: KB common information lists HTTPS/TLS 1.2+, POST, JSON content type, and staging/production domains.
+
+**Primary source**: `https://cert.kbstar.com/quics?page=C112276`
+
+**Alternatives considered**:
+
+- Hardcoding staging only: rejected because production URL is official and must be configurable.
+- Letting arbitrary base URLs through silently: rejected; tests validate URL normalization, while live env can still point to KB-provided staging/production.
+
+### KB test procedure
+
+**Decision**: Live tests require KB partner credentials and must remain opt-in.
+
+**Rationale**: KB's test page states `apiKey` is issued after contract completion, `hsKey` is generated using `apiKey`, and firewall/test app setup happens after contract completion. Default CI cannot assume those credentials or network allowlisting.
+
+**Primary source**: `https://cert.kbstar.com/quics?page=C112283`
+
+**Alternatives considered**:
+
+- Running credentialed smoke in CI: rejected by project government API compliance and KB partner setup requirements.
+
+## UMMAYA Integration Findings
+
+### Verify family shape
+
+**Decision**: Add `kb_identity` as a new verify family and `KbIdentityContext` as a new AuthContext variant.
+
+**Rationale**: The primitive dispatcher keys adapters by family, not by tool id. Registering KB under `ganpyeon_injeung` would overwrite the existing mock adapter and violate the cross-worktree boundary. A new family is additive and keeps BaroCert/MobileID untouched.
+
+**Alternatives considered**:
+
+- Return `GanpyeonInjeungContext(provider="bank")`: rejected because dispatch still needs a unique family to avoid replacing existing adapter registration.
+- Return a plain dict: rejected because the verify dispatcher accepts only typed AuthContext variants or `VerifyMismatchError`.
+
+### Discovery shape
+
+**Decision**: Add `live_verify_kb_identity` to `discovery_bridge._VERIFY_FAMILIES` and `verify_canonical_map` derivation through metadata.
+
+**Rationale**: The core `check` surface translates citizen-shape `tool_id` to a verify family through the canonical map. Discovery metadata is already the source of truth for check tool ids.
+
+**Alternatives considered**:
+
+- Direct `family_hint="kb_identity"` only: rejected because current LLM-facing and IPC paths prefer `tool_id`.
+
+### Gateway eligibility
+
+**Decision**: Keep KB check direct-only and non-proxyable.
+
+**Rationale**: `live_proxy.py` only treats `find` and `locate` live adapters as gateway-proxyable. KB is a citizen identity check and must not be routed through the public-data live gateway without a separate policy spec.
+
+**Alternatives considered**:
+
+- Extend the gateway for `check`: rejected as outside this feature and likely to need a separate security spec.
+
+## Deferred Items Validation
+
+Spec declares no deferred work. Excluded KB app/window automation, identity decryption/storage, and other provider changes are adapter scope exclusions rather than tracked follow-up work.

--- a/specs/live-kbcert-identity-check/spec.md
+++ b/specs/live-kbcert-identity-check/spec.md
@@ -1,0 +1,113 @@
+# Feature Specification: Live KB Identity Check Adapter
+
+**Feature Branch**: `feat/live-kbcert-identity-check`
+**Created**: 2026-05-18
+**Status**: Draft
+**Originating Epic**: #2888
+**Input**: User description: "KB국민인증서 본인확인 요청/결과조회 API를 감싼 live check adapter를 추가한다. The adapter returns only `certTxId`/`reqTxId` based external session references and never stores encrypted identity attributes."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Start KB Identity Check (Priority: P1)
+
+A citizen-facing flow can explicitly select KB국민인증서 identity verification and receive a KB transaction reference that can be handed to the KB standard window or app journey without exposing personal identity fields to UMMAYA.
+
+**Why this priority**: The request step is the minimum useful integration point. It creates the external KB transaction and returns the opaque reference needed for later result polling.
+
+**Independent Test**: Can be fully tested by replaying sanitized KB request fixtures and by asserting the adapter returns only `reqTxId`, `certTxId`, and optional `callUrl` metadata.
+
+**Acceptance Scenarios**:
+
+1. **Given** KB credentials are configured and a caller provides a synthetic `reqTxId`, **When** the live KB check adapter starts the identity request, **Then** it returns a verified check context with an opaque `external_session_ref` containing only transaction identifiers.
+2. **Given** KB credentials are absent, **When** the default test suite runs, **Then** no KB network request is attempted and fixture tests still validate the adapter contract.
+
+---
+
+### User Story 2 - Poll KB Identity Result Safely (Priority: P2)
+
+After the user completes KB국민인증서 in the KB app or standard window, UMMAYA can poll the KB result endpoint and convert successful completion into a check context while dropping CI, DI, name, birthday, gender, nationality, and encrypted identity values.
+
+**Why this priority**: A check adapter is only useful if completion can be recognized, but UMMAYA must not become a repository for identity attributes.
+
+**Independent Test**: Can be fully tested with sanitized request/result JSON fixtures, including fixtures that contain sentinel identity fields and prove they are redacted from outputs and logs.
+
+**Acceptance Scenarios**:
+
+1. **Given** a successful sanitized KB result fixture with `result-code=ok`, **When** the adapter parses the response, **Then** the returned context records only provider, verification timestamp, and opaque external transaction reference.
+2. **Given** a failed status, missing `certTxId`, or mismatched `reqTxId`, **When** the adapter parses the response, **Then** it returns a fail-closed check error and does not expose any identity payload fields.
+
+---
+
+### User Story 3 - Discover KB Check as an Explicit Tool (Priority: P3)
+
+The tool registry exposes KB국민인증서 as a `check`-only live adapter that can be selected explicitly by tool id without altering BaroCert, MobileID, or existing mock verification behavior.
+
+**Why this priority**: Discovery must make the live adapter available while preserving the existing mock identity chain and avoiding cross-worktree merge conflicts.
+
+**Independent Test**: Can be verified by registry tests that import the live adapter, confirm `live_verify_kb_identity` is discoverable under `check`, and confirm existing mock tool ids keep their current mappings.
+
+**Acceptance Scenarios**:
+
+1. **Given** the registry is built, **When** tools are searched for KB국민인증서 identity verification, **Then** `live_verify_kb_identity` appears as a non-core `check` candidate.
+2. **Given** existing BaroCert, MobileID, and mock verify tests run, **When** this feature is present, **Then** their observed behavior remains unchanged.
+
+### Edge Cases
+
+- Missing KB headers or credential environment variables must fail before a network request.
+- Missing `certTxId`, missing `reqTxId`, failed KB status, non-object JSON, upstream non-2xx, timeout, and `reqTxId` mismatch must produce fail-closed check errors.
+- CI, DI, name, birthday, phone number, gender, nationality, and encrypted identity result values must not appear in returned contexts, logs, fixture snapshots, or documentation examples.
+- Default `uv run pytest` and CI runs must not call KB live endpoints.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: The system MUST provide a live KB국민인증서 identity check adapter with tool id `live_verify_kb_identity`.
+- **FR-002**: The adapter MUST bind only to the `check` primitive and MUST NOT alter existing `find`, `locate`, or `send` adapters.
+- **FR-003**: The adapter MUST support the KB identity request flow using `companyCd`, caller-generated `reqTxId`, and `requestType`, with KB `apiKey` and `hsKey` headers supplied from `UMMAYA_` environment variables.
+- **FR-004**: The adapter MUST support the KB identity result lookup flow using `companyCd`, `reqTxId`, `certTxId`, and `requestType`.
+- **FR-005**: The adapter MUST return an `AuthContext`-compatible result that includes `provider="kb"`, `verified_at`, `published_tier`, `nist_aal_hint`, and an opaque `external_session_ref` derived from `reqTxId` and `certTxId`.
+- **FR-006**: The adapter MUST NOT return or persist CI, DI, user name, birthday, phone number, gender, nationality, or encrypted identity result fields.
+- **FR-007**: The adapter MUST validate KB response status using `dataHeader.resultCode`, `dataHeader.successCode`, and `dataBody.result-code` before reporting success.
+- **FR-008**: The adapter MUST fail closed for missing identifiers, failed KB status, mismatched transaction identifiers, malformed payloads, upstream non-2xx responses, and network timeouts.
+- **FR-009**: Tests that call real KB endpoints MUST be marked `@pytest.mark.live`, skipped without required `UMMAYA_KBCERT_*` credentials, and excluded from default CI behavior.
+- **FR-010**: Fixture and unit tests MUST use synthetic or sanitized payloads only.
+- **FR-011**: The adapter documentation MUST cite the official KB pages for the identity flow, common API domain/content-type information, and test procedure, and MUST state that sanitized curl evidence is required before live-readiness claims.
+- **FR-012**: BaroCert, MobileID, and existing mock verification adapters MUST remain behaviorally unchanged.
+
+### Key Entities *(include if feature involves data)*
+
+- **KbIdentityRequest**: Caller-side request fields required to open a KB identity transaction: `companyCd`, `reqTxId`, `requestType`.
+- **KbIdentityRequestReceipt**: Sanitized KB request response metadata: `reqTxId`, `certTxId`, optional `callUrl`, and normalized status.
+- **KbIdentityResultReceipt**: Sanitized KB result lookup metadata: `reqTxId`, `certTxId`, normalized status, and a boolean indicator that KB returned expected identity evidence.
+- **KbIdentityContext**: AuthContext-compatible output for UMMAYA that keeps only provider and opaque transaction reference metadata.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: `uv run pytest tests/...kb... -m "not live"` passes without KB credentials and without attempting a KB network request.
+- **SC-002**: Registry tests confirm `live_verify_kb_identity` is discoverable as `primitive="check"` and no existing mock verify tool id mapping changes.
+- **SC-003**: Redaction tests prove sentinel CI, DI, user name, birthday, gender, and nationality fields from KB result fixtures are absent from adapter outputs.
+- **SC-004**: Negative tests cover missing `certTxId`, failed KB status, mismatched `reqTxId`, missing credential headers, upstream non-2xx, and timeout behavior.
+- **SC-005**: Live tests are skipped by default and execute only when all required `UMMAYA_KBCERT_*` variables are present.
+
+## Assumptions
+
+- The initial KB adapter returns an identity-check context only; it does not issue a downstream delegation token.
+- `GanpyeonInjeungContext` compatibility is acceptable if adding a new context variant would create cross-worktree conflicts; otherwise a narrow `KbIdentityContext` may be added additively.
+- `requestType="NONE"` is the default request type because KB documents it for the standard input window flow.
+- `reqTxId` generation may be caller-supplied or generated by the adapter, but tests use deterministic synthetic values.
+- Sanitized curl evidence is a documentation prerequisite for claiming live readiness, but credentialed live evidence is not required for default CI acceptance.
+
+## Scope Boundaries & Deferred Items *(mandatory)*
+
+### Out of Scope (Permanent)
+
+- KB standard window browser automation, app deep-link automation, and user-device interaction automation are excluded from this adapter; KB owns that ceremony.
+- Decryption, storage, display, or comparison of KB returned identity attributes is excluded; UMMAYA only records opaque transaction references and verification state.
+- BaroCert, MobileID, Government24 submit, and mock adapter behavior changes are excluded from this branch.
+
+### Deferred to Future Work
+
+No items deferred. All requirements for this Epic are addressed in this feature scope.

--- a/specs/live-kbcert-identity-check/tasks.md
+++ b/specs/live-kbcert-identity-check/tasks.md
@@ -1,0 +1,139 @@
+# Tasks: Live KB Identity Check Adapter
+
+**Input**: Design documents from `/Users/um-yunsang/.codex/worktrees/3340/UMMAYA/specs/live-kbcert-identity-check/`
+**Prerequisites**: [plan.md](./plan.md), [spec.md](./spec.md), [research.md](./research.md), [data-model.md](./data-model.md), [contracts/](./contracts/), [quickstart.md](./quickstart.md)
+**Epic**: #2888
+
+**Tests**: Required. Follow TDD: write failing tests before production implementation.
+
+**Organization**: Tasks are grouped by user story and preserve RED/GREEN ordering.
+
+## Phase 1: Setup
+
+**Purpose**: Add fixture/test scaffolding without production behavior.
+
+- [X] T001 [P] Create sanitized KB fixture payloads in `tests/fixtures/kbcert/request_success.json`, `tests/fixtures/kbcert/result_success.json`, `tests/fixtures/kbcert/result_failed.json`, and `tests/fixtures/kbcert/result_mismatch.json`
+- [X] T002 [P] Create failing client tests for header/body construction, response parsing, failure mapping, and recursive redaction in `tests/unit/tools/live/test_kb_identity_client.py`
+- [X] T003 [P] Create failing adapter and registry tests for `live_verify_kb_identity`, `kb_identity` family dispatch, and mock adapter non-regression in `tests/unit/tools/live/test_verify_kb_identity.py`
+- [X] T004 [P] Create skipped-by-default live smoke tests requiring `UMMAYA_KBCERT_*` credentials in `tests/live/test_live_kb_identity.py`
+
+---
+
+## Phase 2: Foundational
+
+**Purpose**: Add the typed check family needed before the live adapter can return a valid AuthContext.
+
+- [X] T005 Add `kb_identity_aal2` tier support to `src/ummaya/tools/registry.py` and `src/ummaya/tools/models.py`
+- [X] T006 Add `KbIdentityContext` and `kb_identity` family support to `src/ummaya/primitives/verify.py`
+
+**Checkpoint**: T002/T003 should still fail because client and adapter implementation do not exist yet, but type imports for `KbIdentityContext` should resolve.
+
+---
+
+## Phase 3: User Story 1 - Start KB Identity Check (Priority: P1)
+
+**Goal**: Build the KB client request path and return opaque transaction references.
+
+**Independent Test**: `uv run pytest tests/unit/tools/live/test_kb_identity_client.py::test_request_body_and_headers_are_constructed_without_identity_fields tests/unit/tools/live/test_verify_kb_identity.py::test_request_mode_returns_kb_identity_context -m "not live"`
+
+### Tests for User Story 1
+
+- [X] T007 [US1] Run T002/T003 request-mode tests and confirm they fail for missing `ummaya.tools.live.kb_identity_client` and `live_verify_kb_identity` implementation
+
+### Implementation for User Story 1
+
+- [X] T008 [US1] Implement `src/ummaya/tools/live/kb_identity_client.py` request body/header construction and request-response parsing
+- [X] T009 [US1] Implement request mode in `src/ummaya/tools/live/verify_kb_identity.py` and package import in `src/ummaya/tools/live/__init__.py`
+- [X] T010 [US1] Run request-mode focused tests and debug until green
+
+---
+
+## Phase 4: User Story 2 - Poll KB Identity Result Safely (Priority: P2)
+
+**Goal**: Parse result lookup fixtures, recognize successful identity evidence, and drop all identity payload values.
+
+**Independent Test**: `uv run pytest tests/unit/tools/live/test_kb_identity_client.py tests/unit/tools/live/test_verify_kb_identity.py -m "not live"`
+
+### Tests for User Story 2
+
+- [X] T011 [US2] Run T002/T003 result-mode, redaction, failed-status, missing-identifier, and mismatched-transaction tests and confirm they fail before implementation
+
+### Implementation for User Story 2
+
+- [X] T012 [US2] Extend `src/ummaya/tools/live/kb_identity_client.py` with result lookup parsing, status validation, mismatch detection, non-2xx handling, timeout handling, and recursive redaction
+- [X] T013 [US2] Extend `src/ummaya/tools/live/verify_kb_identity.py` result mode and sanitized `VerifyMismatchError` conversion
+- [X] T014 [US2] Run result/redaction focused tests and debug until green
+
+---
+
+## Phase 5: User Story 3 - Discover KB Check as an Explicit Tool (Priority: P3)
+
+**Goal**: Make `live_verify_kb_identity` discoverable as a non-core `check` adapter without changing BaroCert, MobileID, or mock behavior.
+
+**Independent Test**: `uv run pytest tests/unit/tools/live/test_verify_kb_identity.py tests/unit/test_verify_canonical_map_parser.py tests/integration/test_discovery_bridge_path_b.py -m "not live"`
+
+### Tests for User Story 3
+
+- [X] T015 [US3] Run registry/canonical-map tests and confirm they fail before discovery registration updates
+
+### Implementation for User Story 3
+
+- [X] T016 [US3] Register live check discovery metadata in `src/ummaya/tools/discovery_bridge.py`, `src/ummaya/tools/verify_canonical_map.py`, `src/ummaya/tools/mvp_surface.py`, and `src/ummaya/tools/register_all.py`
+- [X] T017 [US3] Update registry count and canonical-map tests for the additive live KB adapter in `tests/integration/test_discovery_bridge_path_b.py`, `tests/ipc/test_stdio_verify_dispatch.py`, and `tests/unit/test_verify_canonical_map_parser.py`
+- [X] T018 [US3] Run discovery/registry focused tests and debug until green
+
+---
+
+## Phase 6: Documentation and Live Evidence Guardrails
+
+**Purpose**: Document official KB contract and keep credentialed evidence out of default CI.
+
+- [X] T019 [P] Add adapter documentation in `docs/api/verify/live-kb-identity.md` citing official KB source pages and sanitized curl evidence requirements
+- [X] T020 [P] Ensure `tests/live/test_live_kb_identity.py` uses `@pytest.mark.live` and skips unless all required `UMMAYA_KBCERT_*` variables are present
+
+---
+
+## Phase 7: Polish & Validation
+
+**Purpose**: Verify default no-live behavior and task completion.
+
+- [X] T021 Run `uv run pytest tests/unit/tools/live/test_kb_identity_client.py tests/unit/tools/live/test_verify_kb_identity.py -m "not live"` and fix failures
+- [X] T022 Run `uv run pytest tests/unit/test_verify_canonical_map_parser.py tests/integration/test_discovery_bridge_path_b.py tests/ipc/test_stdio_verify_dispatch.py -m "not live"` and fix failures
+- [X] T023 Run `uv run pytest tests/live/test_live_kb_identity.py -m "not live"` and confirm live tests do not call KB by default
+- [X] T024 Run `uv run ruff check src/ummaya/primitives/verify.py src/ummaya/tools/live tests/unit/tools/live tests/live/test_live_kb_identity.py` and fix issues
+- [X] T025 Run `uv run ruff format --check src/ummaya/primitives/verify.py src/ummaya/tools/live tests/unit/tools/live tests/live/test_live_kb_identity.py` and fix issues
+- [X] T026 Run `uv run mypy src/ummaya/primitives/verify.py src/ummaya/tools/live` and fix type issues
+- [X] T027 Run `uv run pytest -m "not live"` if focused suites are clean and fix feature-related failures
+- [X] T028 Update `specs/live-kbcert-identity-check/tasks.md` checkboxes as tasks complete
+
+## Dependencies & Execution Order
+
+- Phase 1 has no dependencies.
+- Phase 2 depends on Phase 1 tests existing.
+- US1 depends on Phase 2.
+- US2 depends on US1 client/adapter structure.
+- US3 depends on US1 and US2 because discovery should point to a working adapter.
+- Phase 6 can run after US1/US2 data shapes are stable.
+- Phase 7 depends on all user stories.
+
+## Parallel Opportunities
+
+- T001-T004 are file-disjoint and parallel-safe.
+- T019-T020 are file-disjoint after implementation stabilizes.
+- Implementation tasks touching shared registry or verify files must run sequentially in this branch.
+
+## Implementation Strategy
+
+1. Write fixtures and failing tests.
+2. Add the typed `kb_identity` AuthContext.
+3. Implement the KB client and adapter request mode.
+4. Extend result parsing and redaction.
+5. Wire discovery/canonical-map registration.
+6. Add docs and live smoke guardrails.
+7. Run focused suites, then broader non-live tests.
+
+## Notes
+
+- Total tasks: 28, below the 90-task budget.
+- This branch intentionally avoids BaroCert, MobileID, and Government24 submit implementation files.
+- Default tests must not call KB live endpoints.

--- a/src/ummaya/primitives/verify.py
+++ b/src/ummaya/primitives/verify.py
@@ -39,6 +39,7 @@ FamilyHint = Literal[
     "digital_onepass",
     "mobile_id",
     "mydata",
+    "kb_identity",
 ]
 
 
@@ -107,6 +108,7 @@ _MODID_TIERS: frozenset[str] = frozenset({"modid_aal3"})
 _KEC_TIERS: frozenset[str] = frozenset({"kec_aal3"})
 _GEUMYUNG_MODULE_TIERS: frozenset[str] = frozenset({"geumyung_module_aal3"})
 _ANY_ID_SSO_TIERS: frozenset[str] = frozenset({"any_id_sso_aal2"})
+_KB_IDENTITY_TIERS: frozenset[str] = frozenset({"kb_identity_aal2"})
 
 
 class _AuthContextBase(BaseModel):
@@ -363,6 +365,26 @@ class AnyIdSsoContext(_AuthContextBase):
         return self
 
 
+class KbIdentityContext(_AuthContextBase):
+    """KB국민인증서 identity-check context.
+
+    The provider returns personal identity fields, but this context keeps only
+    opaque KB transaction references in ``external_session_ref``.
+    """
+
+    family: Literal["kb_identity"] = "kb_identity"
+    provider: Literal["kb"] = "kb"
+
+    @model_validator(mode="after")
+    def _check_published_tier(self) -> KbIdentityContext:
+        if self.published_tier not in _KB_IDENTITY_TIERS:
+            raise ValueError(
+                f"KbIdentityContext.published_tier must be one of "
+                f"{sorted(_KB_IDENTITY_TIERS)}, got {self.published_tier!r}"
+            )
+        return self
+
+
 # ---------------------------------------------------------------------------
 # AuthContext discriminated union + VerifyMismatchError + VerifyOutput
 # ---------------------------------------------------------------------------
@@ -379,7 +401,8 @@ AuthContext = Annotated[
     | ModidContext
     | KECContext
     | GeumyungModuleContext
-    | AnyIdSsoContext,
+    | AnyIdSsoContext
+    | KbIdentityContext,
     Field(discriminator="family"),
 ]
 
@@ -421,6 +444,7 @@ class VerifyOutput(BaseModel):
         | DigitalOnepassContext
         | MobileIdContext
         | MyDataContext
+        | KbIdentityContext
         | VerifyMismatchError,
         Field(discriminator="family"),
     ]
@@ -516,6 +540,7 @@ async def verify(
                 KECContext,
                 GeumyungModuleContext,
                 AnyIdSsoContext,
+                KbIdentityContext,
             ),
         ):
             span.set_attribute("error.type", "unexpected_adapter_return_type")
@@ -563,6 +588,7 @@ __all__ = [
     "GanpyeonInjeungContext",
     "GeumyungInjeungseoContext",
     "GongdongInjeungseoContext",
+    "KbIdentityContext",
     "MobileIdContext",
     "MyDataContext",
     "VerifyInput",

--- a/src/ummaya/tools/discovery_bridge.py
+++ b/src/ummaya/tools/discovery_bridge.py
@@ -30,7 +30,7 @@ from __future__ import annotations
 import importlib
 import logging
 from datetime import UTC, datetime
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Literal, cast
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
@@ -330,6 +330,8 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
     """Build a GovAPITool wrapper for one check-family adapter."""
     scope_rules = str(entry.get("scope_rules", "")).strip()
     scope_clause = f"{scope_rules}\n\n" if scope_rules else ""
+    auth_type = cast(Literal["public", "api_key", "oauth"], entry.get("auth_type", "api_key"))
+    adapter_mode = cast(Literal["live", "mock"], entry.get("adapter_mode", "mock"))
     result_description = str(
         entry.get(
             "llm_result_description",
@@ -343,7 +345,7 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
         ministry="UMMAYA",
         category=list(entry.get("category", ["check", "mock", "delegation"])),
         endpoint=entry["endpoint"],
-        auth_type=str(entry.get("auth_type", "api_key")),
+        auth_type=auth_type,
         input_schema=_VerifyParamsShell,
         output_schema=_OpaqueOutput,
         llm_description=(
@@ -375,7 +377,7 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
         rate_limit_per_minute=int(entry.get("rate_limit_per_minute", 30)),
         is_core=False,  # Discoverable via lookup search; NOT in primary LLM tool list
         primitive="check",
-        adapter_mode=str(entry.get("adapter_mode", "mock")),
+        adapter_mode=adapter_mode,
     )
 
 

--- a/src/ummaya/tools/discovery_bridge.py
+++ b/src/ummaya/tools/discovery_bridge.py
@@ -78,7 +78,7 @@ class _OpaqueOutput(RootModel[dict[str, Any]]):
 
 
 # ---------------------------------------------------------------------------
-# Verify family metadata table (hand-rolled — verify mocks register by family
+# Verify family metadata table (hand-rolled — verify adapters register by family
 # name into ummaya.primitives.verify._ADAPTER_REGISTRY without an
 # AdapterRegistration object, so we capture metadata declaratively here).
 #
@@ -279,6 +279,43 @@ _VERIFY_FAMILIES: list[dict[str, Any]] = [
             "or find:mydata.public.consent; never invent find:mydata.public.consent."
         ),
     },
+    {
+        "tool_id": "live_verify_kb_identity",
+        "family": "kb_identity",
+        "name_ko": "KB국민인증서 본인확인",
+        "search_hint_ko": [
+            "KB국민인증서",
+            "국민인증서",
+            "KB 인증서",
+            "KB스타뱅킹",
+            "본인확인",
+            "신원검증",
+        ],
+        "search_hint_en": [
+            "KB certificate",
+            "Kookmin certificate",
+            "KB identity",
+            "KB Star Banking",
+            "identity verification",
+        ],
+        "endpoint": "https://stg-openapi.kbstar.com:8443/kbsign/api",
+        "policy_authority": "https://cert.kbstar.com/quics?page=C112279",
+        "category": ["check", "live", "identity"],
+        "adapter_mode": "live",
+        "rate_limit_per_minute": 10,
+        "scope_rules": (
+            "Scope rule: KB identity verification uses exactly scope_list "
+            "['check:kb_identity.identity']. This live check returns only a sanitized "
+            "AuthContext external_session_ref based on reqTxId/certTxId; do not expect "
+            "a DelegationToken and do not persist CI, DI, name, birthdate, gender, "
+            "nationality, or encrypted identity payloads."
+        ),
+        "llm_result_description": (
+            "Returns a KbIdentityContext with provider='kb' and an opaque "
+            "external_session_ref. It never returns raw identity attributes."
+        ),
+        "last_verified": datetime(2026, 5, 18, tzinfo=UTC),
+    },
 ]
 
 
@@ -290,16 +327,23 @@ def _build_verify_search_hint(entry: dict[str, Any]) -> str:
 
 
 def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
-    """Build a GovAPITool wrapper for one verify family mock adapter."""
+    """Build a GovAPITool wrapper for one check-family adapter."""
     scope_rules = str(entry.get("scope_rules", "")).strip()
     scope_clause = f"{scope_rules}\n\n" if scope_rules else ""
+    result_description = str(
+        entry.get(
+            "llm_result_description",
+            "Returns the DelegationContext that downstream find/send calls pass via "
+            "params['delegation_context'].",
+        )
+    )
     return GovAPITool(
         id=entry["tool_id"],
         name_ko=entry["name_ko"],
         ministry="UMMAYA",
-        category=["check", "mock", "delegation"],
+        category=list(entry.get("category", ["check", "mock", "delegation"])),
         endpoint=entry["endpoint"],
-        auth_type="api_key",
+        auth_type=str(entry.get("auth_type", "api_key")),
         input_schema=_VerifyParamsShell,
         output_schema=_OpaqueOutput,
         llm_description=(
@@ -307,9 +351,10 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
             f"check(tool_id='{entry['tool_id']}', params={{...}}). "
             "Do not call this adapter through find.\n\n"
             f"{scope_clause}"
-            f"Verify ceremony for {entry['name_ko']}. Issues a DelegationToken bound to "
-            "the citizen's session and the requested scope_list. Returns the DelegationContext "
-            "that downstream find/send calls pass via params['delegation_context'].\n\n"
+            f"Verify ceremony for {entry['name_ko']}. Binds the result to the citizen's "
+            "session and requested scope_list. Providers that support delegation issue "
+            f"a DelegationToken; identity-only providers return a sanitized AuthContext. "
+            f"{result_description}\n\n"
             "Citizen-shape input: {tool_id, params={scope_list, purpose_ko, purpose_en}}. "
             "The check primitive translates this to the dispatcher's family_hint via "
             "adapter metadata, not via the system prompt."
@@ -323,13 +368,14 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
                 "see AGENTS.md § Hard rules)."
             ),
             citizen_facing_gate="login",
-            last_verified=datetime(2026, 4, 30, tzinfo=UTC),
+            last_verified=entry.get("last_verified", datetime(2026, 4, 30, tzinfo=UTC)),
         ),
         is_concurrency_safe=False,
         cache_ttl_seconds=0,
-        rate_limit_per_minute=30,
+        rate_limit_per_minute=int(entry.get("rate_limit_per_minute", 30)),
         is_core=False,  # Discoverable via lookup search; NOT in primary LLM tool list
         primitive="check",
+        adapter_mode=str(entry.get("adapter_mode", "mock")),
     )
 
 

--- a/src/ummaya/tools/live/__init__.py
+++ b/src/ummaya/tools/live/__init__.py
@@ -1,0 +1,11 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live check adapters.
+
+Importing this package registers live check families with the primitive
+dispatcher. Keep imports explicit so unrelated live adapters do not load by
+accident.
+"""
+
+from __future__ import annotations
+
+import ummaya.tools.live.verify_kb_identity  # noqa: F401

--- a/src/ummaya/tools/live/kb_identity_client.py
+++ b/src/ummaya/tools/live/kb_identity_client.py
@@ -1,0 +1,338 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KB국민인증서 identity-check HTTP client and redaction helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+
+import httpx
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+JsonObject = dict[str, object]
+
+_IDENTITY_KEY_NAMES = frozenset(
+    {
+        "ci",
+        "di",
+        "usernm",
+        "birthday",
+        "receiverhp",
+        "receivername",
+        "receiverbirthday",
+        "gender",
+        "krnfrgndstcd",
+        "phone",
+        "name",
+        "birthdate",
+    }
+)
+_REQUEST_ENDPOINT = "/kbsign/api/sign_request2"
+_RESULT_ENDPOINT = "/kbsign/api/sign_result"
+
+
+class KbIdentityClientError(Exception):
+    """Sanitized KB identity client failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        reason: str = "kb_identity_error",
+        retryable: bool = False,
+    ) -> None:
+        super().__init__(message)
+        self.reason = reason
+        self.retryable = retryable
+
+
+class KbIdentityConfig(BaseModel):
+    """Runtime configuration for KB identity calls."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    base_url: str = Field(min_length=1)
+    api_key: str = Field(min_length=1)
+    hs_key: str = Field(min_length=1)
+    company_cd: str = Field(min_length=1)
+    request_type: str = Field(default="NONE", min_length=1)
+    timeout_seconds: float = Field(default=30.0, gt=0)
+
+    @field_validator("base_url")
+    @classmethod
+    def _normalize_base_url(cls, value: str) -> str:
+        return value.strip().rstrip("/")
+
+    @field_validator("api_key", "hs_key", "company_cd", "request_type")
+    @classmethod
+    def _strip_required_strings(cls, value: str) -> str:
+        stripped = value.strip()
+        if not stripped:
+            raise ValueError("value must not be blank")
+        return stripped
+
+
+class KbIdentityReceipt(BaseModel):
+    """Sanitized KB transaction receipt metadata."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    req_tx_id: str = Field(min_length=1)
+    cert_tx_id: str = Field(min_length=1)
+    call_url: str | None = None
+    result_code: str = Field(min_length=1)
+    client_message: str | None = None
+    system_message: str | None = None
+    identity_evidence_present: bool = False
+
+
+class KbIdentityClient:
+    """Small HTTP client for KB identity request/result endpoints."""
+
+    def __init__(
+        self,
+        config: KbIdentityConfig,
+        *,
+        http_client: httpx.AsyncClient | None = None,
+    ) -> None:
+        self._config = config
+        self._http_client = http_client
+
+    def build_headers(self) -> dict[str, str]:
+        """Build KB headers without logging or exposing secrets."""
+        return {
+            "Accept": "application/json",
+            "Content-Type": "application/json; charset=UTF-8",
+            "apiKey": self._config.api_key,
+            "hsKey": self._config.hs_key,
+        }
+
+    def build_request_body(
+        self,
+        *,
+        req_tx_id: str,
+        request_type: str | None = None,
+    ) -> JsonObject:
+        req_tx_id = _require_non_blank(req_tx_id, "reqTxId")
+        request_type = _require_non_blank(request_type or self._config.request_type, "requestType")
+        return {
+            "dataHeader": {},
+            "dataBody": {
+                "companyCd": self._config.company_cd,
+                "reqTxId": req_tx_id,
+                "requestType": request_type,
+            },
+        }
+
+    def build_result_body(
+        self,
+        *,
+        req_tx_id: str,
+        cert_tx_id: str,
+        request_type: str | None = None,
+    ) -> JsonObject:
+        req_tx_id = _require_non_blank(req_tx_id, "reqTxId")
+        cert_tx_id = _require_non_blank(cert_tx_id, "certTxId")
+        request_type = _require_non_blank(request_type or self._config.request_type, "requestType")
+        return {
+            "dataHeader": {},
+            "dataBody": {
+                "companyCd": self._config.company_cd,
+                "reqTxId": req_tx_id,
+                "certTxId": cert_tx_id,
+                "requestType": request_type,
+            },
+        }
+
+    async def request_identity(
+        self,
+        *,
+        req_tx_id: str,
+        request_type: str | None = None,
+    ) -> KbIdentityReceipt:
+        body = self.build_request_body(req_tx_id=req_tx_id, request_type=request_type)
+        payload = await self._post(_REQUEST_ENDPOINT, body)
+        return self.parse_request_response(payload, expected_req_tx_id=req_tx_id)
+
+    async def lookup_result(
+        self,
+        *,
+        req_tx_id: str,
+        cert_tx_id: str,
+        request_type: str | None = None,
+    ) -> KbIdentityReceipt:
+        body = self.build_result_body(
+            req_tx_id=req_tx_id,
+            cert_tx_id=cert_tx_id,
+            request_type=request_type,
+        )
+        payload = await self._post(_RESULT_ENDPOINT, body)
+        return self.parse_result_response(
+            payload,
+            expected_req_tx_id=req_tx_id,
+            expected_cert_tx_id=cert_tx_id,
+        )
+
+    def parse_request_response(
+        self,
+        payload: Mapping[str, object],
+        *,
+        expected_req_tx_id: str | None = None,
+    ) -> KbIdentityReceipt:
+        return self._parse_response(
+            payload,
+            expected_req_tx_id=expected_req_tx_id,
+            expected_cert_tx_id=None,
+            require_identity_evidence=False,
+        )
+
+    def parse_result_response(
+        self,
+        payload: Mapping[str, object],
+        *,
+        expected_req_tx_id: str,
+        expected_cert_tx_id: str | None = None,
+    ) -> KbIdentityReceipt:
+        return self._parse_response(
+            payload,
+            expected_req_tx_id=expected_req_tx_id,
+            expected_cert_tx_id=expected_cert_tx_id,
+            require_identity_evidence=True,
+        )
+
+    async def _post(self, endpoint: str, body: JsonObject) -> JsonObject:
+        url = f"{self._config.base_url}{endpoint}"
+        headers = self.build_headers()
+        timeout = httpx.Timeout(self._config.timeout_seconds)
+        try:
+            if self._http_client is not None:
+                response = await self._http_client.post(url, json=body, headers=headers)
+            else:
+                async with httpx.AsyncClient(timeout=timeout) as client:
+                    response = await client.post(url, json=body, headers=headers)
+        except httpx.TimeoutException as exc:
+            raise KbIdentityClientError(
+                "KB identity upstream timeout.",
+                reason="timeout",
+                retryable=True,
+            ) from exc
+        except httpx.RequestError as exc:
+            raise KbIdentityClientError(
+                "KB identity upstream request failed.",
+                reason="request_error",
+                retryable=True,
+            ) from exc
+
+        if response.status_code < 200 or response.status_code >= 300:
+            raise KbIdentityClientError(
+                f"KB identity upstream HTTP {response.status_code}.",
+                reason="upstream_http_error",
+                retryable=response.status_code in {500, 502, 503, 504},
+            )
+
+        try:
+            payload = response.json()
+        except ValueError as exc:
+            raise KbIdentityClientError(
+                "KB identity upstream returned non-JSON payload.",
+                reason="invalid_json",
+            ) from exc
+        if not isinstance(payload, dict):
+            raise KbIdentityClientError(
+                "KB identity upstream returned non-object payload.",
+                reason="invalid_json",
+            )
+        return {str(key): value for key, value in payload.items()}
+
+    def _parse_response(
+        self,
+        payload: Mapping[str, object],
+        *,
+        expected_req_tx_id: str | None,
+        expected_cert_tx_id: str | None,
+        require_identity_evidence: bool,
+    ) -> KbIdentityReceipt:
+        data_header = _mapping_at(payload, "dataHeader")
+        data_body = _mapping_at(payload, "dataBody")
+        sanitized_body = sanitize_identity_payload(data_body)
+
+        result_code = str(data_body.get("result-code") or "")
+        header_result = str(data_header.get("resultCode") or "")
+        success_code = str(data_header.get("successCode") or "")
+        if header_result != "0000" or success_code != "0" or result_code != "ok":
+            safe_payload = sanitize_identity_payload(payload)
+            raise KbIdentityClientError(
+                f"KB identity response failed: {safe_payload!r}",
+                reason="failed_status",
+                retryable=False,
+            )
+
+        req_tx_id = _require_non_blank(str(data_body.get("reqTxId") or ""), "reqTxId")
+        cert_tx_id = _require_non_blank(str(data_body.get("certTxId") or ""), "certTxId")
+        if expected_req_tx_id is not None and req_tx_id != expected_req_tx_id:
+            raise KbIdentityClientError("KB identity reqTxId mismatch.", reason="mismatch")
+        if expected_cert_tx_id is not None and cert_tx_id != expected_cert_tx_id:
+            raise KbIdentityClientError("KB identity certTxId mismatch.", reason="mismatch")
+
+        identity_evidence_present = _has_identity_evidence(data_body)
+        if require_identity_evidence and not identity_evidence_present:
+            raise KbIdentityClientError(
+                "KB identity result did not contain expected identity evidence.",
+                reason="missing_identity_evidence",
+            )
+
+        safe_body = sanitized_body if isinstance(sanitized_body, dict) else {}
+        return KbIdentityReceipt(
+            req_tx_id=req_tx_id,
+            cert_tx_id=cert_tx_id,
+            call_url=_optional_str(safe_body.get("callUrl")),
+            result_code=result_code,
+            client_message=_optional_str(safe_body.get("client-message")),
+            system_message=_optional_str(safe_body.get("system-message")),
+            identity_evidence_present=identity_evidence_present,
+        )
+
+
+def sanitize_identity_payload(value: object) -> object:
+    """Recursively drop identity-bearing fields from a JSON-like value."""
+    if isinstance(value, dict):
+        sanitized: JsonObject = {}
+        for raw_key, raw_value in value.items():
+            key = str(raw_key)
+            if key.lower() in _IDENTITY_KEY_NAMES:
+                continue
+            sanitized[key] = sanitize_identity_payload(raw_value)
+        return sanitized
+    if isinstance(value, list):
+        return [sanitize_identity_payload(item) for item in value]
+    return value
+
+
+def _mapping_at(payload: Mapping[str, object], key: str) -> Mapping[str, object]:
+    value = payload.get(key)
+    if not isinstance(value, dict):
+        raise KbIdentityClientError(
+            f"KB identity payload missing object field {key}.",
+            reason="invalid_payload",
+        )
+    return {str(inner_key): inner_value for inner_key, inner_value in value.items()}
+
+
+def _require_non_blank(value: str, field_name: str) -> str:
+    stripped = value.strip()
+    if not stripped:
+        raise KbIdentityClientError(f"{field_name} is required.", reason="missing_field")
+    return stripped
+
+
+def _optional_str(value: object) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _has_identity_evidence(data_body: Mapping[str, object]) -> bool:
+    for key, value in data_body.items():
+        if str(key).lower() in _IDENTITY_KEY_NAMES and value not in (None, ""):
+            return True
+    return False

--- a/src/ummaya/tools/live/verify_kb_identity.py
+++ b/src/ummaya/tools/live/verify_kb_identity.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Live check adapter for KB국민인증서 identity verification."""
+
+from __future__ import annotations
+
+import os
+import secrets
+from datetime import UTC, datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, ValidationError
+
+from ummaya.primitives.verify import (
+    KbIdentityContext,
+    VerifyMismatchError,
+    register_verify_adapter,
+)
+from ummaya.tools.live.kb_identity_client import (
+    KbIdentityClient,
+    KbIdentityClientError,
+    KbIdentityConfig,
+    KbIdentityReceipt,
+)
+
+_TOOL_ID = "live_verify_kb_identity"
+_FAMILY = "kb_identity"
+_REQUIRED_ENV = (
+    "UMMAYA_KBCERT_BASE_URL",
+    "UMMAYA_KBCERT_API_KEY",
+    "UMMAYA_KBCERT_HS_KEY",
+    "UMMAYA_KBCERT_COMPANY_CD",
+)
+
+
+class KbIdentityParams(BaseModel):
+    """Session context accepted by the live KB check adapter."""
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+    mode: Literal["auto", "request", "result"] = "auto"
+    req_tx_id: str | None = Field(default=None, alias="reqTxId")
+    cert_tx_id: str | None = Field(default=None, alias="certTxId")
+    request_type: str | None = Field(default=None, alias="requestType")
+    fixture_response: dict[str, object] | None = Field(default=None, alias="_fixture_response")
+
+
+async def invoke(session_context: dict[str, object]) -> KbIdentityContext | VerifyMismatchError:
+    """Run the KB identity check flow and return a sanitized AuthContext."""
+    try:
+        params = KbIdentityParams.model_validate(session_context)
+        config = _config_from_env()
+        client = KbIdentityClient(config)
+        mode = _resolve_mode(params)
+        if mode == "request":
+            req_tx_id = params.req_tx_id or _generate_req_tx_id()
+            receipt = (
+                client.parse_request_response(
+                    params.fixture_response,
+                    expected_req_tx_id=req_tx_id,
+                )
+                if params.fixture_response is not None
+                else await client.request_identity(
+                    req_tx_id=req_tx_id,
+                    request_type=params.request_type,
+                )
+            )
+        else:
+            req_tx_id = _require_param(params.req_tx_id, "reqTxId")
+            cert_tx_id = _require_param(params.cert_tx_id, "certTxId")
+            receipt = (
+                client.parse_result_response(
+                    params.fixture_response,
+                    expected_req_tx_id=req_tx_id,
+                    expected_cert_tx_id=cert_tx_id,
+                )
+                if params.fixture_response is not None
+                else await client.lookup_result(
+                    req_tx_id=req_tx_id,
+                    cert_tx_id=cert_tx_id,
+                    request_type=params.request_type,
+                )
+            )
+        return _context_from_receipt(receipt)
+    except ValidationError:
+        return _mismatch("Invalid KB identity parameters.")
+    except (KbIdentityClientError, ValueError) as exc:
+        return _mismatch(str(exc))
+
+
+def _config_from_env() -> KbIdentityConfig:
+    missing = [name for name in _REQUIRED_ENV if not os.environ.get(name, "").strip()]
+    if missing:
+        raise KbIdentityClientError(
+            "Missing KB identity configuration: " + ", ".join(missing),
+            reason="missing_configuration",
+        )
+    return KbIdentityConfig(
+        base_url=os.environ["UMMAYA_KBCERT_BASE_URL"],
+        api_key=os.environ["UMMAYA_KBCERT_API_KEY"],
+        hs_key=os.environ["UMMAYA_KBCERT_HS_KEY"],
+        company_cd=os.environ["UMMAYA_KBCERT_COMPANY_CD"],
+        request_type=os.environ.get("UMMAYA_KBCERT_REQUEST_TYPE", "NONE"),
+    )
+
+
+def _resolve_mode(params: KbIdentityParams) -> Literal["request", "result"]:
+    if params.mode == "request":
+        return "request"
+    if params.mode == "result":
+        return "result"
+    return "result" if params.cert_tx_id else "request"
+
+
+def _require_param(value: str | None, field_name: str) -> str:
+    if value is None or not value.strip():
+        raise KbIdentityClientError(f"{field_name} is required.", reason="missing_field")
+    return value.strip()
+
+
+def _generate_req_tx_id() -> str:
+    return "ummaya-" + secrets.token_urlsafe(24)
+
+
+def _context_from_receipt(receipt: KbIdentityReceipt) -> KbIdentityContext:
+    return KbIdentityContext(
+        published_tier="kb_identity_aal2",
+        nist_aal_hint="AAL2",
+        verified_at=datetime.now(UTC),
+        external_session_ref=(f"kbcert:reqTxId={receipt.req_tx_id};certTxId={receipt.cert_tx_id}"),
+        provider="kb",
+    )
+
+
+def _mismatch(message: str) -> VerifyMismatchError:
+    return VerifyMismatchError(
+        family="mismatch_error",
+        reason="family_mismatch",
+        expected_family=_FAMILY,
+        observed_family="kb_identity_error",
+        message=message,
+    )
+
+
+register_verify_adapter(_FAMILY, invoke)
+
+__all__ = ["KbIdentityParams", "invoke"]

--- a/src/ummaya/tools/models.py
+++ b/src/ummaya/tools/models.py
@@ -244,6 +244,7 @@ class GovAPITool(BaseModel):
             "mobile_id_mdl_aal2",
             "mobile_id_resident_aal2",
             "mydata_individual_aal2",
+            "kb_identity_aal2",
         ]
         | None
     ) = None

--- a/src/ummaya/tools/mvp_surface.py
+++ b/src/ummaya/tools/mvp_surface.py
@@ -359,7 +359,7 @@ class _VerifyInputForLLM(BaseModel):
             "values documented in the system prompt's <check_families> table: "
             "gongdong_injeungseo / geumyung_injeungseo / ganpyeon_injeung / "
             "mobile_id / mydata / simple_auth_module / modid / kec / "
-            "geumyung_module / any_id_sso. "
+            "geumyung_module / any_id_sso / kb_identity. "
             "Set automatically from tool_id by the pre-validator when "
             "citizen-shape input is supplied."
         ),
@@ -474,12 +474,15 @@ VERIFY_TOOL = GovAPITool(
         "family_hint values + canonical AAL hints are documented in the "
         "system prompt's <check_families> table. The LLM defaults to the "
         "lowest AAL satisfying the citizen's stated purpose.\n\n"
+        "KB국민인증서 live identity checks return a sanitized AuthContext with "
+        "only reqTxId/certTxId-derived external_session_ref; raw identity "
+        "attributes are never returned.\n\n"
         "Exception: family_hint='any_id_sso' returns an IdentityAssertion "
         "with no DelegationToken — do NOT chain a send after this check."
     ),
     search_hint=(
         "인증 위임 토큰 check 모바일ID 공동인증서 금융인증서 간편인증 "
-        "마이데이터 KEC SSO delegation token authentication ceremony"
+        "마이데이터 KB국민인증서 KEC SSO delegation token authentication ceremony"
     ),
     policy=AdapterRealDomainPolicy(
         real_classification_url="https://www.data.go.kr/policy/privacyPolicy.do",

--- a/src/ummaya/tools/register_all.py
+++ b/src/ummaya/tools/register_all.py
@@ -117,6 +117,7 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> Routin
 
     # Register MVP LLM-visible core surface first (FR-001, SC-003)
     register_mvp_surface(registry)
+    import ummaya.tools.live  # noqa: F401 — registers opt-in live check adapters
     import ummaya.tools.mock  # noqa: F401 — registers all mock surfaces in production
 
     # Locate provider endpoints are first-class adapters under the central
@@ -173,7 +174,7 @@ def register_all_tools(registry: ToolRegistry, executor: ToolExecutor) -> Routin
 
     bridge_count = bridge_per_primitive_registries(registry)
     logger.info(
-        "discovery_bridge: bridged %d non-core mock adapters into BM25 corpus",
+        "discovery_bridge: bridged %d non-core check/send adapters into BM25 corpus",
         bridge_count,
     )
 

--- a/src/ummaya/tools/registry.py
+++ b/src/ummaya/tools/registry.py
@@ -99,6 +99,7 @@ PublishedTier = Literal[
     "kec_aal3",  # 공동인증서 AX-channel (AAL3, joint-cert legacy)
     "geumyung_module_aal3",  # 금융인증서 AX-channel (AAL3, FNS managed)
     "any_id_sso_aal2",  # Any-ID SSO (identity-only — no delegation grant)
+    "kb_identity_aal2",  # KB국민인증서 본인확인 live check
 ]
 
 # T008 — advisory secondary axis; hint for external consumers only.

--- a/src/ummaya/tools/verify_canonical_map.py
+++ b/src/ummaya/tools/verify_canonical_map.py
@@ -20,6 +20,7 @@ Design
 - The bridge metadata in :mod:`ummaya.tools.discovery_bridge` is the adapter
   inventory mirrored into the central ToolRegistry for discovery.
 - FR-008b: raises ``RuntimeError`` if fewer than 10 entries are available.
+  Live check adapters may also appear when they are declared in bridge metadata.
 """
 
 from __future__ import annotations
@@ -74,7 +75,7 @@ def _load_map() -> Mapping[str, str]:
     from ummaya.tools.discovery_bridge import _VERIFY_FAMILIES  # noqa: PLC0415
 
     mapping: dict[str, str] = {
-        str(entry["tool_id"]): _tool_id_to_family(str(entry["tool_id"]))
+        str(entry["tool_id"]): str(entry.get("family") or _tool_id_to_family(str(entry["tool_id"])))
         for entry in _VERIFY_FAMILIES
         if isinstance(entry, dict) and isinstance(entry.get("tool_id"), str)
     }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -61,7 +61,7 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
     if not _marker_selected("live", marker_expr):
         skip_live = pytest.mark.skip(reason="live tests require -m live")
         for item in items:
-            if "live" in item.keywords:
+            if item.get_closest_marker("live") is not None:
                 item.add_marker(skip_live)
 
     # ``live_embedder`` family (spec 026, NFR-NoNetAtRuntime)
@@ -70,5 +70,5 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
             reason="live_embedder tests require -m live_embedder (downloads HF weights)"
         )
         for item in items:
-            if "live_embedder" in item.keywords:
+            if item.get_closest_marker("live_embedder") is not None:
                 item.add_marker(skip_embedder)

--- a/tests/fixtures/kbcert/request_success.json
+++ b/tests/fixtures/kbcert/request_success.json
@@ -1,0 +1,16 @@
+{
+  "dataHeader": {
+    "resultCode": "0000",
+    "resultMessage": "success",
+    "successCode": "0",
+    "category": "API"
+  },
+  "dataBody": {
+    "reqTxId": "synthetic-req-tx-id",
+    "certTxId": "synthetic-cert-tx-id",
+    "callUrl": "https://cert.kbstar.com/quics?page=C111978",
+    "result-code": "ok",
+    "client-message": "success",
+    "system-message": "success"
+  }
+}

--- a/tests/fixtures/kbcert/result_failed.json
+++ b/tests/fixtures/kbcert/result_failed.json
@@ -1,0 +1,16 @@
+{
+  "dataHeader": {
+    "resultCode": "9999",
+    "resultMessage": "failed",
+    "successCode": "1",
+    "category": "API"
+  },
+  "dataBody": {
+    "result-code": "fail",
+    "client-message": "expired transaction",
+    "system-message": "synthetic expired transaction",
+    "reqTxId": "synthetic-req-tx-id",
+    "certTxId": "synthetic-cert-tx-id",
+    "CI": "SENTINEL_CI_SHOULD_NOT_LEAK"
+  }
+}

--- a/tests/fixtures/kbcert/result_mismatch.json
+++ b/tests/fixtures/kbcert/result_mismatch.json
@@ -1,0 +1,16 @@
+{
+  "dataHeader": {
+    "resultCode": "0000",
+    "resultMessage": "success",
+    "successCode": "0",
+    "category": "API"
+  },
+  "dataBody": {
+    "result-code": "ok",
+    "client-message": "success",
+    "system-message": "success",
+    "reqTxId": "different-req-tx-id",
+    "certTxId": "synthetic-cert-tx-id",
+    "CI": "SENTINEL_CI_SHOULD_NOT_LEAK"
+  }
+}

--- a/tests/fixtures/kbcert/result_success.json
+++ b/tests/fixtures/kbcert/result_success.json
@@ -1,0 +1,21 @@
+{
+  "dataHeader": {
+    "resultCode": "0000",
+    "resultMessage": "success",
+    "successCode": "0",
+    "category": "API"
+  },
+  "dataBody": {
+    "result-code": "ok",
+    "client-message": "success",
+    "system-message": "success",
+    "reqTxId": "synthetic-req-tx-id",
+    "certTxId": "synthetic-cert-tx-id",
+    "userNm": "SENTINEL_USER_NAME_SHOULD_NOT_LEAK",
+    "birthday": "SENTINEL_BIRTHDAY_SHOULD_NOT_LEAK",
+    "CI": "SENTINEL_CI_SHOULD_NOT_LEAK",
+    "DI": "SENTINEL_DI_SHOULD_NOT_LEAK",
+    "gender": "SENTINEL_GENDER_SHOULD_NOT_LEAK",
+    "krnFrgnDstcd": "SENTINEL_NATIONALITY_SHOULD_NOT_LEAK"
+  }
+}

--- a/tests/integration/test_discovery_bridge_path_b.py
+++ b/tests/integration/test_discovery_bridge_path_b.py
@@ -41,12 +41,12 @@ def test_b1_total_tool_count_includes_mocks(
 ) -> None:
     """Path B-1: bridge registers active non-core mock adapters into main registry.
 
-    Expected total: 68 after both verified public-data adapter waves.
+    Expected total: 69 after both verified public-data adapter waves plus KB live check.
     """
     r, _ = loaded_registry
     total = len(r.all_tools())
-    assert total == 68, (
-        f"Expected 68 total tools after discovery_bridge runs; got {total}. "
+    assert total == 69, (
+        f"Expected 69 total tools after discovery_bridge runs; got {total}. "
         f"Verify the bridge registered the active mock adapters."
     )
 
@@ -54,7 +54,7 @@ def test_b1_total_tool_count_includes_mocks(
 def test_b1_verify_mocks_in_registry(
     loaded_registry: tuple[ToolRegistry, ToolExecutor],
 ) -> None:
-    """All 10 canonical verify family tool_ids are registered."""
+    """All canonical check family tool_ids are registered."""
     r, _ = loaded_registry
     ids = {t.id for t in r.all_tools()}
     expected = {
@@ -68,9 +68,23 @@ def test_b1_verify_mocks_in_registry(
         "mock_verify_ganpyeon_injeung",
         "mock_verify_mobile_id",
         "mock_verify_mydata",
+        "live_verify_kb_identity",
     }
     missing = expected - ids
     assert not missing, f"Missing verify adapters in main registry: {missing}"
+
+
+def test_b1_kb_live_check_registered_as_non_core_check(
+    loaded_registry: tuple[ToolRegistry, ToolExecutor],
+) -> None:
+    """KB identity is an opt-in live check adapter, not a core primitive."""
+    r, _ = loaded_registry
+    tool = r.lookup("live_verify_kb_identity")
+
+    assert tool.primitive == "check"
+    assert tool.adapter_mode == "live"
+    assert tool.is_core is False
+    assert "live" in tool.category
 
 
 def test_b1_submit_mocks_in_registry(

--- a/tests/integration/test_mcp_otel_spans.py
+++ b/tests/integration/test_mcp_otel_spans.py
@@ -87,8 +87,8 @@ class TestMCPToolsListShape:
         tools = response["result"]["tools"]
         # Subscribe is deferred out of the active surface until UMMAYA owns an
         # app/push delivery runtime. The MCP tool list mirrors the active
-        # registry: 68 tools after Spec #2798's 16-adapter live expansion.
-        assert len(tools) == 68, f"Tool list count drift: got {len(tools)}, expected 68"
+        # registry: 69 tools after adding the opt-in live KB identity check.
+        assert len(tools) == 69, f"Tool list count drift: got {len(tools)}, expected 69"
 
     def test_tools_list_entries_have_required_keys(self, mcp_server: MCPServer) -> None:
         response = asyncio.run(

--- a/tests/integration/test_tool_id_to_family_hint_translation.py
+++ b/tests/integration/test_tool_id_to_family_hint_translation.py
@@ -9,7 +9,7 @@ Covers contracts/verify-input-shape.md invariants I-V1 / I-V2 / I-V3 / I-V5.
 
 US3 acceptance criterion:
   ``pytest tests/integration/test_tool_id_to_family_hint_translation.py -v``
-  reports ≥12 PASS / 0 FAIL (10 canonical-family cases + 1 legacy + 1 unknown
+  reports ≥13 PASS / 0 FAIL (11 canonical-family cases + 1 legacy + 1 unknown
   + 1 idempotency).
 
 References
@@ -28,7 +28,7 @@ from ummaya.tools.mvp_surface import _VerifyInputForLLM
 
 # ---------------------------------------------------------------------------
 # Parametrised canonical-family cases (I-V1)
-# One case per canonical family; 10 total.
+# One case per canonical family; 11 total.
 # ---------------------------------------------------------------------------
 
 _CANONICAL_CASES: list[tuple[str, str]] = [
@@ -42,6 +42,7 @@ _CANONICAL_CASES: list[tuple[str, str]] = [
     ("mock_verify_module_kec", "kec"),
     ("mock_verify_module_geumyung", "geumyung_module"),
     ("mock_verify_module_any_id_sso", "any_id_sso"),
+    ("live_verify_kb_identity", "kb_identity"),
 ]
 
 _SAMPLE_PARAMS: dict[str, object] = {

--- a/tests/ipc/test_stdio_verify_dispatch.py
+++ b/tests/ipc/test_stdio_verify_dispatch.py
@@ -19,7 +19,7 @@ Fix:
     when the tool_id lookup misses (legacy compatibility).
 
 This test asserts:
-1. All 10 canonical ``mock_verify_*`` ↔ family_hint pairs resolve
+1. All canonical ``*_verify_*`` ↔ family_hint pairs resolve
    correctly via the canonical map (single source-of-truth derived from
    ``prompts/system_v1.md`` ``<check_families>``).
 2. The full IPC dispatch path translates ``tool_id`` → ``family_hint``
@@ -79,6 +79,13 @@ _EXPECTED_PAIRS: dict[str, str] = {
     "mock_verify_module_kec": "kec",
     "mock_verify_module_geumyung": "geumyung_module",
     "mock_verify_module_any_id_sso": "any_id_sso",
+    "live_verify_kb_identity": "kb_identity",
+}
+
+_DISPATCH_PAIRS: dict[str, str] = {
+    tool_id: family
+    for tool_id, family in _EXPECTED_PAIRS.items()
+    if tool_id.startswith("mock_verify_")
 }
 
 
@@ -86,8 +93,8 @@ _EXPECTED_PAIRS: dict[str, str] = {
     ("tool_id", "expected_family"),
     list(_EXPECTED_PAIRS.items()),
 )
-def test_resolve_family_covers_all_10_canonical_pairs(tool_id: str, expected_family: str) -> None:
-    """All 10 canonical mock_verify_* tool_ids resolve to the right family_hint.
+def test_resolve_family_covers_all_canonical_pairs(tool_id: str, expected_family: str) -> None:
+    """All canonical check tool_ids resolve to the right family_hint.
 
     This is the SOT-mirror assertion: prompt-side
     ``<check_families>`` and code-side mapping must agree.
@@ -328,7 +335,7 @@ def _extract_verify_envelope(frames: list[dict[str, Any]]) -> dict[str, Any]:
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("tool_id", "expected_family"),
-    list(_EXPECTED_PAIRS.items()),
+    list(_DISPATCH_PAIRS.items()),
 )
 async def test_dispatch_verify_translates_tool_id_to_family_hint(
     tool_id: str,

--- a/tests/live/test_live_kb_identity.py
+++ b/tests/live/test_live_kb_identity.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Opt-in live smoke tests for KB identity check.
+
+These tests require partner-issued KB credentials and network allowlisting.
+They are skipped unless both `-m live` and all `UMMAYA_KBCERT_*` variables are
+present.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from ummaya.primitives.verify import KbIdentityContext
+from ummaya.tools.live.verify_kb_identity import invoke
+
+_REQUIRED_ENV = (
+    "UMMAYA_KBCERT_BASE_URL",
+    "UMMAYA_KBCERT_API_KEY",
+    "UMMAYA_KBCERT_HS_KEY",
+    "UMMAYA_KBCERT_COMPANY_CD",
+)
+
+
+def _skip_without_kb_credentials() -> None:
+    missing = [name for name in _REQUIRED_ENV if not os.environ.get(name, "").strip()]
+    if missing:
+        pytest.skip("KB identity live test credentials are not configured: " + ", ".join(missing))
+
+
+def test_live_kb_identity_credentials_are_explicit() -> None:
+    """Default non-live selection has a no-network guard test in this file."""
+    assert "UMMAYA_KBCERT_API_KEY" in _REQUIRED_ENV
+    assert "UMMAYA_KBCERT_HS_KEY" in _REQUIRED_ENV
+
+
+@pytest.mark.live
+@pytest.mark.asyncio
+async def test_live_kb_identity_request_smoke() -> None:
+    _skip_without_kb_credentials()
+
+    result = await invoke({"mode": "request", "reqTxId": "ummaya-live-synthetic-req-tx-id"})
+
+    assert isinstance(result, KbIdentityContext)
+    assert result.external_session_ref is not None
+    assert "CI" not in result.model_dump_json()
+    assert "DI" not in result.model_dump_json()

--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -38,10 +38,11 @@ class TestToolRegistration:
         # Spec #2797 verified public-data wave: + 14 direct-curl verified
         # data.go.kr/LINK adapters = 52.
         # Spec #2798 live expansion: + 16 approved data.go.kr adapters = 68.
+        # Spec live-kbcert-identity-check: + 1 live check adapter = 69.
         # is_core=False so the LLM's primary tool list stays at active
         # primitives + lookup-class; these participate in
         # lookup(mode="search") BM25 corpus only.
-        assert len(registry) == 68
+        assert len(registry) == 69
 
     def test_tool_ids_present(self) -> None:
         """Each expected tool_id is in the registry.
@@ -107,6 +108,8 @@ class TestToolRegistration:
             "ccourt_publication_documents",
             "moj_stay_person_counter",
             "msit_business_announcement_lookup",
+            # Live check adapter
+            "live_verify_kb_identity",
         }
         for tool_id in expected:
             assert tool_id in registry, f"{tool_id} not found in registry"

--- a/tests/tools/test_routing_consistency.py
+++ b/tests/tools/test_routing_consistency.py
@@ -170,7 +170,7 @@ class TestInvariant4UniqueToolId:
 
 
 class TestCheck7ToolListClosure:
-    """The Python-side registered tool set matches the 68-entry registry.
+    """The Python-side registered tool set matches the 69-entry registry.
 
     Divergence from this set indicates either an unauthorized addition or
     an inadvertent removal — both are CI failures.
@@ -226,6 +226,8 @@ class TestCheck7ToolListClosure:
             "mock_verify_ganpyeon_injeung",
             "mock_verify_mobile_id",
             "mock_verify_mydata",
+            # Live check adapter
+            "live_verify_kb_identity",
             # 5 submit wrappers
             "mock_submit_module_hometax_taxreturn",
             "mock_submit_module_gov24_minwon",

--- a/tests/unit/test_verify_canonical_map_parser.py
+++ b/tests/unit/test_verify_canonical_map_parser.py
@@ -3,7 +3,7 @@
 
 Asserts FR-008b regression criteria:
 - The canonical map has ≥10 entries.
-- All 10 canonical tool_id keys are present.
+- All canonical tool_id keys are present.
 - Each family_hint value matches the expected canonical value.
 - ``resolve_family`` returns the correct family_hint for every key.
 - ``resolve_family`` returns ``None`` for an unknown tool_id.
@@ -38,6 +38,7 @@ EXPECTED_MAPPING: dict[str, str] = {
     "mock_verify_module_kec": "kec",
     "mock_verify_module_geumyung": "geumyung_module",
     "mock_verify_module_any_id_sso": "any_id_sso",
+    "live_verify_kb_identity": "kb_identity",
 }
 
 
@@ -52,8 +53,8 @@ def test_canonical_map_has_at_least_ten_entries() -> None:
     assert len(mapping) >= 10, f"Expected ≥10 entries in canonical map, got {len(mapping)}"
 
 
-def test_all_ten_canonical_tool_ids_present() -> None:
-    """All 10 canonical tool_id keys from data-model.md § 2 MUST be present."""
+def test_all_canonical_tool_ids_present() -> None:
+    """All canonical tool_id keys from discovery metadata MUST be present."""
     mapping = get_canonical_map()
     missing = [tid for tid in EXPECTED_MAPPING if tid not in mapping]
     assert not missing, f"Missing tool_ids in canonical map: {missing}"
@@ -113,15 +114,19 @@ def test_get_canonical_map_is_idempotent() -> None:
 
 
 def test_canonical_family_hint_values_are_all_present() -> None:
-    """All 10 expected family_hint values from data-model.md § 2 MUST appear."""
+    """All expected family_hint values from discovery metadata MUST appear."""
     expected_families = set(EXPECTED_MAPPING.values())
     actual_families = set(get_canonical_map().values())
     missing_families = expected_families - actual_families
     assert not missing_families, f"Missing family_hint values in canonical map: {missing_families}"
 
 
-def test_canonical_map_tool_ids_start_with_mock_verify() -> None:
-    """All canonical tool_id keys MUST start with 'mock_verify_'."""
+def test_canonical_map_tool_ids_are_check_verify_ids() -> None:
+    """All canonical tool_id keys MUST be explicit check adapter ids."""
     mapping = get_canonical_map()
-    invalid = [tid for tid in mapping if not tid.startswith("mock_verify_")]
-    assert not invalid, f"tool_ids NOT starting with 'mock_verify_': {invalid}"
+    invalid = [
+        tid
+        for tid in mapping
+        if not (tid.startswith("mock_verify_") or tid.startswith("live_verify_"))
+    ]
+    assert not invalid, f"tool_ids NOT in check verify namespace: {invalid}"

--- a/tests/unit/tools/live/test_kb_identity_client.py
+++ b/tests/unit/tools/live/test_kb_identity_client.py
@@ -1,0 +1,159 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the KB identity live client.
+
+Fixtures are synthetic and sanitized; no test in this module calls KB.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import httpx
+import pytest
+
+from ummaya.tools.live.kb_identity_client import (
+    KbIdentityClient,
+    KbIdentityClientError,
+    KbIdentityConfig,
+    sanitize_identity_payload,
+)
+
+FIXTURE_DIR = Path(__file__).parents[3] / "fixtures" / "kbcert"
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+def _config() -> KbIdentityConfig:
+    return KbIdentityConfig(
+        base_url="https://stg-openapi.kbstar.com:8443/",
+        api_key="synthetic-api-key",
+        hs_key="synthetic-hs-key",
+        company_cd="TEST0000",
+    )
+
+
+def test_request_body_and_headers_are_constructed_without_identity_fields() -> None:
+    client = KbIdentityClient(_config())
+
+    headers = client.build_headers()
+    body = client.build_request_body(req_tx_id="synthetic-req-tx-id")
+
+    assert headers["apiKey"] == "synthetic-api-key"
+    assert headers["hsKey"] == "synthetic-hs-key"
+    assert headers["Content-Type"] == "application/json; charset=UTF-8"
+    assert body == {
+        "dataHeader": {},
+        "dataBody": {
+            "companyCd": "TEST0000",
+            "reqTxId": "synthetic-req-tx-id",
+            "requestType": "NONE",
+        },
+    }
+    assert "CI" not in json.dumps(body)
+    assert "DI" not in json.dumps(body)
+
+
+def test_result_body_requires_cert_tx_id() -> None:
+    client = KbIdentityClient(_config())
+
+    with pytest.raises(KbIdentityClientError, match="certTxId is required"):
+        client.build_result_body(req_tx_id="synthetic-req-tx-id", cert_tx_id="")
+
+
+def test_parse_request_response_returns_sanitized_receipt() -> None:
+    client = KbIdentityClient(_config())
+
+    receipt = client.parse_request_response(
+        _fixture("request_success.json"),
+        expected_req_tx_id="synthetic-req-tx-id",
+    )
+
+    assert receipt.req_tx_id == "synthetic-req-tx-id"
+    assert receipt.cert_tx_id == "synthetic-cert-tx-id"
+    assert receipt.call_url == "https://cert.kbstar.com/quics?page=C111978"
+    assert receipt.result_code == "ok"
+    assert receipt.identity_evidence_present is False
+
+
+def test_parse_result_response_redacts_identity_values() -> None:
+    client = KbIdentityClient(_config())
+
+    receipt = client.parse_result_response(
+        _fixture("result_success.json"),
+        expected_req_tx_id="synthetic-req-tx-id",
+        expected_cert_tx_id="synthetic-cert-tx-id",
+    )
+    dumped = receipt.model_dump_json()
+
+    assert receipt.identity_evidence_present is True
+    assert receipt.req_tx_id == "synthetic-req-tx-id"
+    assert receipt.cert_tx_id == "synthetic-cert-tx-id"
+    for sentinel in (
+        "SENTINEL_CI_SHOULD_NOT_LEAK",
+        "SENTINEL_DI_SHOULD_NOT_LEAK",
+        "SENTINEL_USER_NAME_SHOULD_NOT_LEAK",
+        "SENTINEL_BIRTHDAY_SHOULD_NOT_LEAK",
+        "SENTINEL_GENDER_SHOULD_NOT_LEAK",
+        "SENTINEL_NATIONALITY_SHOULD_NOT_LEAK",
+    ):
+        assert sentinel not in dumped
+
+
+def test_failed_status_raises_sanitized_error() -> None:
+    client = KbIdentityClient(_config())
+
+    with pytest.raises(KbIdentityClientError) as exc_info:
+        client.parse_result_response(
+            _fixture("result_failed.json"),
+            expected_req_tx_id="synthetic-req-tx-id",
+            expected_cert_tx_id="synthetic-cert-tx-id",
+        )
+
+    message = str(exc_info.value)
+    assert "KB identity response failed" in message
+    assert "SENTINEL_CI_SHOULD_NOT_LEAK" not in message
+
+
+def test_mismatched_req_tx_id_raises_fail_closed() -> None:
+    client = KbIdentityClient(_config())
+
+    with pytest.raises(KbIdentityClientError, match="reqTxId mismatch"):
+        client.parse_result_response(
+            _fixture("result_mismatch.json"),
+            expected_req_tx_id="synthetic-req-tx-id",
+            expected_cert_tx_id="synthetic-cert-tx-id",
+        )
+
+
+def test_sanitize_identity_payload_recursively_drops_forbidden_keys() -> None:
+    payload = {
+        "outer": {
+            "CI": "SENTINEL_CI_SHOULD_NOT_LEAK",
+            "safe": "kept",
+            "nested": [{"DI": "SENTINEL_DI_SHOULD_NOT_LEAK", "status": "ok"}],
+        }
+    }
+
+    sanitized = sanitize_identity_payload(payload)
+    dumped = json.dumps(sanitized)
+
+    assert "SENTINEL_CI_SHOULD_NOT_LEAK" not in dumped
+    assert "SENTINEL_DI_SHOULD_NOT_LEAK" not in dumped
+    assert sanitized == {"outer": {"safe": "kept", "nested": [{"status": "ok"}]}}
+
+
+@pytest.mark.asyncio
+async def test_upstream_non_2xx_raises_sanitized_error() -> None:
+    async def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(503, json={"CI": "SENTINEL_CI_SHOULD_NOT_LEAK"})
+
+    async with httpx.AsyncClient(transport=httpx.MockTransport(handler)) as http_client:
+        client = KbIdentityClient(_config(), http_client=http_client)
+        with pytest.raises(KbIdentityClientError) as exc_info:
+            await client.request_identity(req_tx_id="synthetic-req-tx-id")
+
+    assert "upstream HTTP 503" in str(exc_info.value)
+    assert "SENTINEL_CI_SHOULD_NOT_LEAK" not in str(exc_info.value)

--- a/tests/unit/tools/live/test_verify_kb_identity.py
+++ b/tests/unit/tools/live/test_verify_kb_identity.py
@@ -1,0 +1,146 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Tests for the live KB identity check adapter."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import ummaya.tools.live.verify_kb_identity as kb_adapter
+import ummaya.tools.mock  # noqa: F401
+from ummaya.primitives.verify import (
+    GanpyeonInjeungContext,
+    KbIdentityContext,
+    VerifyMismatchError,
+    verify,
+)
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.register_all import register_all_tools
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.verify_canonical_map import resolve_family
+
+FIXTURE_DIR = Path(__file__).parents[3] / "fixtures" / "kbcert"
+
+
+def _fixture(name: str) -> dict[str, object]:
+    return json.loads((FIXTURE_DIR / name).read_text())
+
+
+def _env() -> dict[str, str]:
+    return {
+        "UMMAYA_KBCERT_BASE_URL": "https://stg-openapi.kbstar.com:8443/",
+        "UMMAYA_KBCERT_API_KEY": "synthetic-api-key",
+        "UMMAYA_KBCERT_HS_KEY": "synthetic-hs-key",
+        "UMMAYA_KBCERT_COMPANY_CD": "TEST0000",
+    }
+
+
+@pytest.mark.asyncio
+async def test_request_mode_returns_kb_identity_context(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key, value in _env().items():
+        monkeypatch.setenv(key, value)
+
+    result = await kb_adapter.invoke(
+        {
+            "mode": "request",
+            "reqTxId": "synthetic-req-tx-id",
+            "_fixture_response": _fixture("request_success.json"),
+        }
+    )
+
+    assert isinstance(result, KbIdentityContext)
+    assert result.family == "kb_identity"
+    assert result.provider == "kb"
+    assert result.external_session_ref == (
+        "kbcert:reqTxId=synthetic-req-tx-id;certTxId=synthetic-cert-tx-id"
+    )
+
+
+@pytest.mark.asyncio
+async def test_result_mode_redacts_identity_values(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key, value in _env().items():
+        monkeypatch.setenv(key, value)
+
+    result = await kb_adapter.invoke(
+        {
+            "mode": "result",
+            "reqTxId": "synthetic-req-tx-id",
+            "certTxId": "synthetic-cert-tx-id",
+            "_fixture_response": _fixture("result_success.json"),
+        }
+    )
+    dumped = result.model_dump_json() if hasattr(result, "model_dump_json") else str(result)
+
+    assert isinstance(result, KbIdentityContext)
+    assert "SENTINEL_CI_SHOULD_NOT_LEAK" not in dumped
+    assert "SENTINEL_DI_SHOULD_NOT_LEAK" not in dumped
+    assert "SENTINEL_USER_NAME_SHOULD_NOT_LEAK" not in dumped
+
+
+@pytest.mark.asyncio
+async def test_missing_credentials_returns_sanitized_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    for key in _env():
+        monkeypatch.delenv(key, raising=False)
+
+    result = await kb_adapter.invoke({"mode": "request", "reqTxId": "synthetic-req-tx-id"})
+
+    assert isinstance(result, VerifyMismatchError)
+    assert result.expected_family == "kb_identity"
+    assert "UMMAYA_KBCERT_API_KEY" in result.message
+
+
+@pytest.mark.asyncio
+async def test_validation_errors_do_not_echo_identity_payload() -> None:
+    result = await kb_adapter.invoke(
+        {
+            "mode": "request",
+            "_fixture_response": [{"CI": "SENTINEL_CI_SHOULD_NOT_LEAK"}],
+        }
+    )
+
+    assert isinstance(result, VerifyMismatchError)
+    assert result.message == "Invalid KB identity parameters."
+    assert "SENTINEL_CI_SHOULD_NOT_LEAK" not in result.model_dump_json()
+
+
+@pytest.mark.asyncio
+async def test_verify_dispatch_supports_kb_identity(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key, value in _env().items():
+        monkeypatch.setenv(key, value)
+
+    result = await verify(
+        "kb_identity",
+        {
+            "mode": "request",
+            "reqTxId": "synthetic-req-tx-id",
+            "_fixture_response": _fixture("request_success.json"),
+        },
+    )
+
+    assert isinstance(result, KbIdentityContext)
+
+
+def test_live_kb_tool_is_discoverable_under_check() -> None:
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry=registry)
+    register_all_tools(registry, executor)
+
+    tool = registry.find("live_verify_kb_identity")
+
+    assert tool.primitive == "check"
+    assert tool.adapter_mode == "live"
+    assert tool.is_core is False
+    assert resolve_family("live_verify_kb_identity") == "kb_identity"
+
+
+@pytest.mark.asyncio
+async def test_existing_ganpyeon_mock_remains_unchanged() -> None:
+    result = await verify("ganpyeon_injeung", {})
+
+    assert isinstance(result, GanpyeonInjeungContext)
+    assert result.provider == "kakao"
+    assert result.external_session_ref == "mock-ganpyeon-ref-001"

--- a/tests/unit/tools/test_digital_onepass_deletion.py
+++ b/tests/unit/tools/test_digital_onepass_deletion.py
@@ -170,8 +170,8 @@ def test_verify_adapter_registry_exact_family_count_after_deletion() -> None:
     This is the SC-003/SC-004 compound check: both the absence of digital_onepass
     AND the presence of the 10 replacement families plus the KB live check family.
     """
-    import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     import ummaya.tools.live  # noqa: F401 — trigger side-effect registration
+    import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.verify import _VERIFY_ADAPTERS
 
     families = list(_VERIFY_ADAPTERS.keys())

--- a/tests/unit/tools/test_digital_onepass_deletion.py
+++ b/tests/unit/tools/test_digital_onepass_deletion.py
@@ -165,18 +165,19 @@ def test_verify_adapter_registry_has_no_digital_onepass_key() -> None:
 
 
 def test_verify_adapter_registry_exact_family_count_after_deletion() -> None:
-    """After digital_onepass deletion, _VERIFY_ADAPTERS has exactly 10 families.
+    """After digital_onepass deletion, _VERIFY_ADAPTERS has exactly 11 families.
 
     This is the SC-003/SC-004 compound check: both the absence of digital_onepass
-    AND the presence of the 10 replacement families.
+    AND the presence of the 10 replacement families plus the KB live check family.
     """
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
+    import ummaya.tools.live  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.verify import _VERIFY_ADAPTERS
 
     families = list(_VERIFY_ADAPTERS.keys())
-    assert len(families) == 10, (
-        f"Expected exactly 10 verify families after digital_onepass deletion "
-        f"(FR-004 + 5 existing + 5 new Epic ε). "
+    assert len(families) == 11, (
+        f"Expected exactly 11 verify families after digital_onepass deletion "
+        f"(FR-004 + 5 existing + 5 new Epic ε + 1 live KB check). "
         f"Got {len(families)}: {sorted(families)}"
     )
 

--- a/tests/unit/tools/test_registry_count_breakdown.py
+++ b/tests/unit/tools/test_registry_count_breakdown.py
@@ -2,8 +2,8 @@
 """T035 — Registry count breakdown assertion (SC-003).
 
 Boots the registry and asserts the active count breakdown from spec.md SC-003:
-  - Main ToolRegistry: 68 entries
-  - ummaya.primitives.verify._VERIFY_ADAPTERS: 10 families
+  - Main ToolRegistry: 69 entries
+  - ummaya.primitives.verify._VERIFY_ADAPTERS: 11 families
   - ummaya.primitives.submit._ADAPTER_REGISTRY: 5 families
 
 Test FAILS if any count is off-by-one.
@@ -16,7 +16,7 @@ do NOT silently adjust the expected values.
 from __future__ import annotations
 
 # ---------------------------------------------------------------------------
-# Main ToolRegistry count — 68 total
+# Main ToolRegistry count — 69 total
 # ---------------------------------------------------------------------------
 # Epic η #2298 — extended from 16 to 18 by adding `check` / `send`
 # to mvp_surface as `is_core=True` GovAPITool entries (FR-021).
@@ -42,10 +42,12 @@ from __future__ import annotations
 # verified public-data adapters under src/ummaya/tools/verified_data_go_kr/.
 # Spec #2798 — extended from 52 to 68 by registering sixteen additional
 # approved live public-data adapters from the 2026-05-16 direct evidence batch.
-_EXPECTED_MAIN_REGISTRY_COUNT = 68
+# Spec live-kbcert-identity-check — extended from 68 to 69 by adding one opt-in
+# live KB identity check adapter under the check primitive.
+_EXPECTED_MAIN_REGISTRY_COUNT = 69
 
 _EXPECTED_MAIN_REGISTRY_BREAKDOWN = {
-    "live_adapters": 42,  # 12 existing Live + 30 verified public-data adapters
+    "live_adapters": 43,  # 12 existing Live + 30 verified public-data + KB check
     "mvp_surface": 4,  # find + locate + check + send (main-verb surface)
     "locate_adapters": 5,  # kakao/juso/provider-specific locate adapters
     "lookup_mocks": 2,  # mock_lookup_module_hometax_simplified + mock_lookup_module_gov24_certificate  # noqa: E501
@@ -95,6 +97,7 @@ _EXPECTED_LIVE_TOOL_IDS = frozenset(
         "ccourt_publication_documents",
         "moj_stay_person_counter",
         "msit_business_announcement_lookup",
+        "live_verify_kb_identity",
     }
 )
 
@@ -109,7 +112,7 @@ _EXPECTED_LOOKUP_MOCK_IDS = frozenset(
 
 
 def test_main_registry_total_count() -> None:
-    """Main ToolRegistry must have exactly 68 entries after register_all_tools()."""
+    """Main ToolRegistry must have exactly 69 entries after register_all_tools()."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.tools.executor import ToolExecutor
     from ummaya.tools.register_all import register_all_tools
@@ -185,10 +188,10 @@ def test_main_registry_lookup_mock_ids_present() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Verify sub-registry count — 10 families
+# Verify sub-registry count — 11 families
 # ---------------------------------------------------------------------------
 
-_EXPECTED_VERIFY_COUNT = 10
+_EXPECTED_VERIFY_COUNT = 11
 
 _EXPECTED_VERIFY_FAMILIES = frozenset(
     {
@@ -204,13 +207,16 @@ _EXPECTED_VERIFY_FAMILIES = frozenset(
         "kec",
         "geumyung_module",
         "any_id_sso",
+        # 1 live check adapter
+        "kb_identity",
     }
 )
 
 
 def test_verify_adapter_registry_count() -> None:
-    """ummaya.primitives.verify._VERIFY_ADAPTERS must have exactly 10 families."""
+    """ummaya.primitives.verify._VERIFY_ADAPTERS must have exactly 11 families."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
+    import ummaya.tools.live  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.verify import _VERIFY_ADAPTERS
 
     actual = len(_VERIFY_ADAPTERS)
@@ -222,8 +228,9 @@ def test_verify_adapter_registry_count() -> None:
 
 
 def test_verify_adapter_registry_families() -> None:
-    """All 10 expected verify family keys must be present in _VERIFY_ADAPTERS."""
+    """All 11 expected verify family keys must be present in _VERIFY_ADAPTERS."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
+    import ummaya.tools.live  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.verify import _VERIFY_ADAPTERS
 
     registered = frozenset(_VERIFY_ADAPTERS.keys())
@@ -345,8 +352,9 @@ def test_all_active_surface_counts_match_canonical() -> None:
         # Locate-provider adapters add five first-class registry entries.
         # Spec #2798 adds sixteen approved live data.go.kr adapters, bringing
         # the main ToolRegistry from 52 to 68.
-        "main_registry": 68,
-        "verify_families": 10,
+        # Spec live-kbcert-identity-check adds one opt-in live check adapter.
+        "main_registry": 69,
+        "verify_families": 11,
         "submit_adapters": 5,
     }
 

--- a/tests/unit/tools/test_registry_count_breakdown.py
+++ b/tests/unit/tools/test_registry_count_breakdown.py
@@ -215,8 +215,8 @@ _EXPECTED_VERIFY_FAMILIES = frozenset(
 
 def test_verify_adapter_registry_count() -> None:
     """ummaya.primitives.verify._VERIFY_ADAPTERS must have exactly 11 families."""
-    import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     import ummaya.tools.live  # noqa: F401 — trigger side-effect registration
+    import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.verify import _VERIFY_ADAPTERS
 
     actual = len(_VERIFY_ADAPTERS)
@@ -229,8 +229,8 @@ def test_verify_adapter_registry_count() -> None:
 
 def test_verify_adapter_registry_families() -> None:
     """All 11 expected verify family keys must be present in _VERIFY_ADAPTERS."""
-    import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     import ummaya.tools.live  # noqa: F401 — trigger side-effect registration
+    import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.verify import _VERIFY_ADAPTERS
 
     registered = frozenset(_VERIFY_ADAPTERS.keys())


### PR DESCRIPTION
## Summary

- Add the Spec Kit package for the live KB identity check adapter.
- Add `live_verify_kb_identity` as an opt-in `check` adapter with sanitized `KbIdentityContext` output.
- Add KB request/result client parsing, fixture replay tests, live-test guardrails, registry/canonical-map updates, generated docs artifacts, and adapter documentation.

## Validation

- `uv run pytest tests/unit/tools/live/test_kb_identity_client.py tests/unit/tools/live/test_verify_kb_identity.py -m "not live"`
- `uv run pytest tests/unit/test_verify_canonical_map_parser.py tests/integration/test_discovery_bridge_path_b.py tests/ipc/test_stdio_verify_dispatch.py -m "not live"`
- `uv run pytest tests/live/test_live_kb_identity.py -m "not live"`
- `uv run ruff check src tests`
- `uv run python scripts/docs_generate.py --check`
- `uv run ruff format --check src/ummaya/primitives/verify.py src/ummaya/tools/live tests/unit/tools/live tests/live/test_live_kb_identity.py src/ummaya/tools/discovery_bridge.py src/ummaya/tools/verify_canonical_map.py src/ummaya/tools/mvp_surface.py src/ummaya/tools/register_all.py`
- `uv run mypy src/ummaya/primitives/verify.py src/ummaya/tools/live`
- `uv run pytest -m "not live"`

Closes #2888