### PR TITLE
feat: add KFTC OpenGiro send adapters

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,1 +1,3 @@
-{"feature_directory": "specs/2798-data-go-kr-live-expansion"}
+{
+  "feature_directory": "specs/2799-kftc-opengiro-send"
+}

--- a/docs-site/public/_llm/generated/adapters.json
+++ b/docs-site/public/_llm/generated/adapters.json
@@ -251,6 +251,32 @@
     "tool_id": "mfds_easy_drug_info_lookup"
   },
   {
+    "docs_path": "docs/api/submit/kftc_opengiro.md",
+    "permission_tier": 2,
+    "primitive": "send",
+    "schema_path": "docs/api/schemas/mock_kftc_opengiro_bill_send_v1.json",
+    "source": "Mock — Send",
+    "tier": "mock",
+    "tool_id": "mock_kftc_opengiro_bill_send_v1"
+  },
+  {
+    "docs_path": "docs/api/submit/kftc_opengiro.md",
+    "permission_tier": 2,
+    "primitive": "send",
+    "schema_path": null,
+    "tier": "mock",
+    "tool_id": "mock_kftc_opengiro_bill_send_v1 / mock_kftc_opengiro_payment_send_v1"
+  },
+  {
+    "docs_path": "docs/api/submit/kftc_opengiro.md",
+    "permission_tier": 2,
+    "primitive": "send",
+    "schema_path": "docs/api/schemas/mock_kftc_opengiro_payment_send_v1.json",
+    "source": "Mock — Send",
+    "tier": "mock",
+    "tool_id": "mock_kftc_opengiro_payment_send_v1"
+  },
+  {
     "docs_path": "docs/api/submit/traffic_fine_pay.md",
     "permission_tier": 2,
     "primitive": "send",

--- a/docs-site/src/data/generated/adapters.json
+++ b/docs-site/src/data/generated/adapters.json
@@ -251,6 +251,32 @@
     "tool_id": "mfds_easy_drug_info_lookup"
   },
   {
+    "docs_path": "docs/api/submit/kftc_opengiro.md",
+    "permission_tier": 2,
+    "primitive": "send",
+    "schema_path": "docs/api/schemas/mock_kftc_opengiro_bill_send_v1.json",
+    "source": "Mock — Send",
+    "tier": "mock",
+    "tool_id": "mock_kftc_opengiro_bill_send_v1"
+  },
+  {
+    "docs_path": "docs/api/submit/kftc_opengiro.md",
+    "permission_tier": 2,
+    "primitive": "send",
+    "schema_path": null,
+    "tier": "mock",
+    "tool_id": "mock_kftc_opengiro_bill_send_v1 / mock_kftc_opengiro_payment_send_v1"
+  },
+  {
+    "docs_path": "docs/api/submit/kftc_opengiro.md",
+    "permission_tier": 2,
+    "primitive": "send",
+    "schema_path": "docs/api/schemas/mock_kftc_opengiro_payment_send_v1.json",
+    "source": "Mock — Send",
+    "tier": "mock",
+    "tool_id": "mock_kftc_opengiro_payment_send_v1"
+  },
+  {
     "docs_path": "docs/api/submit/traffic_fine_pay.md",
     "permission_tier": 2,
     "primitive": "send",

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -68,6 +68,8 @@ Every adapter spec follows the seven-section template in [`specs/1637-p6-docs-sm
 | Mock — Check | `mock_verify_geumyung_injeungseo` | `check` | mock | 2 | [verify/geumyung_injeungseo.md](./verify/geumyung_injeungseo.md) | [mock_verify_geumyung_injeungseo.json](./schemas/mock_verify_geumyung_injeungseo.json) |
 | Mock — Check | `mock_verify_ganpyeon_injeung` | `check` | mock | 2 | [verify/ganpyeon_injeung.md](./verify/ganpyeon_injeung.md) | [mock_verify_ganpyeon_injeung.json](./schemas/mock_verify_ganpyeon_injeung.json) |
 | Mock — Check | `mock_verify_mydata` | `check` | mock | 2 | [verify/mydata.md](./verify/mydata.md) | [mock_verify_mydata.json](./schemas/mock_verify_mydata.json) |
+| Mock — Send | `mock_kftc_opengiro_bill_send_v1` | `send` | mock | 2 | [submit/kftc_opengiro.md](./submit/kftc_opengiro.md) | [mock_kftc_opengiro_bill_send_v1.json](./schemas/mock_kftc_opengiro_bill_send_v1.json) |
+| Mock — Send | `mock_kftc_opengiro_payment_send_v1` | `send` | mock | 2 | [submit/kftc_opengiro.md](./submit/kftc_opengiro.md) | [mock_kftc_opengiro_payment_send_v1.json](./schemas/mock_kftc_opengiro_payment_send_v1.json) |
 | Mock — Send | `mock_traffic_fine_pay_v1` | `send` | mock | 2 | [submit/traffic_fine_pay.md](./submit/traffic_fine_pay.md) | [mock_traffic_fine_pay_v1.json](./schemas/mock_traffic_fine_pay_v1.json) |
 | Mock — Send | `mock_welfare_application_submit_v1` | `send` | mock | 2 | [submit/welfare_application.md](./submit/welfare_application.md) | [mock_welfare_application_submit_v1.json](./schemas/mock_welfare_application_submit_v1.json) |
 | Geocoding | `juso_adm_cd_lookup` | `locate` | live | 1 | [locate/index.md](./locate/index.md) | [juso_adm_cd_lookup.json](./schemas/juso_adm_cd_lookup.json) |
@@ -135,10 +137,12 @@ Every adapter spec follows the seven-section template in [`specs/1637-p6-docs-sm
 | `kakao_keyword_search` | Kakao Local keyword search | live | 1 | [locate/index.md](./locate/index.md) |
 | `sgis_adm_cd_lookup` | SGIS reverse geocoding | live | 1 | [locate/index.md](./locate/index.md) |
 
-### `send` (2 entries)
+### `send` (4 entries)
 
 | tool_id | Source | Tier | Permission | Spec |
 |---|---|---|---|---|
+| `mock_kftc_opengiro_bill_send_v1` | KFTC OpenGiro bill service (mock) | mock | 2 | [submit/kftc_opengiro.md](./submit/kftc_opengiro.md) |
+| `mock_kftc_opengiro_payment_send_v1` | KFTC OpenGiro payment service (mock) | mock | 2 | [submit/kftc_opengiro.md](./submit/kftc_opengiro.md) |
 | `mock_traffic_fine_pay_v1` | data.go.kr (mock) | mock | 2 | [submit/traffic_fine_pay.md](./submit/traffic_fine_pay.md) |
 | `mock_welfare_application_submit_v1` | KFTC MyData (mock) | mock | 2 | [submit/welfare_application.md](./submit/welfare_application.md) |
 

--- a/docs/api/schemas/mock_kftc_opengiro_bill_send_v1.json
+++ b/docs/api/schemas/mock_kftc_opengiro_bill_send_v1.json
@@ -1,0 +1,88 @@
+{
+  "$defs": {
+    "_OpaqueOutput": {
+      "additionalProperties": true,
+      "description": "Generic envelope wrapper for bridge-registered tools' outputs.",
+      "title": "_OpaqueOutput",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/mock_kftc_opengiro_bill_send_v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Typed params for the OpenGiro bill service fixture.",
+  "properties": {
+    "amount_krw": {
+      "anyOf": [
+        {
+          "maximum": 99999999,
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": 15000,
+      "description": "Bill amount in KRW. Required for create_bill.",
+      "title": "Amount Krw"
+    },
+    "bill_reference": {
+      "default": "MOCK-BILL-2026-001",
+      "description": "Biller-side bill reference. Fixture values may use MOCK/REJECT/EXPIRED.",
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Bill Reference",
+      "type": "string"
+    },
+    "due_date": {
+      "anyOf": [
+        {
+          "format": "date",
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": "2026-06-30",
+      "description": "Bill due date. Required for create_bill.",
+      "title": "Due Date"
+    },
+    "giro_no": {
+      "default": "1234567",
+      "description": "OpenGiro giro number from the biller contract.",
+      "maxLength": 32,
+      "minLength": 4,
+      "title": "Giro No",
+      "type": "string"
+    },
+    "live_probe_requested": {
+      "default": false,
+      "description": "Opt-in live probe flag. Fixture mode is used unless this is true.",
+      "title": "Live Probe Requested",
+      "type": "boolean"
+    },
+    "operation": {
+      "default": "create_bill",
+      "description": "OpenGiro bill operation to mirror.",
+      "enum": [
+        "create_bill",
+        "cancel_bill",
+        "check_payment_status"
+      ],
+      "title": "Operation",
+      "type": "string"
+    },
+    "payer_reference": {
+      "default": "MOCK-PAYER",
+      "description": "Sanitized payer reference for fixture correlation.",
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Payer Reference",
+      "type": "string"
+    }
+  },
+  "title": "mock_kftc_opengiro_bill_send_v1",
+  "type": "object"
+}

--- a/docs/api/schemas/mock_kftc_opengiro_payment_send_v1.json
+++ b/docs/api/schemas/mock_kftc_opengiro_payment_send_v1.json
@@ -1,0 +1,89 @@
+{
+  "$defs": {
+    "_OpaqueOutput": {
+      "additionalProperties": true,
+      "description": "Generic envelope wrapper for bridge-registered tools' outputs.",
+      "title": "_OpaqueOutput",
+      "type": "object"
+    }
+  },
+  "$id": "https://ummaya.example/api/schemas/mock_kftc_opengiro_payment_send_v1.json",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "Typed params for the OpenGiro payment service fixture.",
+  "properties": {
+    "amount_krw": {
+      "anyOf": [
+        {
+          "maximum": 99999999,
+          "minimum": 1,
+          "type": "integer"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": 15000,
+      "description": "Payment amount in KRW. Required for payment URL creation.",
+      "title": "Amount Krw"
+    },
+    "giro_no": {
+      "default": "1234567",
+      "description": "OpenGiro giro number from the biller contract.",
+      "maxLength": 32,
+      "minLength": 4,
+      "title": "Giro No",
+      "type": "string"
+    },
+    "live_probe_requested": {
+      "default": false,
+      "description": "Opt-in live probe flag. Fixture mode is used unless this is true.",
+      "title": "Live Probe Requested",
+      "type": "boolean"
+    },
+    "operation": {
+      "default": "create_link_payment_url",
+      "description": "OpenGiro payment operation to mirror.",
+      "enum": [
+        "create_inquiry_payment_url",
+        "create_input_payment_url",
+        "create_link_payment_url",
+        "query_payment_result"
+      ],
+      "title": "Operation",
+      "type": "string"
+    },
+    "payer_reference": {
+      "default": "MOCK-PAYER",
+      "description": "Sanitized payer reference for fixture correlation.",
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Payer Reference",
+      "type": "string"
+    },
+    "payment_reference": {
+      "default": "MOCK-PAY-2026-001",
+      "description": "Payment correlation reference. Fixture values may use MOCK/REJECT/EXPIRED.",
+      "maxLength": 64,
+      "minLength": 1,
+      "title": "Payment Reference",
+      "type": "string"
+    },
+    "redirect_return_url": {
+      "anyOf": [
+        {
+          "maxLength": 512,
+          "type": "string"
+        },
+        {
+          "type": "null"
+        }
+      ],
+      "default": null,
+      "description": "Operator-approved return URL for browser redirect fixtures.",
+      "title": "Redirect Return Url"
+    }
+  },
+  "title": "mock_kftc_opengiro_payment_send_v1",
+  "type": "object"
+}

--- a/docs/api/submit/kftc_opengiro.md
+++ b/docs/api/submit/kftc_opengiro.md
@@ -1,0 +1,142 @@
+---
+tool_id: mock_kftc_opengiro_bill_send_v1 / mock_kftc_opengiro_payment_send_v1
+primitive: send
+tier: mock
+permission_tier: 2
+---
+
+# KFTC OpenGiro Send Adapters
+
+## Overview
+
+Wraps the Korea Financial Telecommunications and Clearings Institute (KFTC) OpenGiro bill and payment OpenAPI surfaces as two UMMAYA `send` adapters. The adapters are fixture-backed now because the current developer-portal state is not live-ready: Callback URL registration is missing, API Key registration is blocked by that missing Callback URL, and gated OpenGiro documents remain access-denied.
+
+| Field | Value |
+|---|---|
+| Bill adapter | `mock_kftc_opengiro_bill_send_v1` |
+| Payment adapter | `mock_kftc_opengiro_payment_send_v1` |
+| Source | KFTC OpenGiro public OpenAPI pages |
+| Primitive | `send` |
+| Module | `src/ummaya/tools/mock/kftc/opengiro.py` |
+
+## Envelope
+
+Both adapters use the shared `SubmitInput` / `SubmitOutput` envelope. KFTC-specific vocabulary lives only in adapter params and `adapter_receipt`.
+
+### Bill params
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `operation` | `create_bill`, `cancel_bill`, `check_payment_status` | yes | OpenGiro bill service operation |
+| `giro_no` | `str` | yes | Biller giro number; receipts mask it |
+| `bill_reference` | `str` | yes | Biller-side reference; receipts hash it |
+| `amount_krw` | `int \| null` | create only | Bill amount |
+| `due_date` | `date \| null` | create only | Bill due date |
+| `payer_reference` | `str` | no | Sanitized fixture correlation reference |
+| `live_probe_requested` | `bool` | no | Rejects unless KFTC live readiness is fully configured |
+
+### Payment params
+
+| Field | Type | Required | Description |
+|---|---|---|---|
+| `operation` | `create_inquiry_payment_url`, `create_input_payment_url`, `create_link_payment_url`, `query_payment_result` | yes | OpenGiro payment service operation |
+| `giro_no` | `str` | yes | Biller giro number; receipts mask it |
+| `payment_reference` | `str` | yes | Payment correlation reference; receipts hash it |
+| `amount_krw` | `int \| null` | URL creation only | Payment amount |
+| `payer_reference` | `str` | no | Sanitized fixture correlation reference |
+| `redirect_return_url` | `str \| null` | no | Operator-approved browser return URL for fixtures |
+| `live_probe_requested` | `bool` | no | Rejects unless KFTC live readiness is fully configured |
+
+## Search hints
+
+- 한국어: `오픈지로`, `금융결제원`, `지로`, `부과`, `청구`, `납부`, `결제URL`, `납부결과`
+- English: `OpenGiro`, `KFTC`, `giro bill`, `bill issue`, `payment status`, `payment URL`, `payment result`
+
+## Endpoint
+
+- **Mode**: Fixture-backed mock-to-live
+- **Bill public source**: https://developers.kftc.or.kr/dev/openapi/open-giro/index
+- **Payment public source**: https://developers.kftc.or.kr/dev/openapi/open-giro/pay-service
+- **Developer starter workflow**: https://developers.kftc.or.kr/dev/starter/starter
+- **Service access notice**: https://developers.kftc.or.kr/dev/support/notice/all/detail?id=44&boardCtgCd=all
+
+Official target endpoints mirrored by the fixture:
+
+| Operation | Method | Target when live |
+|---|---|---|
+| Bill create | `POST` | `https://api.giro.or.kr/v1/bills/giro` |
+| Bill cancel | `POST` | `https://api.giro.or.kr/v1/bills/giro/cancel` |
+| Bill payment status | `GET` | `https://api.giro.or.kr/v1/bills/giro/payment-yn` |
+| Payment inquiry URL | `POST` | `https://api.giro.or.kr/v1/payments/giro-inqr-pay-url` |
+| Payment input URL | `POST` | `https://api.giro.or.kr/v1/payments/giro-inpt-pay-url` |
+| Payment link URL | `POST` | `https://api.giro.or.kr/v1/payments/link-pay-url` |
+| Payment result | `GET` | `https://api.giro.or.kr/v1/payments` |
+
+## Permission tier rationale
+
+OpenGiro bill and payment operations are side-effecting financial actions, so they map to `send`. UMMAYA does not invent a separate permission classification; each adapter cites the official KFTC developer page through `AdapterRealDomainPolicy.real_classification_url` and declares the citizen-facing gate as `send`.
+
+The adapters require `published_tier_minimum="geumyung_injeungseo_personal_aal2"` because the user-facing flow involves KFTC financial infrastructure and payment-adjacent action. The dispatcher enforces this tier before adapter invocation.
+
+## Worked example
+
+### Payment URL fixture input
+
+```json
+{
+  "tool_id": "mock_kftc_opengiro_payment_send_v1",
+  "params": {
+    "operation": "create_link_payment_url",
+    "giro_no": "1234567",
+    "payment_reference": "MOCK-PAY-2026-001",
+    "amount_krw": 25000
+  }
+}
+```
+
+### Payment URL fixture output
+
+```json
+{
+  "transaction_id": "urn:ummaya:send:<sha256>",
+  "status": "pending",
+  "adapter_receipt": {
+    "receipt_ref": "MOCK-OG-PAY-<hash>",
+    "service": "payment",
+    "operation": "create_link_payment_url",
+    "upstream_rsp_code": "A0000",
+    "status_detail": "payment_url_issued",
+    "giro_no_masked": "123***67",
+    "reference_hash": "<sha256[:16]>",
+    "payment_url": "https://mock.open-giro.ummaya.local/pay/<hash>",
+    "mock": true,
+    "_mode": "mock"
+  }
+}
+```
+
+## Operator setup
+
+Live probing remains disabled until all readiness checks pass:
+
+1. OpenGiro service application is complete in the KFTC developer portal.
+2. The operator registers the deployment-specific Callback URL.
+3. OpenGiro `부과서비스` and `납부서비스` are registered to the API Key.
+4. `UMMAYA_KFTC_OPENGIRO_CLIENT_ID` and `UMMAYA_KFTC_OPENGIRO_CLIENT_SECRET` are provided through operator secret storage, never repository files.
+5. KFTC access token material is obtained outside CI and redacted from evidence.
+6. Gated OpenGiro documents are accessible.
+7. `UMMAYA_KFTC_OPENGIRO_LIVE_PROBE_ENABLED=true` is set only for a manual live probe.
+
+The canonical callback path documented for operators is:
+
+```text
+https://<operator-host>/auth/kftc/opengiro/callback
+```
+
+## Constraints
+
+- Default tests and CI must not call KFTC.
+- Do not click or capture the KFTC Client Secret in browser automation.
+- `live_probe_requested=true` returns `setup_blocked` unless all UMMAYA_KFTC readiness settings are complete.
+- Receipts mask `giro_no` and hash bill/payment references.
+- Fixture paths cover success, validation failure, missing setup, rejected, and expired payment URL outcomes.

--- a/specs/2799-kftc-opengiro-send/checklists/requirements.md
+++ b/specs/2799-kftc-opengiro-send/checklists/requirements.md
@@ -1,0 +1,34 @@
+# Specification Quality Checklist: KFTC OpenGiro Send Adapter
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-05-18  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Validation pass 1 completed on 2026-05-18. The spec intentionally names KFTC OpenGiro as the external business channel and UMMAYA `send` as the product primitive; implementation details are deferred to planning artifacts.

--- a/specs/2799-kftc-opengiro-send/contracts/live-probe-evidence-contract.md
+++ b/specs/2799-kftc-opengiro-send/contracts/live-probe-evidence-contract.md
@@ -1,0 +1,20 @@
+# Contract: Future Live Probe Evidence
+
+Live KFTC OpenGiro execution is not complete in this epic. A future live-validation task must capture sanitized direct-curl evidence before flipping any adapter from mock to live.
+
+## Required Evidence Per Endpoint
+
+| Evidence | Requirement |
+|---|---|
+| Official endpoint URL | Must match KFTC public or approved gated documentation |
+| HTTP method | Must match KFTC documentation |
+| Request headers | Authorization/token values redacted |
+| Request body/query | Personal identifiers and financial account data redacted |
+| Response headers | Stored with sensitive values redacted |
+| Response body | Stored with tokens, payment URLs, and personal identifiers redacted or fixture-replaced |
+| Result classification | Map to `pending`, `succeeded`, `failed`, or `rejected` with rationale |
+
+## Default CI Rule
+
+Live probe artifacts are evidence only. CI tests must use fixtures and must not call KFTC.
+

--- a/specs/2799-kftc-opengiro-send/contracts/opengiro-send-contract.md
+++ b/specs/2799-kftc-opengiro-send/contracts/opengiro-send-contract.md
@@ -1,0 +1,64 @@
+# Contract: OpenGiro Send Adapters
+
+## Adapter IDs
+
+- `mock_kftc_opengiro_bill_send_v1`
+- `mock_kftc_opengiro_payment_send_v1`
+
+The `mock_` prefix is mandatory until KFTC Callback URL, API Key, and sanitized direct-curl evidence are complete.
+
+## Input Envelope
+
+The shared primitive envelope remains:
+
+```json
+{
+  "tool_id": "mock_kftc_opengiro_payment_send_v1",
+  "params": {
+    "operation": "create_link_payment_url",
+    "payment_reference": "FIXTURE-PAY-2026-001",
+    "amount_krw": 12000
+  }
+}
+```
+
+Domain-specific fields are allowed only inside `params`.
+
+## Output Envelope
+
+The adapter returns `SubmitOutput`:
+
+```json
+{
+  "transaction_id": "urn:ummaya:send:<sha256>",
+  "status": "pending",
+  "adapter_receipt": {
+    "source": "kftc_opengiro_fixture",
+    "operation": "create_link_payment_url",
+    "rsp_code": "A0000",
+    "rsp_message": "fixture accepted",
+    "status_detail": "pending_external_payment",
+    "next_redirect_url": "https://www.giro.or.kr/open/apipay.do?T=fixture",
+    "expires_in_seconds": 600,
+    "mock": true,
+    "_actual_endpoint_when_live": "https://api.giro.or.kr/v1/payments/link-pay-url"
+  }
+}
+```
+
+## Status Mapping
+
+| OpenGiro condition | `SubmitStatus` | Receipt `status_detail` |
+|---|---|---|
+| Fixture accepted and awaits external citizen payment | `pending` | `pending_external_payment` |
+| Fixture accepted for bill creation/cancellation | `succeeded` | `accepted` |
+| Validation/setup blocker | `rejected` | `setup_blocked` |
+| Upstream-style rejection fixture | `rejected` | `rejected` |
+| Expired payment URL fixture | `failed` | `expired` |
+
+## Source URLs
+
+- Bill service: `https://developers.kftc.or.kr/dev/openapi/open-giro/index`
+- Payment service: `https://developers.kftc.or.kr/dev/openapi/open-giro/pay-service`
+- Starter/setup flow: `https://developers.kftc.or.kr/dev/starter/starter`
+

--- a/specs/2799-kftc-opengiro-send/contracts/operator-setup-contract.md
+++ b/specs/2799-kftc-opengiro-send/contracts/operator-setup-contract.md
@@ -1,0 +1,30 @@
+# Contract: KFTC OpenGiro Operator Setup
+
+## Required Setup States
+
+| Step | Required Evidence | Secret Handling |
+|---|---|---|
+| OpenGiro service application | Portal row shows `오픈지로` as `이용중` | No secret involved |
+| Callback URL registration | Portal shows at least one operator-approved Callback URL | Do not embed secrets in URL |
+| API Key registration | OpenGiro `부과서비스` and `납부서비스` show API Key registered | Do not reveal Client Secret in screenshots |
+| Secret provisioning | `UMMAYA_KFTC_OPENGIRO_CLIENT_ID` and secret counterpart exist in operator storage | Never commit `.env` or print values |
+| Live probe readiness | Sanitized curl headers/body stored in feature evidence path | Redact Authorization, Client Secret, tokens, personal identifiers |
+
+## Canonical Callback Path
+
+The documented deployment path is:
+
+```text
+https://<operator-gateway-host>/auth/kftc/opengiro/callback
+```
+
+For local development, an operator may choose a localhost URL only when the local callback server exists and the portal account owner accepts that environment-specific registration.
+
+## Fail-Closed Behavior
+
+- Missing Callback URL: report setup blocker.
+- Missing API Key registration: report setup blocker.
+- Missing Client ID or Client Secret: report setup blocker.
+- Missing access token: report setup blocker.
+- Gated KFTC documents inaccessible: keep fixture mode and mark live validation incomplete.
+

--- a/specs/2799-kftc-opengiro-send/data-model.md
+++ b/specs/2799-kftc-opengiro-send/data-model.md
@@ -1,0 +1,92 @@
+# Data Model: KFTC OpenGiro Send Adapter
+
+## Entity: OpenGiroSetupReadiness
+
+Represents whether the KFTC developer portal and UMMAYA operator environment are ready for live OpenGiro probing.
+
+| Field | Type | Validation |
+|---|---|---|
+| `service_status` | `Literal["not_requested", "pending", "active"]` | `active` maps to portal `이용중` |
+| `callback_url_registered` | `bool` | Must be true before API Key registration is considered ready |
+| `api_key_registered` | `bool` | Must be true before live token or API probes |
+| `documents_accessible` | `bool` | False when `/dev/doc/open-giro` access is denied |
+| `tool_accessible` | `bool` | False when portal test tools are unavailable |
+| `last_checked_at` | `datetime` | UTC timestamp |
+| `blockers` | `tuple[str, ...]` | Sanitized messages only; no secrets |
+
+## Entity: OpenGiroBillParams
+
+Adapter-specific input model for `mock_kftc_opengiro_bill_send_v1`.
+
+| Field | Type | Required | Validation |
+|---|---|---|---|
+| `operation` | `Literal["create_bill", "cancel_bill", "check_payment_status"]` | yes | Selects the bill-service fixture path |
+| `giro_no` | `str` | yes | 1-32 chars, fixture-safe identifier |
+| `bill_reference` | `str | None` | conditional | Required for create/cancel fixture flows |
+| `amount_krw` | `int | None` | conditional | Required for create; 0 < amount <= 10,000,000 |
+| `payer_label` | `str | None` | no | Sanitized display label, max 64 chars |
+| `due_date` | `date | None` | no | ISO date; fixture validation only |
+
+## Entity: OpenGiroPaymentParams
+
+Adapter-specific input model for `mock_kftc_opengiro_payment_send_v1`.
+
+| Field | Type | Required | Validation |
+|---|---|---|---|
+| `operation` | `Literal["create_inquiry_payment_url", "create_input_payment_url", "create_link_payment_url", "query_payment_result"]` | yes | Selects payment-service fixture path |
+| `giro_no` | `str | None` | conditional | Required for giro-based URL flows |
+| `payment_reference` | `str` | yes | 1-64 chars, fixture-safe identifier |
+| `amount_krw` | `int | None` | conditional | Required for URL creation, 0 < amount <= 10,000,000 |
+| `redirect_hint` | `str | None` | no | Non-secret label or fixture redirect hint; never a real secret-bearing URL |
+
+## Entity: OpenGiroReceipt
+
+Domain-specific data nested under `SubmitOutput.adapter_receipt`.
+
+| Field | Type | Validation |
+|---|---|---|
+| `source` | `Literal["kftc_opengiro_fixture"]` | Required in this epic |
+| `operation` | `str` | Echoes the operation |
+| `rsp_code` | `str` | Fixture response code, e.g. `A0000` |
+| `rsp_message` | `str` | Sanitized response message |
+| `status_detail` | `Literal["accepted", "pending_external_payment", "rejected", "expired", "setup_blocked"]` | Maps into `SubmitStatus` |
+| `next_redirect_url` | `str | None` | Fixture URL only; real URLs are not stored in CI artifacts |
+| `expires_in_seconds` | `int | None` | Payment URL expiry metadata when applicable |
+| `mock` | `bool` | Always true in this epic |
+| `_reference_implementation` | `str` | Transparency field |
+| `_actual_endpoint_when_live` | `str` | Official KFTC target URL |
+| `_security_wrapping_pattern` | `str` | OAuth/API-key/callback pattern |
+| `_policy_authority` | `str` | Official KFTC URL |
+| `_international_reference` | `str` | Reference analog |
+
+## State Transitions
+
+### Setup readiness
+
+```text
+not_requested -> active
+active -> callback_missing
+callback_missing -> api_key_missing
+api_key_missing -> ready_for_sanitized_live_probe
+ready_for_sanitized_live_probe -> live_validated
+```
+
+This epic stops at `callback_missing` or `api_key_missing` unless the operator completes portal setup outside the agent flow and provides sanitized evidence.
+
+### Payment URL lifecycle
+
+```text
+created -> pending_external_payment -> settled
+created -> expired
+created -> rejected
+```
+
+Fixture tests cover `created`, `expired`, and `rejected`. Real `settled` confirmation is deferred until KFTC live evidence exists.
+
+## Validation Rules
+
+- New input models use `ConfigDict(frozen=True, extra="forbid")`.
+- Adapter functions accept `dict[str, object]` from the `send` dispatcher and validate with their Pydantic input model.
+- No top-level `SubmitInput` or `SubmitOutput` field changes.
+- No raw Client Secret, token, authorization code, or personal financial identifier may be stored in any model dump used by tests.
+

--- a/specs/2799-kftc-opengiro-send/dispatch-tree.md
+++ b/specs/2799-kftc-opengiro-send/dispatch-tree.md
@@ -1,0 +1,17 @@
+# Dispatch Tree: KFTC OpenGiro Send Adapter
+
+This feature is implemented Lead-solo in the current Codex environment.
+
+Reason: the task set touches credential-sensitive KFTC readiness, one coupled adapter module, schema generation, and count assertions. AGENTS.md prefers Sonnet teammates for 3+ independent tasks, but this session has no Sonnet subagent target available and the write set is tightly coupled.
+
+```text
+Phase 1 Setup (T001-T003): Lead solo
+Phase 2 Foundational (T004-T007): Lead solo
+Phase 3 US1 classification (T008-T010): Lead solo
+Phase 4 US2 credential path (T011-T014): Lead solo
+Phase 5 US3 send invocation (T015-T019): Lead solo
+Phase 6 US4 evidence/schema (T020-T023): Lead solo
+Phase 7 validation (T024-T027): Lead solo
+```
+
+No worker receives independent write ownership in this run. The implementation still follows the tasks.md ordering and marks tasks complete only after verification.

--- a/specs/2799-kftc-opengiro-send/evidence/README.md
+++ b/specs/2799-kftc-opengiro-send/evidence/README.md
@@ -1,0 +1,27 @@
+# KFTC OpenGiro Evidence
+
+## Official Sources
+
+| Source | URL | Evidence used |
+|---|---|---|
+| Developer starter workflow | `https://developers.kftc.or.kr/dev/starter/starter` | Service application, API Key creation, Callback URL registration, token issuance, and REST test tool sequence |
+| OpenGiro bill service | `https://developers.kftc.or.kr/dev/openapi/open-giro/index` | Public bill endpoint group for create, cancel, and payment-status inquiry |
+| OpenGiro payment service | `https://developers.kftc.or.kr/dev/openapi/open-giro/pay-service` | Public payment URL and payment-result endpoint group |
+| OpenGiro access notice | `https://developers.kftc.or.kr/dev/support/notice/all/detail?id=44&boardCtgCd=all` | OpenGiro OpenAPI is public; documents/materials need approval |
+| OpenGiro launch notice | `https://developers.kftc.or.kr/dev/support/notice/all/detail?id=45&boardCtgCd=all` | Historical launch support only |
+
+## Portal State Observed 2026-05-18
+
+| Portal area | State | Handling |
+|---|---|---|
+| `MY PAGE > 내 서비스 관리` | OpenGiro is `이용중` after user-directed service application | Recorded as readiness evidence |
+| `API Key 관리` | Client ID visible, Client Secret masked, OpenGiro `부과서비스` and `납부서비스` listed | Secret was not revealed or copied |
+| API Key registration | `등록된 Callback URL 이 없습니다.` | Live probe blocked until operator registers Callback URL |
+| `문서 > 오픈지로` | Access denied | Do not invent gated spec |
+| `지원 > 자료실` search `오픈지로` | 0 results | Public documents not found through 자료실 |
+
+## Sanitization Rules
+
+- No Client Secret, access token, authorization code, raw `Authorization` header, or raw personal financial identifier may be committed.
+- Direct `curl` evidence is required before any future live conversion, with headers and personal identifiers redacted.
+- Default verification remains fixture-only.

--- a/specs/2799-kftc-opengiro-send/plan.md
+++ b/specs/2799-kftc-opengiro-send/plan.md
@@ -1,0 +1,113 @@
+# Implementation Plan: KFTC OpenGiro Send Adapter
+
+**Branch**: `2799-kftc-opengiro-send` | **Date**: 2026-05-18 | **Spec**: [spec.md](./spec.md)  
+**Input**: Feature specification from `specs/2799-kftc-opengiro-send/spec.md`  
+**Epic**: [#2951](https://github.com/umyunsang/UMMAYA/issues/2951) under Initiative [#2290](https://github.com/umyunsang/UMMAYA/issues/2290)
+
+## Summary
+
+Add a KFTC OpenGiro `send` adapter family as a credential-blocked mock-to-live surface: official KFTC OpenGiro public pages define bill and payment endpoints, but the logged-in developer portal currently blocks API Key registration until a Callback URL is registered and keeps OpenGiro documents access-denied. Per UMMAYA's adapter rule, this feature therefore ships fixture-backed, source-cited `send` adapters and operator setup/evidence artifacts now, while keeping live OpenGiro execution fail-closed until KFTC callback/API-key readiness and sanitized direct-curl evidence exist.
+
+The implementation reuses UMMAYA's existing `send` sub-registry, deterministic `SubmitOutput` envelope, discovery bridge, schema builder, and mock transparency stamping. It does not add a new primitive or live financial gateway route in this epic.
+
+## Technical Context
+
+**Language/Version**: Python 3.12+ (existing backend baseline; no version bump)  
+**Primary Dependencies**: Existing `pydantic` v2, `pydantic-settings`, `httpx`, `pytest`, `pytest-asyncio`, stdlib `logging`; no new runtime dependencies  
+**Storage**: No persistent storage changes. Operator secrets remain in UMMAYA-prefixed environment variables or operator secret storage outside the repo. Fixture artifacts live under repository test/docs paths and contain no live KFTC secrets.  
+**Testing**: `uv run pytest` focused tests; schema check via `uv run python scripts/build_schemas.py --check`; no live KFTC calls in default tests or CI  
+**Target Platform**: macOS/Linux developer workstations and GitHub Actions Ubuntu CI for fixture-only verification  
+**Project Type**: Single Python package plus docs/tests  
+**Performance Goals**: Adapter fixture invocation remains sub-10 ms excluding test harness overhead; schema generation remains deterministic; no external network call in default test path  
+**Constraints**: Secret-safe, fail-closed, no `Any` in new I/O schemas, stdlib `logging` only, English source text except Korean domain data, no CI live calls, no arbitrary Callback URL portal registration by the agent  
+**Scale/Scope**: Two `send` adapters for OpenGiro modules: bill service and payment service. One operator setup/readiness guide. One official-source evidence matrix. JSON Schema exports and docs catalog updates.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Status | Evaluation |
+|---|---|---|
+| **I. Reference-Driven Development** | PASS | Research maps decisions to `docs/vision.md`, `docs/requirements/ummaya-migration-tree.md`, restored Claude Code OAuth callback/deps patterns, existing UMMAYA `send` implementation, and official KFTC developer pages. |
+| **II. Fail-Closed Security** | PASS | KFTC live credentials are not read from the browser or committed. Adapter policy cites KFTC official pages. Missing Callback/API-key readiness returns setup blockers. |
+| **III. Pydantic v2 Strict Typing** | PASS | New adapter input models use frozen Pydantic v2 models with explicit fields. Outputs reuse `SubmitOutput`. No `Any` in new I/O schemas. |
+| **IV. Government API Compliance** | PASS | No live KFTC calls in CI. Live probing remains marked and blocked until operator readiness evidence exists. Rate limits and credentials are explicit. |
+| **V. Policy Alignment** | PASS | Supports Korea AX public-service integration through a single UMMAYA conversational surface while preserving consent and explainability. |
+| **VI. Deferred Work Accountability** | PASS | Spec deferred table contains three tracked follow-up issues created by `/speckit-taskstoissues`: #2979, #2980, and #2981. No untracked deferral prose remains. |
+
+**Gate verdict**: PASS pre-research and PASS post-design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/2799-kftc-opengiro-send/
+├── spec.md
+├── plan.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+├── checklists/
+│   └── requirements.md
+├── contracts/
+│   ├── opengiro-send-contract.md
+│   ├── operator-setup-contract.md
+│   └── live-probe-evidence-contract.md
+└── tasks.md
+```
+
+### Source Code (repository root)
+
+```text
+src/ummaya/
+├── settings.py                         # add UMMAYA_KFTC_* non-secret and secret settings
+├── tools/
+│   ├── models.py                       # add KFTC ministry enum
+│   ├── mock/__init__.py                # import KFTC OpenGiro fixture-backed send adapters
+│   └── mock/kftc/
+│       ├── __init__.py
+│       └── opengiro.py                 # bill + payment send adapters, fixture-first
+└── primitives/submit.py                # no shape change; reused by adapters
+
+docs/api/
+├── README.md                           # add KFTC OpenGiro rows under send
+├── submit/kftc_opengiro.md             # seven-section adapter doc
+└── schemas/
+    ├── mock_kftc_opengiro_bill_send_v1.json
+    └── mock_kftc_opengiro_payment_send_v1.json
+
+tests/
+├── unit/tools/test_mock_kftc_opengiro.py
+├── integration/test_kftc_opengiro_discovery.py
+└── lint/test_kftc_secret_redaction.py
+```
+
+**Structure Decision**: Keep the work in the existing mock/send adapter architecture because KFTC credentials are not live-ready. The adapter IDs use the `mock_` prefix until sanitized live evidence exists; the public KFTC endpoint URLs are still recorded as the official target surface for mock-to-live migration.
+
+## Complexity Tracking
+
+No constitution violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |
+
+## Phase 0: Outline & Research - completed
+
+See [research.md](./research.md). Key decisions:
+
+1. OpenGiro maps to `send`, not `find`, because bill/payment operations are financial side effects.
+2. The implementation must be fixture-backed and `mock_`-prefixed now because Callback URL and API Key registration are not complete.
+3. Two adapters are cleaner than one operation-switching adapter: OpenGiro bill service and OpenGiro payment service are separate KFTC modules with different endpoint groups.
+4. No arbitrary portal Callback URL will be registered in this epic. Operator setup documents the canonical callback expectation and leaves portal registration to the deployment owner.
+5. Live `send` gateway generalization remains deferred because current live gateway code only allows `find`/`locate`.
+
+## Phase 1: Design & Contracts - completed
+
+See [data-model.md](./data-model.md), [contracts/](./contracts/), and [quickstart.md](./quickstart.md). Summary:
+
+- `OpenGiroBillParams` covers bill creation, bill cancellation, and payment-status inquiry fixture shapes.
+- `OpenGiroPaymentParams` covers payment URL creation and payment result inquiry fixture shapes.
+- `OpenGiroSetupReadiness` documents service, callback, key registration, document access, and tool access state.
+- Contracts define the send adapter behavior, operator setup flow, and required live-probe evidence before any future live enablement.

--- a/specs/2799-kftc-opengiro-send/quickstart.md
+++ b/specs/2799-kftc-opengiro-send/quickstart.md
@@ -1,0 +1,59 @@
+# Quickstart: KFTC OpenGiro Send Adapter
+
+## 1. Verify Portal Readiness
+
+Expected current state from 2026-05-18:
+
+- OpenGiro service: `이용중`
+- Callback URL: missing
+- API Key registration: blocked by missing Callback URL
+- OpenGiro documents: access denied
+- 자료실 search for `오픈지로`: 0 results
+
+Do not click Client Secret 조회.
+
+## 2. Run Fixture Verification
+
+```bash
+uv run pytest tests/unit/tools/test_mock_kftc_opengiro.py \
+  tests/integration/test_kftc_opengiro_discovery.py \
+  tests/lint/test_kftc_secret_redaction.py
+```
+
+## 3. Check Schemas
+
+```bash
+uv run python scripts/build_schemas.py --check
+```
+
+## 4. Expected Send Fixture Shape
+
+```python
+from ummaya.primitives.submit import send
+import ummaya.tools.mock.kftc.opengiro  # import registers adapters
+
+result = await send(
+    "mock_kftc_opengiro_payment_send_v1",
+    {
+        "operation": "create_link_payment_url",
+        "payment_reference": "FIXTURE-PAY-2026-001",
+        "amount_krw": 12000,
+    },
+    auth_context=<AAL2 auth context>,
+)
+```
+
+Expected result:
+
+- `transaction_id` starts with `urn:ummaya:send:`
+- `status` is `pending`
+- `adapter_receipt.mock` is `true`
+- `adapter_receipt._actual_endpoint_when_live` points to the official KFTC endpoint
+
+## 5. Future Live-Probe Gate
+
+Only after the operator registers the real Callback URL and API Key:
+
+1. Run direct `curl` probes manually against KFTC with secrets redacted from saved artifacts.
+2. Store sanitized request/response evidence under this feature's evidence path.
+3. Update the adapter from `mock_` to live in a follow-up task after the evidence passes review.

--- a/specs/2799-kftc-opengiro-send/research.md
+++ b/specs/2799-kftc-opengiro-send/research.md
@@ -1,0 +1,89 @@
+# Research: KFTC OpenGiro Send Adapter
+
+## Reference Bootstrap
+
+- **UMMAYA thesis/docs**: `docs/vision.md` Layer 2 states each public-service channel is a schema-driven tool module with fail-closed defaults; `docs/requirements/ummaya-migration-tree.md` fixes active primitives as `find`, `locate`, `send`, `check`.
+- **Claude Code restored source**: `.references/claude-code-sourcemap/restored-src/src/query/deps.ts` supports explicit dependency injection; `.references/claude-code-sourcemap/restored-src/src/services/oauth/auth-code-listener.ts` shows callback capture as a narrow listener that validates `state`; `.references/claude-code-sourcemap/restored-src/src/services/oauth/client.ts` shows redirect URI and token exchange are separate phases.
+- **UMMAYA adapter sources**: `src/ummaya/primitives/submit.py` defines the `send` envelope and deterministic transaction id; `src/ummaya/tools/mock/data_go_kr/fines_pay.py` is the nearest existing financial send mock; `src/ummaya/tools/discovery_bridge.py` bridges send/check mock adapters into discovery; `scripts/build_schemas.py` exports send schemas.
+- **External primary sources**: KFTC developer site public OpenGiro bill and payment pages; KFTC developer site starter guide; KFTC service-access notice; logged-in portal state observed through Computer Use on 2026-05-18.
+- **Implementation constraints**: No live KFTC call in CI; no Client Secret lookup or storage; no arbitrary Callback URL registration; no live financial `send` gateway expansion in this epic.
+- **Blocked evidence**: `/dev/doc/open-giro` still shows "접근 권한이 없습니다. 관리자에게 문의해 주세요."; API Key registration shows "등록된 Callback URL 이 없습니다."; 자료실 `오픈지로` search returns 0 results.
+
+## Decision 1: Map OpenGiro to `send`
+
+**Decision**: KFTC OpenGiro bill and payment modules are `send` adapters.
+
+**Rationale**: Public OpenGiro pages expose bill creation/cancellation and payment URL/result flows. These are financial or payment-adjacent side effects, not read-only public-data lookups. UMMAYA's `send` envelope already absorbs write transactions and produces `SubmitOutput`.
+
+**Alternatives considered**:
+- `find`: rejected because payment URL creation and bill registration are not read-only.
+- New `pay` primitive: rejected because `send` is the active reserved write primitive.
+
+## Decision 2: Ship fixture-backed `mock_` adapters now
+
+**Decision**: Implement `mock_kftc_opengiro_bill_send_v1` and `mock_kftc_opengiro_payment_send_v1` as official-shape, fixture-backed adapters.
+
+**Rationale**: The user account has OpenGiro service in `이용중`, but API Key registration is blocked until a Callback URL exists. KFTC documents remain gated. AGENTS.md states: public API plus credential becomes Live; channel exists but no credential/access becomes Mock mirroring the reference shape. The correct status today is mock-to-live, not live.
+
+**Alternatives considered**:
+- Register a live adapter that silently returns fixture data: rejected because it would blur real settlement with mock behavior.
+- Register a live adapter and attempt calls with incomplete credentials: rejected by the direct-curl evidence rule and KFTC portal blocker.
+
+## Decision 3: Use two adapters for the two OpenGiro modules
+
+**Decision**: Use two send adapters: bill service and payment service.
+
+**Rationale**: KFTC presents OpenGiro as two modules: `부과서비스` and `납부서비스`. They have different operation sets and field groups. Two adapters keep schemas smaller and make discovery more precise while still belonging to one OpenGiro feature family.
+
+**Alternatives considered**:
+- One `operation`-switching mega-adapter: rejected because it would mix bill and payment schemas and weaken validation.
+- One adapter per endpoint: rejected as too granular for the LLM tool surface.
+
+## Decision 4: Canonical operator setup before live probing
+
+**Decision**: Document a canonical UMMAYA callback path and setup readiness checklist, but do not register a Callback URL in the portal during this implementation.
+
+**Rationale**: Registering a portal Callback URL changes third-party persistent account configuration. The deployment owner must choose the real gateway host. The agent should not store or reveal Client Secret values. The contract should tell operators exactly what readiness evidence is required.
+
+**Alternatives considered**:
+- Register `http://localhost:8000/auth/kftc/callback`: rejected because it may be wrong for production and the current UMMAYA gateway has no KFTC callback route.
+- Click Client Secret 조회: rejected because secret retrieval is unnecessary and unsafe.
+
+## Decision 5: Do not expand live adapter gateway in this epic
+
+**Decision**: Keep live gateway send support deferred.
+
+**Rationale**: `src/ummaya/gateway/app.py` and `src/ummaya/tools/live_proxy.py` currently constrain operator-managed live proxy calls to `find` and `locate`. Financial `send` gateway semantics need idempotency, irreversible-action handling, credential isolation, and stronger operator review. This feature can prepare fixture-backed adapters and setup docs without changing that architecture.
+
+**Alternatives considered**:
+- Add `send` to proxyable primitives now: rejected because it is a high-risk cross-cutting gateway change.
+
+## Official KFTC Evidence Matrix
+
+| Surface | Official URL | Evidence Used | Feature Decision |
+|---|---|---|---|
+| Developer starter workflow | `https://developers.kftc.or.kr/dev/starter/starter` | Service application, API Key creation, Callback URL registration, API Key registration, token issuance, REST API test tool sequence | Operator setup guide |
+| OpenGiro bill service | `https://developers.kftc.or.kr/dev/openapi/open-giro/index` | `POST /v1/bills/giro`, `POST /v1/bills/giro/cancel`, `GET /v1/bills/giro/payment-yn` documented on public page | Bill send adapter |
+| OpenGiro payment service | `https://developers.kftc.or.kr/dev/openapi/open-giro/pay-service` | `POST /v1/payments/giro-inqr-pay-url`, `POST /v1/payments/giro-inpt-pay-url`, `POST /v1/payments/link-pay-url`, `GET /v1/payments` documented on public page | Payment send adapter |
+| Service access notice | `https://developers.kftc.or.kr/dev/support/notice/all/detail?id=44&boardCtgCd=all` | OpenGiro OpenAPI public; document/material access approval required; contact channel `opengiro@kftc.or.kr` observed in prior CUA research | Gated-doc blocker |
+| OpenGiro launch notice | `https://developers.kftc.or.kr/dev/support/notice/all/detail?id=45&boardCtgCd=all` | Service added 2021-02-05, no attachment | Historical support only |
+
+## Portal Readiness Evidence - 2026-05-18
+
+| Portal Area | Observed State | Security Handling |
+|---|---|---|
+| `MY PAGE > 내 서비스 관리` | OpenGiro changed from `신청` to `이용중` | State change performed under user direction |
+| `API Key 관리` | Client ID visible; Client Secret masked; OpenGiro APIs listed as `부과서비스`, `납부서비스` | Secret 조회 was not clicked |
+| API Key registration | Clicking `등록` showed `등록된 Callback URL 이 없습니다.` | Treat as setup blocker |
+| `문서 > 오픈지로` | Access denied alert | Do not invent gated spec |
+| `지원 > 자료실` search for `오픈지로` | 0 results | Public docs not available through 자료실 |
+
+## Deferred Item Validation
+
+Spec deferred table has three tracked follow-up issues:
+
+1. #2979: Production financial settlement confirmation beyond documented redirect/result APIs.
+2. #2980: General live `send` gateway support for all financial adapters.
+3. #2981: Additional KFTC services beyond OpenGiro.
+
+All three are represented in the Deferred Items table and were converted to GitHub tracking issues by `/speckit-taskstoissues`.

--- a/specs/2799-kftc-opengiro-send/spec.md
+++ b/specs/2799-kftc-opengiro-send/spec.md
@@ -1,0 +1,141 @@
+# Feature Specification: KFTC OpenGiro Send Adapter
+
+**Feature Branch**: `2799-kftc-opengiro-send`  
+**Created**: 2026-05-18  
+**Status**: Draft  
+**Input**: User description: "Wrap the KFTC OpenGiro official billing and payment OpenAPI as a UMMAYA send primitive live adapter. Use the logged-in KFTC developer site evidence, preserve UMMAYA's Claude Code-style tool loop, avoid secret leakage, respect the official Callback URL and API Key workflow, and move through the full Spec Kit pipeline without further review prompts."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Classify OpenGiro as a Send Channel (Priority: P1)
+
+A maintainer can decide, from official KFTC evidence and UMMAYA's primitive model, whether OpenGiro belongs in the live tool system and which citizen-facing action it represents.
+
+**Why this priority**: UMMAYA must not add a financial side-effecting adapter without proving the official channel exists and mapping it to the correct primitive and permission gate.
+
+**Independent Test**: Review the feature evidence and adapter catalog update; confirm that OpenGiro is documented as a `send` channel, that read-only discovery is not used for payment actions, and that the source links point to official KFTC developer pages.
+
+**Acceptance Scenarios**:
+
+1. **Given** the KFTC OpenGiro public OpenAPI pages list bill and payment endpoints, **When** UMMAYA documents the candidate adapter, **Then** it classifies OpenGiro bill creation, bill cancellation, payment URL creation, and payment result inquiry under a financial `send` surface with explicit irreversible-action handling where applicable.
+2. **Given** the KFTC developer portal requires service application, Callback URL registration, and API Key registration before testing, **When** the adapter readiness is documented, **Then** the spec marks credentialed live execution as blocked until those official portal steps are complete and evidence is captured without exposing secrets.
+
+---
+
+### User Story 2 - Register a Safe KFTC Credential Path (Priority: P1)
+
+An operator can prepare OpenGiro credentials for UMMAYA without revealing Client Secret values in source, logs, specs, screenshots, or test artifacts.
+
+**Why this priority**: The KFTC portal exposes persistent API credentials and callback configuration; mishandling them would create a long-lived financial API risk.
+
+**Independent Test**: Run credential-path tests and inspect generated artifacts; no Client Secret value appears, Callback URL requirements are documented, and the system fails closed when credentials or callback setup are missing.
+
+**Acceptance Scenarios**:
+
+1. **Given** OpenGiro service is `이용중` but no Callback URL is registered, **When** an operator tries to register the API Key or run a live adapter probe, **Then** UMMAYA reports the missing Callback URL/API Key readiness as a setup blocker instead of attempting a live call.
+2. **Given** a Client ID and masked Client Secret are available in the portal, **When** the operator configures UMMAYA, **Then** only environment variables or operator secret storage are used and no secret value is written to repository files or CI logs.
+3. **Given** a Callback URL is required by KFTC, **When** UMMAYA documents the setup path, **Then** it names one canonical callback path and states that registering it in the KFTC portal is an operator action tied to the configured deployment environment.
+
+---
+
+### User Story 3 - Invoke OpenGiro Through the Send Envelope (Priority: P2)
+
+A citizen-facing UMMAYA session can request an OpenGiro bill/payment action through the existing `send` primitive and receive a structured receipt without exposing KFTC-specific vocabulary in the primitive envelope.
+
+**Why this priority**: The adapter must preserve UMMAYA's main-verb abstraction; domain-specific fields belong inside the adapter params and receipt, not in the shared primitive contract.
+
+**Independent Test**: Use fixture-backed adapter tests to invoke the OpenGiro send tool with valid and invalid params; confirm that the shared envelope remains `{tool_id, params}` on input and `{transaction_id, status, adapter_receipt}` on output.
+
+**Acceptance Scenarios**:
+
+1. **Given** a valid OpenGiro bill or payment request fixture, **When** the session invokes the OpenGiro tool through `send`, **Then** the response includes a deterministic UMMAYA transaction id, a terminal or pending status, and an adapter receipt containing only sanitized OpenGiro receipt fields.
+2. **Given** required OpenGiro params are missing or malformed, **When** the session invokes the adapter, **Then** UMMAYA returns a validation error inside the tool loop and does not contact KFTC.
+3. **Given** a live KFTC response indicates rejection, expiry, or upstream error, **When** the adapter handles it, **Then** the response maps to `rejected`, `failed`, or `pending` without unhandled exceptions or retries that could duplicate a financial action.
+
+---
+
+### User Story 4 - Preserve Mock-to-Live Evidence (Priority: P3)
+
+A reviewer can trace every OpenGiro adapter field back to official KFTC documentation or a sanitized live readiness artifact.
+
+**Why this priority**: KFTC document access is partially gated; UMMAYA needs explicit provenance so future maintainers know which evidence is public, which requires portal approval, and which was intentionally deferred.
+
+**Independent Test**: Inspect the feature research, adapter documentation, JSON schema, and fixtures; every endpoint, field group, callback blocker, and permission statement has a source or blocker note.
+
+**Acceptance Scenarios**:
+
+1. **Given** public OpenGiro pages provide endpoint and response examples but gated documents remain inaccessible, **When** research artifacts are reviewed, **Then** public-source evidence and gated-source blockers are separated.
+2. **Given** a fixture is used before live KFTC calls are allowed, **When** the adapter documentation is generated, **Then** it marks the fixture as shape-mirrored and records what must be revalidated before enabling live execution.
+
+### Edge Cases
+
+- Callback URL is absent, malformed, or registered for a different deployment environment.
+- OpenGiro API Key registration remains blocked after service application.
+- KFTC document pages remain access-denied even after OpenGiro is marked `이용중`.
+- Payment URL responses expire before the citizen completes the external payment step.
+- The upstream response is successful at the KFTC gateway but rejected by the biller or payment institution.
+- The same citizen request is retried after a timeout and could duplicate a financial action.
+- Live credentials are present locally but the session lacks the required citizen permission gate.
+- Tests run in CI without live KFTC credentials and must not contact KFTC.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: System MUST document KFTC OpenGiro as an official financial side-effecting channel mapped to UMMAYA's `send` primitive.
+- **FR-002**: System MUST separate public KFTC OpenAPI evidence from portal-gated documents and record the exact blocker state observed in the developer portal.
+- **FR-003**: System MUST define one canonical OpenGiro adapter family covering bill creation, bill cancellation, payment URL creation, and payment/result inquiry, while keeping the shared `send` envelope domain-neutral.
+- **FR-004**: System MUST require a cited KFTC policy/source URL and citizen-facing `send` gate for any OpenGiro adapter registration.
+- **FR-005**: System MUST fail closed when Callback URL registration, API Key registration, Client ID, Client Secret, or access token readiness is incomplete.
+- **FR-006**: System MUST prevent KFTC Client Secret values, access tokens, authorization codes, and raw financial identifiers from being committed, logged, included in test artifacts, or printed in final reports.
+- **FR-007**: System MUST provide fixture-backed tests for successful, validation-failed, upstream-rejected, expired-payment-url, and missing-credential paths without contacting live KFTC services in CI.
+- **FR-008**: System MUST map upstream OpenGiro outcomes into the existing `send` result statuses without introducing a new primitive or domain-specific top-level envelope fields.
+- **FR-009**: System MUST define operator setup instructions for KFTC service application, Callback URL registration, API Key registration, and safe secret provisioning.
+- **FR-010**: System MUST treat actual financial settlement or external payment confirmation as citizen/operator-mediated unless official KFTC docs prove a fully API-callable settlement flow for the registered application.
+- **FR-011**: System MUST expose bilingual Korean/English search hints sufficient for tool discovery of OpenGiro bill/payment requests.
+- **FR-012**: System MUST update the adapter catalog and schema exports so maintainers can verify the OpenGiro surface from documentation alone.
+- **FR-013**: System MUST ensure live execution is opt-in and excluded from default tests and CI.
+- **FR-014**: System MUST include a sanitized direct-curl evidence checklist for any future live probe before live mode is considered complete.
+
+### Key Entities *(include if feature involves data)*
+
+- **OpenGiro Service Readiness**: The portal-level state for service application, Callback URL registration, API Key registration, and document/tool access.
+- **OpenGiro Credential Set**: Operator-held Client ID, Client Secret, access token material, and callback configuration required to call KFTC services.
+- **OpenGiro Send Request**: Adapter-specific request payload for bill creation, bill cancellation, payment URL creation, payment result inquiry, or payment-status inquiry.
+- **OpenGiro Receipt**: Sanitized adapter result containing transaction status, upstream response code/message, optional payment URL metadata, and non-secret correlation identifiers.
+- **Evidence Artifact**: Official source link, portal blocker note, sanitized response header/body sample, or fixture provenance record used to justify adapter behavior.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: 100% of OpenGiro endpoints included in this feature have an official KFTC source URL or a documented gated-source blocker.
+- **SC-002**: 0 committed files, logs, test snapshots, or final reports contain KFTC Client Secret, access token, authorization code, or raw personal financial identifiers.
+- **SC-003**: Default test runs complete without making live KFTC network calls.
+- **SC-004**: Fixture-backed tests cover at least five paths: success, validation failure, missing credential/setup, upstream rejection, and expired payment URL.
+- **SC-005**: The adapter catalog lists the OpenGiro surface under `send` with Korean and English search hints and a policy citation.
+- **SC-006**: An operator can follow the documented setup path and determine, in under 10 minutes, whether the KFTC portal is ready for live probing or still blocked by Callback URL/API Key/document access.
+
+## Assumptions
+
+- The feature uses the KFTC developer portal account already logged in by the user for readiness inspection, but does not reveal or store Client Secret values.
+- OpenGiro service application has been switched to `이용중`, while API Key registration is blocked until a Callback URL is registered.
+- KFTC public OpenAPI pages are sufficient for fixture shape and adapter documentation, but gated documents are not treated as available until portal access is granted.
+- The first implementation keeps live KFTC calls disabled by default and uses fixtures for CI and local non-live verification.
+- The canonical Callback URL belongs to the operator's deployed UMMAYA gateway environment; registering an arbitrary localhost URL in the KFTC portal is not assumed safe for production.
+
+## Scope Boundaries & Deferred Items *(mandatory)*
+
+### Out of Scope (Permanent)
+
+- Secret retrieval from the browser UI by the agent — persistent KFTC secrets must be handled by the operator and never read into the conversation.
+- CI execution against live KFTC, government, identity, payment, certificate, utility, or citizen-infrastructure endpoints — default verification uses fixtures only.
+- UMMAYA-issued financial authorization policy — permission classification must cite KFTC or the relevant agency; UMMAYA does not invent policy.
+
+### Deferred to Future Work
+
+| Item | Reason for Deferral | Target Epic/Phase | Tracking Issue |
+|------|---------------------|-------------------|----------------|
+| Production financial settlement confirmation beyond documented OpenGiro redirect/result APIs | Requires approved KFTC documents, registered Callback URL, API Key, and sanitized live probe evidence | Follow-up live validation after this adapter epic | #2979 |
+| General live `send` gateway support for all financial adapters | Existing gateway only permits live `find` and `locate`; broader send-gateway semantics need separate architecture review | Tool system live-gateway expansion | #2980 |
+| Additional KFTC services beyond OpenGiro, such as OpenBanking transfer or Financial Certificate verification | Different scopes, credentials, assurance levels, and documents | Separate KFTC service adapter epics | #2981 |

--- a/specs/2799-kftc-opengiro-send/tasks.md
+++ b/specs/2799-kftc-opengiro-send/tasks.md
@@ -1,0 +1,180 @@
+# Tasks: KFTC OpenGiro Send Adapter
+
+**Input**: Design documents from `/specs/2799-kftc-opengiro-send/`
+**Prerequisites**: `plan.md`, `spec.md`, `research.md`, `data-model.md`, `contracts/`, `quickstart.md`
+
+**Tests**: Required by FR-007. Test tasks are listed before their corresponding implementation tasks and must avoid live KFTC calls.
+
+**Organization**: Tasks are grouped by user story so each increment is independently testable.
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Confirm the feature branch is ready and preserve the implementation dispatch record.
+
+- [X] T001 Verify repository ignore rules already cover `.env`, `secrets/`, Python caches, and generated test artifacts in `.gitignore`
+- [X] T002 Create implementation dispatch tree for this feature in `specs/2799-kftc-opengiro-send/dispatch-tree.md`
+- [X] T003 [P] Add fixture evidence directory placeholders in `specs/2799-kftc-opengiro-send/evidence/README.md`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Add shared metadata and configuration required before the OpenGiro stories can register adapters safely.
+
+**CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T004 Add KFTC ministry metadata support in `src/ummaya/tools/models.py`
+- [X] T005 Add UMMAYA-prefixed KFTC OpenGiro readiness settings in `src/ummaya/settings.py`
+- [X] T006 [P] Create KFTC mock package module scaffolding in `src/ummaya/tools/mock/kftc/__init__.py`
+- [X] T007 Register the KFTC mock package side effect import in `src/ummaya/tools/mock/__init__.py`
+
+**Checkpoint**: Shared metadata and import paths exist; user story implementation can proceed.
+
+---
+
+## Phase 3: User Story 1 - Classify OpenGiro as a Send Channel (Priority: P1) MVP
+
+**Goal**: Maintainers can verify that KFTC OpenGiro belongs under the `send` primitive with official-source citations.
+
+**Independent Test**: Review generated docs/catalog rows and confirm OpenGiro is not classified as read-only lookup.
+
+### Tests for User Story 1
+
+- [X] T008 [P] [US1] Add discovery/catalog integration tests for OpenGiro `send` classification in `tests/integration/test_kftc_opengiro_discovery.py`
+
+### Implementation for User Story 1
+
+- [X] T009 [US1] Add official-source OpenGiro adapter documentation in `docs/api/submit/kftc_opengiro.md`
+- [X] T010 [US1] Update adapter catalog references for OpenGiro `send` rows in `docs/api/README.md`
+
+**Checkpoint**: OpenGiro classification is independently reviewable from docs and discovery tests.
+
+---
+
+## Phase 4: User Story 2 - Register a Safe KFTC Credential Path (Priority: P1)
+
+**Goal**: Operators can understand and validate KFTC readiness without exposing Client Secret values.
+
+**Independent Test**: Run the setup/readiness and redaction tests; no secret values or live calls are required.
+
+### Tests for User Story 2
+
+- [X] T011 [P] [US2] Add KFTC setup readiness tests in `tests/unit/tools/test_mock_kftc_opengiro.py`
+- [X] T012 [P] [US2] Add KFTC secret-redaction lint tests in `tests/lint/test_kftc_secret_redaction.py`
+
+### Implementation for User Story 2
+
+- [X] T013 [US2] Implement OpenGiro setup readiness models and fail-closed helper logic in `src/ummaya/tools/mock/kftc/opengiro.py`
+- [X] T014 [US2] Document KFTC Callback URL and API Key readiness workflow in `docs/api/submit/kftc_opengiro.md`
+
+**Checkpoint**: Missing callback/API-key/secret readiness is represented as a setup blocker and secrets are not exposed.
+
+---
+
+## Phase 5: User Story 3 - Invoke OpenGiro Through the Send Envelope (Priority: P2)
+
+**Goal**: UMMAYA sessions can invoke fixture-backed OpenGiro bill and payment actions through the existing `send` envelope.
+
+**Independent Test**: Run unit tests that call `send(SubmitInput(...))` for valid, invalid, rejected, expired, and missing-credential fixture paths.
+
+### Tests for User Story 3
+
+- [X] T015 [P] [US3] Add bill adapter happy/error path tests in `tests/unit/tools/test_mock_kftc_opengiro.py`
+- [X] T016 [P] [US3] Add payment adapter happy/error path tests in `tests/unit/tools/test_mock_kftc_opengiro.py`
+
+### Implementation for User Story 3
+
+- [X] T017 [US3] Implement `mock_kftc_opengiro_bill_send_v1` models and submit registration in `src/ummaya/tools/mock/kftc/opengiro.py`
+- [X] T018 [US3] Implement `mock_kftc_opengiro_payment_send_v1` models and submit registration in `src/ummaya/tools/mock/kftc/opengiro.py`
+- [X] T019 [US3] Add deterministic sanitized receipt mapping for success, pending, failed, and rejected OpenGiro outcomes in `src/ummaya/tools/mock/kftc/opengiro.py`
+
+**Checkpoint**: Both OpenGiro adapters execute through `send` and return `SubmitOutput` without live KFTC calls.
+
+---
+
+## Phase 6: User Story 4 - Preserve Mock-to-Live Evidence (Priority: P3)
+
+**Goal**: Future live conversion can trace every OpenGiro field to official KFTC evidence or a documented portal blocker.
+
+**Independent Test**: Run schema generation/checks and inspect evidence artifacts for official URLs and blocked-live criteria.
+
+### Tests for User Story 4
+
+- [X] T020 [P] [US4] Add schema export assertions for OpenGiro send adapters in `tests/integration/test_kftc_opengiro_discovery.py`
+
+### Implementation for User Story 4
+
+- [X] T021 [US4] Generate OpenGiro submit JSON schema exports in `docs/api/schemas/mock_kftc_opengiro_bill_send_v1.json` and `docs/api/schemas/mock_kftc_opengiro_payment_send_v1.json`
+- [X] T022 [US4] Backfill deferred tracking issue numbers in `specs/2799-kftc-opengiro-send/spec.md`
+- [X] T023 [US4] Record sanitized official-source and portal-blocker evidence in `specs/2799-kftc-opengiro-send/evidence/README.md`
+
+**Checkpoint**: Mock-to-live state is documented and schema exports match registered adapters.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+**Purpose**: Validate the full feature and prepare it for PR review.
+
+- [X] T024 Run quickstart verification commands from `specs/2799-kftc-opengiro-send/quickstart.md`
+- [X] T025 Run focused tests for KFTC OpenGiro adapters with `uv run pytest tests/unit/tools/test_mock_kftc_opengiro.py tests/integration/test_kftc_opengiro_discovery.py tests/lint/test_kftc_secret_redaction.py`
+- [X] T026 Run full non-live test suite with `uv run pytest`
+- [X] T027 Update task checkboxes in `specs/2799-kftc-opengiro-send/tasks.md` after verification completes
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies.
+- **Foundational (Phase 2)**: Depends on Setup completion and blocks user stories.
+- **US1 and US2 (Phases 3-4)**: Can start after Foundational and are both P1.
+- **US3 (Phase 5)**: Depends on US1 classification and US2 readiness helpers.
+- **US4 (Phase 6)**: Depends on registered adapters and generated schema evidence.
+- **Polish (Phase 7)**: Depends on all selected user stories being complete.
+
+### User Story Dependencies
+
+- **US1**: No dependency beyond Foundational.
+- **US2**: No dependency beyond Foundational.
+- **US3**: Depends on US1 and US2.
+- **US4**: Depends on US3.
+
+### Parallel Opportunities
+
+- T003 can run in parallel with T001-T002.
+- T006 can run in parallel with T004-T005 before T007 wires imports.
+- T008, T011, and T012 can be authored in parallel because they touch separate test concerns.
+- T015 and T016 can be authored in parallel in the same test file only if coordinated; otherwise keep sequential in a solo implementation.
+- T020 can run after adapter IDs are stable and before schema generation.
+
+---
+
+## Implementation Strategy
+
+### MVP First
+
+1. Complete Setup and Foundational tasks.
+2. Complete US1 and US2 to establish primitive classification plus safe credential readiness.
+3. Validate docs and readiness tests before writing send execution code.
+
+### Incremental Delivery
+
+1. Add OpenGiro classification and metadata.
+2. Add fail-closed setup readiness.
+3. Add bill and payment adapters through the shared `send` primitive.
+4. Generate schemas and preserve mock-to-live evidence.
+
+### Team Strategy
+
+This feature has more than three logical tasks but tightly coupled adapter, schema, and test files. The current implementation will be Lead-solo to avoid unsupported Sonnet delegation in this Codex environment and to keep the credential-sensitive changes in one review context.
+
+---
+
+## Notes
+
+- Total tasks: 27, below the 90-task Epic budget.
+- No task may call live KFTC from CI.
+- No task may reveal, print, or commit KFTC Client Secret, access token, authorization code, or raw personal financial identifiers.
+- PR must close the Epic issue only; task sub-issues are linked for tracking and closed after merge.

--- a/src/ummaya/settings.py
+++ b/src/ummaya/settings.py
@@ -55,6 +55,31 @@ class UmmayaSettings(BaseSettings):
     data_go_kr_api_key: str = Field(default="")
     """공공데이터포털 통합 API 키, shared by KOROAD / KMA / HIRA / NMC / NFA / MOHW."""
 
+    # --- KFTC OpenGiro (fixture-backed until operator live readiness is proven) ---
+    kftc_opengiro_service_enabled: bool = Field(default=False)
+    """KFTC OpenGiro service application state (UMMAYA_KFTC_OPENGIRO_SERVICE_ENABLED)."""
+
+    kftc_opengiro_callback_url: str = Field(default="")
+    """Operator-approved KFTC Callback URL (UMMAYA_KFTC_OPENGIRO_CALLBACK_URL)."""
+
+    kftc_opengiro_api_key_registered: bool = Field(default=False)
+    """Whether OpenGiro bill/payment APIs are registered to the API Key."""
+
+    kftc_opengiro_client_id: str = Field(default="")
+    """KFTC developer portal Client ID. Never log or commit its paired secret."""
+
+    kftc_opengiro_client_secret: str = Field(default="")
+    """KFTC developer portal Client Secret. Never print, log, or commit this value."""
+
+    kftc_opengiro_access_token: str = Field(default="")
+    """Short-lived KFTC access token for future live probes. Empty by default."""
+
+    kftc_opengiro_documents_accessible: bool = Field(default=False)
+    """Whether gated KFTC OpenGiro documents are accessible to the operator."""
+
+    kftc_opengiro_live_probe_enabled: bool = Field(default=False)
+    """Explicit opt-in for future live KFTC probes. Default false keeps CI fixture-only."""
+
     # --- Live adapter gateway (release CLI path) ---
     live_adapter_mode: Literal["auto", "proxy", "direct"] = Field(default="auto")
     """Live adapter route (UMMAYA_LIVE_ADAPTER_MODE).

--- a/src/ummaya/tools/mock/__init__.py
+++ b/src/ummaya/tools/mock/__init__.py
@@ -6,6 +6,7 @@ Five mock system sub-packages (byte- or shape-mirror-able public systems):
 - barocert: developers.barocert.com SDK docs (shape mirror)
 - mydata: KFTC MyData v240930 (shape mirror, mTLS/OAuth profile)
 - npki_crypto: PyPinkSign crypto layer (PKCS#7/#12 only; portal session is OPAQUE)
+- kftc: KFTC OpenGiro public OpenAPI (fixture-backed until portal readiness)
 
 OPAQUE systems (Government 24 submission, KEC XML signature, NPKI portal
 session handshake) live in docs/scenarios/ only — no mock adapter
@@ -41,6 +42,7 @@ tool-call loop.
 # Import triggers self-registration in ummaya.primitives.submit._ADAPTER_REGISTRY.
 # APPEND ONLY — do not remove or reorder existing entries.
 import ummaya.tools.mock.data_go_kr.fines_pay  # noqa: F401, E402
+import ummaya.tools.mock.kftc.opengiro  # noqa: F401, E402
 import ummaya.tools.mock.mydata.welfare_application  # noqa: F401, E402
 
 # Epic ε #2296 T023–T025 — new delegation-aware submit adapters.

--- a/src/ummaya/tools/mock/kftc/__init__.py
+++ b/src/ummaya/tools/mock/kftc/__init__.py
@@ -1,0 +1,8 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KFTC mock-to-live adapter package."""
+
+from __future__ import annotations
+
+from ummaya.tools.mock.kftc import opengiro as opengiro
+
+__all__ = ["opengiro"]

--- a/src/ummaya/tools/mock/kftc/opengiro.py
+++ b/src/ummaya/tools/mock/kftc/opengiro.py
@@ -358,11 +358,12 @@ async def invoke_bill(params: dict[str, object]) -> SubmitOutput:
 
     status, rsp_code, rsp_message, detail = _fixture_outcome(typed.bill_reference)
     if status == SubmitStatus.succeeded:
-        detail = {
-            "create_bill": "created",
-            "cancel_bill": "cancelled",
-            "check_payment_status": "payment_status_checked",
-        }[typed.operation]
+        if typed.operation == "create_bill":
+            detail = "created"
+        elif typed.operation == "cancel_bill":
+            detail = "cancelled"
+        else:
+            detail = "payment_status_checked"
 
     receipt = OpenGiroReceipt(
         receipt_ref=f"MOCK-OG-BILL-{_hash_ref(typed.bill_reference)}",

--- a/src/ummaya/tools/mock/kftc/opengiro.py
+++ b/src/ummaya/tools/mock/kftc/opengiro.py
@@ -1,0 +1,522 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Fixture-backed KFTC OpenGiro send adapters.
+
+KFTC public OpenGiro pages expose bill and payment OpenAPI surfaces, but the
+current developer-portal state is not live-ready: Callback URL and API Key
+registration remain incomplete and gated OpenGiro documents are inaccessible.
+Per UMMAYA adapter rules, these adapters mirror the public reference shape as
+mock ``send`` tools until operator-owned live probe evidence exists.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from datetime import UTC, date, datetime, timedelta
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+from ummaya.primitives.submit import (
+    SubmitOutput,
+    SubmitStatus,
+    derive_transaction_id,
+    register_submit_adapter,
+)
+from ummaya.settings import UmmayaSettings, settings
+from ummaya.tools.models import AdapterRealDomainPolicy
+from ummaya.tools.registry import AdapterPrimitive, AdapterRegistration, AdapterSourceMode
+from ummaya.tools.transparency import stamp_mock_response
+
+logger = logging.getLogger(__name__)
+
+BillOperation = Literal["create_bill", "cancel_bill", "check_payment_status"]
+PaymentOperation = Literal[
+    "create_inquiry_payment_url",
+    "create_input_payment_url",
+    "create_link_payment_url",
+    "query_payment_result",
+]
+OpenGiroStatusDetail = Literal[
+    "created",
+    "cancelled",
+    "payment_status_checked",
+    "payment_url_issued",
+    "payment_result_confirmed",
+    "expired",
+    "rejected",
+    "setup_blocked",
+    "failed",
+]
+
+_BILL_TOOL_ID: Final = "mock_kftc_opengiro_bill_send_v1"
+_PAYMENT_TOOL_ID: Final = "mock_kftc_opengiro_payment_send_v1"
+_BILL_NONCE: Final = "mock_kftc_opengiro_bill_send_v1_nonce_v1"
+_PAYMENT_NONCE: Final = "mock_kftc_opengiro_payment_send_v1_nonce_v1"
+
+_REFERENCE_IMPL: Final = "kftc-opengiro-public-openapi"
+_SECURITY_WRAPPING: Final = (
+    "KFTC developer portal service application + Callback URL + API Key registration "
+    "+ OAuth-style access token"
+)
+_INTERNATIONAL_REF: Final = "Singapore APEX payment API gateway"
+_BILL_POLICY_URL: Final = "https://developers.kftc.or.kr/dev/openapi/open-giro/index"
+_PAYMENT_POLICY_URL: Final = "https://developers.kftc.or.kr/dev/openapi/open-giro/pay-service"
+_STARTER_URL: Final = "https://developers.kftc.or.kr/dev/starter/starter"
+_FIXTURE_ISSUED_AT: Final = datetime(2026, 5, 18, 0, 0, tzinfo=UTC)
+
+_BILL_ENDPOINTS: Final[dict[str, str]] = {
+    "create_bill": "https://api.giro.or.kr/v1/bills/giro",
+    "cancel_bill": "https://api.giro.or.kr/v1/bills/giro/cancel",
+    "check_payment_status": "https://api.giro.or.kr/v1/bills/giro/payment-yn",
+}
+_PAYMENT_ENDPOINTS: Final[dict[str, str]] = {
+    "create_inquiry_payment_url": "https://api.giro.or.kr/v1/payments/giro-inqr-pay-url",
+    "create_input_payment_url": "https://api.giro.or.kr/v1/payments/giro-inpt-pay-url",
+    "create_link_payment_url": "https://api.giro.or.kr/v1/payments/link-pay-url",
+    "query_payment_result": "https://api.giro.or.kr/v1/payments",
+}
+
+
+class OpenGiroSetupReadiness(BaseModel):
+    """Operator-owned live-readiness state for KFTC OpenGiro."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    service_enabled: bool = False
+    callback_url_registered: bool = False
+    api_key_registered: bool = False
+    client_id_configured: bool = False
+    client_secret_configured: bool = False
+    access_token_configured: bool = False
+    documents_accessible: bool = False
+    live_probe_enabled: bool = False
+    live_ready: bool = False
+    blockers: tuple[str, ...] = Field(default_factory=tuple)
+
+
+class OpenGiroBillParams(BaseModel):
+    """Typed params for the OpenGiro bill service fixture."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operation: BillOperation = Field(
+        default="create_bill",
+        description="OpenGiro bill operation to mirror.",
+    )
+    giro_no: str = Field(
+        default="1234567",
+        min_length=4,
+        max_length=32,
+        description="OpenGiro giro number from the biller contract.",
+    )
+    bill_reference: str = Field(
+        default="MOCK-BILL-2026-001",
+        min_length=1,
+        max_length=64,
+        description="Biller-side bill reference. Fixture values may use MOCK/REJECT/EXPIRED.",
+    )
+    amount_krw: int | None = Field(
+        default=15_000,
+        ge=1,
+        le=99_999_999,
+        description="Bill amount in KRW. Required for create_bill.",
+    )
+    due_date: date | None = Field(
+        default=date(2026, 6, 30),
+        description="Bill due date. Required for create_bill.",
+    )
+    payer_reference: str = Field(
+        default="MOCK-PAYER",
+        min_length=1,
+        max_length=64,
+        description="Sanitized payer reference for fixture correlation.",
+    )
+    live_probe_requested: bool = Field(
+        default=False,
+        description="Opt-in live probe flag. Fixture mode is used unless this is true.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_operation_requirements(self) -> OpenGiroBillParams:
+        if self.operation == "create_bill":
+            if self.amount_krw is None:
+                raise ValueError("create_bill requires amount_krw")
+            if self.due_date is None:
+                raise ValueError("create_bill requires due_date")
+        if self.operation in {"cancel_bill", "check_payment_status"} and not self.bill_reference:
+            raise ValueError(f"{self.operation} requires bill_reference")
+        return self
+
+
+class OpenGiroPaymentParams(BaseModel):
+    """Typed params for the OpenGiro payment service fixture."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    operation: PaymentOperation = Field(
+        default="create_link_payment_url",
+        description="OpenGiro payment operation to mirror.",
+    )
+    giro_no: str = Field(
+        default="1234567",
+        min_length=4,
+        max_length=32,
+        description="OpenGiro giro number from the biller contract.",
+    )
+    payment_reference: str = Field(
+        default="MOCK-PAY-2026-001",
+        min_length=1,
+        max_length=64,
+        description="Payment correlation reference. Fixture values may use MOCK/REJECT/EXPIRED.",
+    )
+    amount_krw: int | None = Field(
+        default=15_000,
+        ge=1,
+        le=99_999_999,
+        description="Payment amount in KRW. Required for payment URL creation.",
+    )
+    payer_reference: str = Field(
+        default="MOCK-PAYER",
+        min_length=1,
+        max_length=64,
+        description="Sanitized payer reference for fixture correlation.",
+    )
+    redirect_return_url: str | None = Field(
+        default=None,
+        max_length=512,
+        description="Operator-approved return URL for browser redirect fixtures.",
+    )
+    live_probe_requested: bool = Field(
+        default=False,
+        description="Opt-in live probe flag. Fixture mode is used unless this is true.",
+    )
+
+    @model_validator(mode="after")
+    def _validate_operation_requirements(self) -> OpenGiroPaymentParams:
+        if self.operation != "query_payment_result" and self.amount_krw is None:
+            raise ValueError(f"{self.operation} requires amount_krw")
+        if self.operation == "query_payment_result" and not self.payment_reference:
+            raise ValueError("query_payment_result requires payment_reference")
+        return self
+
+
+class OpenGiroReceipt(BaseModel):
+    """Sanitized receipt placed inside SubmitOutput.adapter_receipt."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    receipt_ref: str
+    service: Literal["bill", "payment"]
+    operation: str
+    upstream_rsp_code: str
+    upstream_rsp_message: str
+    status_detail: OpenGiroStatusDetail
+    giro_no_masked: str
+    reference_hash: str
+    amount_krw: int | None = None
+    payment_url: str | None = None
+    expires_at: datetime | None = None
+    setup_blockers: tuple[str, ...] = Field(default_factory=tuple)
+    mock: bool = True
+
+
+def build_setup_readiness(
+    settings_obj: UmmayaSettings | None = None,
+) -> OpenGiroSetupReadiness:
+    """Build fail-closed OpenGiro live-readiness state from UMMAYA settings."""
+    cfg = settings if settings_obj is None else settings_obj
+    service_enabled = bool(cfg.kftc_opengiro_service_enabled)
+    callback_url_registered = bool(str(cfg.kftc_opengiro_callback_url).strip())
+    api_key_registered = bool(cfg.kftc_opengiro_api_key_registered)
+    client_id_configured = bool(str(cfg.kftc_opengiro_client_id).strip())
+    client_secret_configured = bool(str(cfg.kftc_opengiro_client_secret).strip())
+    access_token_configured = bool(str(cfg.kftc_opengiro_access_token).strip())
+    documents_accessible = bool(cfg.kftc_opengiro_documents_accessible)
+    live_probe_enabled = bool(cfg.kftc_opengiro_live_probe_enabled)
+
+    blockers: list[str] = []
+    if not service_enabled:
+        blockers.append("OpenGiro service is not marked enabled in UMMAYA settings")
+    if not callback_url_registered:
+        blockers.append("KFTC Callback URL is not registered")
+    if not api_key_registered:
+        blockers.append("OpenGiro API Key registration is incomplete")
+    if not client_id_configured:
+        blockers.append("KFTC Client ID is not configured")
+    if not client_secret_configured:
+        blockers.append("KFTC Client Secret is not configured")
+    if not access_token_configured:
+        blockers.append("KFTC access token is not configured")
+    if not documents_accessible:
+        blockers.append("Gated KFTC OpenGiro documents are not accessible")
+    if not live_probe_enabled:
+        blockers.append("UMMAYA_KFTC_OPENGIRO_LIVE_PROBE_ENABLED is false")
+
+    return OpenGiroSetupReadiness(
+        service_enabled=service_enabled,
+        callback_url_registered=callback_url_registered,
+        api_key_registered=api_key_registered,
+        client_id_configured=client_id_configured,
+        client_secret_configured=client_secret_configured,
+        access_token_configured=access_token_configured,
+        documents_accessible=documents_accessible,
+        live_probe_enabled=live_probe_enabled,
+        live_ready=not blockers,
+        blockers=tuple(blockers),
+    )
+
+
+def _hash_ref(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()[:16]
+
+
+def _mask_giro_no(giro_no: str) -> str:
+    if len(giro_no) <= 5:
+        return "*" * len(giro_no)
+    return f"{giro_no[:3]}***{giro_no[-2:]}"
+
+
+def _fixture_outcome(reference: str) -> tuple[SubmitStatus, str, str, OpenGiroStatusDetail]:
+    upper = reference.upper()
+    if "REJECT" in upper:
+        return SubmitStatus.rejected, "R4001", "Rejected by fixture upstream", "rejected"
+    if "EXPIRED" in upper:
+        return SubmitStatus.failed, "E4100", "Payment URL expired in fixture", "expired"
+    if "FAIL" in upper:
+        return SubmitStatus.failed, "E5000", "Fixture upstream failure", "failed"
+    return SubmitStatus.succeeded, "A0000", "Fixture accepted", "created"
+
+
+def _stamp_receipt(
+    receipt: OpenGiroReceipt,
+    *,
+    endpoint: str,
+    policy_authority: str,
+) -> dict[str, object]:
+    return stamp_mock_response(
+        receipt.model_dump(mode="json", exclude_none=True),
+        reference_implementation=_REFERENCE_IMPL,
+        actual_endpoint_when_live=endpoint,
+        security_wrapping_pattern=_SECURITY_WRAPPING,
+        policy_authority=policy_authority,
+        international_reference=_INTERNATIONAL_REF,
+    )
+
+
+def _setup_blocked_output(
+    *,
+    tool_id: str,
+    params: dict[str, object],
+    nonce: str,
+    service: Literal["bill", "payment"],
+    operation: str,
+    giro_no: str,
+    reference: str,
+    endpoint: str,
+    policy_authority: str,
+) -> SubmitOutput:
+    readiness = build_setup_readiness()
+    receipt = OpenGiroReceipt(
+        receipt_ref=f"MOCK-OG-SETUP-{_hash_ref(reference)}",
+        service=service,
+        operation=operation,
+        upstream_rsp_code="UMMAYA_SETUP_BLOCKED",
+        upstream_rsp_message="; ".join(readiness.blockers),
+        status_detail="setup_blocked",
+        giro_no_masked=_mask_giro_no(giro_no),
+        reference_hash=_hash_ref(reference),
+        setup_blockers=readiness.blockers,
+    )
+    return SubmitOutput(
+        transaction_id=derive_transaction_id(tool_id, params, adapter_nonce=nonce),
+        status=SubmitStatus.rejected,
+        adapter_receipt=_stamp_receipt(
+            receipt,
+            endpoint=endpoint,
+            policy_authority=policy_authority,
+        ),
+    )
+
+
+async def invoke_bill(params: dict[str, object]) -> SubmitOutput:
+    """Invoke the fixture-backed OpenGiro bill adapter."""
+    typed = OpenGiroBillParams.model_validate(params)
+    endpoint = _BILL_ENDPOINTS[typed.operation]
+    if typed.live_probe_requested and not build_setup_readiness().live_ready:
+        return _setup_blocked_output(
+            tool_id=_BILL_TOOL_ID,
+            params=dict(params),
+            nonce=_BILL_NONCE,
+            service="bill",
+            operation=typed.operation,
+            giro_no=typed.giro_no,
+            reference=typed.bill_reference,
+            endpoint=endpoint,
+            policy_authority=_BILL_POLICY_URL,
+        )
+
+    status, rsp_code, rsp_message, detail = _fixture_outcome(typed.bill_reference)
+    if status == SubmitStatus.succeeded:
+        detail = {
+            "create_bill": "created",
+            "cancel_bill": "cancelled",
+            "check_payment_status": "payment_status_checked",
+        }[typed.operation]
+
+    receipt = OpenGiroReceipt(
+        receipt_ref=f"MOCK-OG-BILL-{_hash_ref(typed.bill_reference)}",
+        service="bill",
+        operation=typed.operation,
+        upstream_rsp_code=rsp_code,
+        upstream_rsp_message=rsp_message,
+        status_detail=detail,
+        giro_no_masked=_mask_giro_no(typed.giro_no),
+        reference_hash=_hash_ref(typed.bill_reference),
+        amount_krw=typed.amount_krw,
+    )
+    logger.debug("mock_kftc_opengiro_bill_send_v1: operation=%s", typed.operation)
+    return SubmitOutput(
+        transaction_id=derive_transaction_id(
+            _BILL_TOOL_ID,
+            dict(params),
+            adapter_nonce=_BILL_NONCE,
+        ),
+        status=status,
+        adapter_receipt=_stamp_receipt(
+            receipt,
+            endpoint=endpoint,
+            policy_authority=_BILL_POLICY_URL,
+        ),
+    )
+
+
+async def invoke_payment(params: dict[str, object]) -> SubmitOutput:
+    """Invoke the fixture-backed OpenGiro payment adapter."""
+    typed = OpenGiroPaymentParams.model_validate(params)
+    endpoint = _PAYMENT_ENDPOINTS[typed.operation]
+    if typed.live_probe_requested and not build_setup_readiness().live_ready:
+        return _setup_blocked_output(
+            tool_id=_PAYMENT_TOOL_ID,
+            params=dict(params),
+            nonce=_PAYMENT_NONCE,
+            service="payment",
+            operation=typed.operation,
+            giro_no=typed.giro_no,
+            reference=typed.payment_reference,
+            endpoint=endpoint,
+            policy_authority=_PAYMENT_POLICY_URL,
+        )
+
+    status, rsp_code, rsp_message, detail = _fixture_outcome(typed.payment_reference)
+    payment_url: str | None = None
+    expires_at: datetime | None = None
+    if status == SubmitStatus.succeeded:
+        if typed.operation == "query_payment_result":
+            detail = "payment_result_confirmed"
+        else:
+            status = SubmitStatus.pending
+            detail = "payment_url_issued"
+            reference_hash = _hash_ref(typed.payment_reference)
+            payment_url = f"https://mock.open-giro.ummaya.local/pay/{reference_hash}"
+            expires_at = _FIXTURE_ISSUED_AT + timedelta(minutes=10)
+
+    receipt = OpenGiroReceipt(
+        receipt_ref=f"MOCK-OG-PAY-{_hash_ref(typed.payment_reference)}",
+        service="payment",
+        operation=typed.operation,
+        upstream_rsp_code=rsp_code,
+        upstream_rsp_message=rsp_message,
+        status_detail=detail,
+        giro_no_masked=_mask_giro_no(typed.giro_no),
+        reference_hash=_hash_ref(typed.payment_reference),
+        amount_krw=typed.amount_krw,
+        payment_url=payment_url,
+        expires_at=expires_at,
+    )
+    logger.debug("mock_kftc_opengiro_payment_send_v1: operation=%s", typed.operation)
+    return SubmitOutput(
+        transaction_id=derive_transaction_id(
+            _PAYMENT_TOOL_ID,
+            dict(params),
+            adapter_nonce=_PAYMENT_NONCE,
+        ),
+        status=status,
+        adapter_receipt=_stamp_receipt(
+            receipt,
+            endpoint=endpoint,
+            policy_authority=_PAYMENT_POLICY_URL,
+        ),
+    )
+
+
+BILL_REGISTRATION = AdapterRegistration(
+    tool_id=_BILL_TOOL_ID,
+    primitive=AdapterPrimitive.send,
+    module_path=__name__,
+    input_model_ref=f"{__name__}.OpenGiroBillParams",
+    source_mode=AdapterSourceMode.OOS,
+    published_tier_minimum="geumyung_injeungseo_personal_aal2",
+    nist_aal_hint="AAL2",
+    is_concurrency_safe=False,
+    cache_ttl_seconds=0,
+    rate_limit_per_minute=10,
+    search_hint={
+        "ko": ["오픈지로", "금융결제원", "지로", "부과", "청구", "납부확인"],
+        "en": ["OpenGiro", "KFTC", "giro bill", "bill issue", "payment status"],
+    },
+    auth_type="oauth",
+    nonce=_BILL_NONCE,
+    policy=AdapterRealDomainPolicy(
+        real_classification_url=_BILL_POLICY_URL,
+        real_classification_text=(
+            "금융결제원 OpenGiro 부과서비스 — 공식 OpenAPI 페이지와 개발자 "
+            "Callback URL/API Key 절차에 근거한 send 게이트."
+        ),
+        citizen_facing_gate="send",
+        last_verified=datetime(2026, 5, 18, tzinfo=UTC),
+    ),
+)
+
+PAYMENT_REGISTRATION = AdapterRegistration(
+    tool_id=_PAYMENT_TOOL_ID,
+    primitive=AdapterPrimitive.send,
+    module_path=__name__,
+    input_model_ref=f"{__name__}.OpenGiroPaymentParams",
+    source_mode=AdapterSourceMode.OOS,
+    published_tier_minimum="geumyung_injeungseo_personal_aal2",
+    nist_aal_hint="AAL2",
+    is_concurrency_safe=False,
+    cache_ttl_seconds=0,
+    rate_limit_per_minute=10,
+    search_hint={
+        "ko": ["오픈지로", "금융결제원", "지로", "납부", "결제URL", "납부결과"],
+        "en": ["OpenGiro", "KFTC", "giro payment", "payment URL", "payment result"],
+    },
+    auth_type="oauth",
+    nonce=_PAYMENT_NONCE,
+    policy=AdapterRealDomainPolicy(
+        real_classification_url=_PAYMENT_POLICY_URL,
+        real_classification_text=(
+            "금융결제원 OpenGiro 납부서비스 — 공식 OpenAPI 페이지와 개발자 "
+            "Callback URL/API Key 절차에 근거한 send 게이트."
+        ),
+        citizen_facing_gate="send",
+        last_verified=datetime(2026, 5, 18, tzinfo=UTC),
+    ),
+)
+
+register_submit_adapter(BILL_REGISTRATION, invoke_bill)
+register_submit_adapter(PAYMENT_REGISTRATION, invoke_payment)
+
+__all__ = [
+    "BILL_REGISTRATION",
+    "PAYMENT_REGISTRATION",
+    "OpenGiroBillParams",
+    "OpenGiroPaymentParams",
+    "OpenGiroReceipt",
+    "OpenGiroSetupReadiness",
+    "build_setup_readiness",
+    "invoke_bill",
+    "invoke_payment",
+]

--- a/src/ummaya/tools/models.py
+++ b/src/ummaya/tools/models.py
@@ -62,6 +62,7 @@ Ministry = Literal[
     "MPM",  # 인사혁신처 — public job notices
     "MSS",  # 중소벤처기업부 — SME support notices
     "KSD",  # 한국예탁결제원 — securities terminology
+    "KFTC",  # 금융결제원 — financial telecommunications and clearing
     "CCOURT",  # 헌법재판소 — constitutional court publications
     "DJTC",  # 대전교통공사 — Daejeon metro
     "MOF",  # 해양수산부 — marine water quality

--- a/tests/integration/test_discovery_bridge_path_b.py
+++ b/tests/integration/test_discovery_bridge_path_b.py
@@ -41,12 +41,12 @@ def test_b1_total_tool_count_includes_mocks(
 ) -> None:
     """Path B-1: bridge registers active non-core mock adapters into main registry.
 
-    Expected total: 68 after both verified public-data adapter waves.
+    Expected total: 70 after both verified public-data adapter waves plus KFTC OpenGiro.
     """
     r, _ = loaded_registry
     total = len(r.all_tools())
-    assert total == 68, (
-        f"Expected 68 total tools after discovery_bridge runs; got {total}. "
+    assert total == 70, (
+        f"Expected 70 total tools after discovery_bridge runs; got {total}. "
         f"Verify the bridge registered the active mock adapters."
     )
 
@@ -76,13 +76,15 @@ def test_b1_verify_mocks_in_registry(
 def test_b1_submit_mocks_in_registry(
     loaded_registry: tuple[ToolRegistry, ToolExecutor],
 ) -> None:
-    """All 5 submit mock tool_ids are registered (3 ε + 2 Spec 031)."""
+    """All 7 submit mock tool_ids are registered (3 ε + 2 Spec 031 + 2 OpenGiro)."""
     r, _ = loaded_registry
     ids = {t.id for t in r.all_tools()}
     expected = {
         "mock_submit_module_hometax_taxreturn",
         "mock_submit_module_gov24_minwon",
         "mock_submit_module_public_mydata_action",
+        "mock_kftc_opengiro_bill_send_v1",
+        "mock_kftc_opengiro_payment_send_v1",
         "mock_traffic_fine_pay_v1",
         "mock_welfare_application_submit_v1",
     }

--- a/tests/integration/test_kftc_opengiro_discovery.py
+++ b/tests/integration/test_kftc_opengiro_discovery.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Discovery and schema tests for KFTC OpenGiro send adapters."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.lookup import lookup
+from ummaya.tools.models import LookupSearchInput
+from ummaya.tools.register_all import register_all_tools
+from ummaya.tools.registry import ToolRegistry
+
+
+@pytest.fixture(scope="module")
+def loaded_registry() -> tuple[ToolRegistry, ToolExecutor]:
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry=registry)
+    register_all_tools(registry, executor)
+    return registry, executor
+
+
+def test_opengiro_send_adapters_are_registered_for_discovery(
+    loaded_registry: tuple[ToolRegistry, ToolExecutor],
+) -> None:
+    registry, _executor = loaded_registry
+    ids = {tool.id for tool in registry.all_tools()}
+
+    assert "mock_kftc_opengiro_bill_send_v1" in ids
+    assert "mock_kftc_opengiro_payment_send_v1" in ids
+
+    bill = registry.lookup("mock_kftc_opengiro_bill_send_v1")
+    payment = registry.lookup("mock_kftc_opengiro_payment_send_v1")
+    assert bill.primitive == "send"
+    assert payment.primitive == "send"
+    assert bill.policy is not None
+    assert payment.policy is not None
+    assert bill.policy.citizen_facing_gate == "send"
+    assert payment.policy.citizen_facing_gate == "send"
+
+
+def test_opengiro_korean_payment_query_surfaces_send_candidate(
+    loaded_registry: tuple[ToolRegistry, ToolExecutor],
+) -> None:
+    registry, executor = loaded_registry
+
+    async def _run() -> list[str]:
+        result = await lookup(
+            LookupSearchInput(mode="search", query="오픈지로 지로 납부 결제URL 생성", top_k=10),
+            registry=registry,
+            executor=executor,
+            session_identity="test-kftc-opengiro",
+        )
+        return [candidate.tool_id for candidate in result.candidates]
+
+    ids = asyncio.run(_run())
+    assert "mock_kftc_opengiro_payment_send_v1" in ids
+
+
+def test_opengiro_schema_exports_exist_after_generation() -> None:
+    schema_dir = Path("docs/api/schemas")
+    bill_path = schema_dir / "mock_kftc_opengiro_bill_send_v1.json"
+    payment_path = schema_dir / "mock_kftc_opengiro_payment_send_v1.json"
+
+    assert bill_path.exists()
+    assert payment_path.exists()
+
+    bill = json.loads(bill_path.read_text(encoding="utf-8"))
+    payment = json.loads(payment_path.read_text(encoding="utf-8"))
+    assert bill["title"] == "mock_kftc_opengiro_bill_send_v1"
+    assert payment["title"] == "mock_kftc_opengiro_payment_send_v1"
+    assert "operation" in bill["properties"]
+    assert "operation" in payment["properties"]
+    assert "_OpaqueOutput" in bill["$defs"]
+    assert "_OpaqueOutput" in payment["$defs"]

--- a/tests/integration/test_mcp_otel_spans.py
+++ b/tests/integration/test_mcp_otel_spans.py
@@ -87,8 +87,8 @@ class TestMCPToolsListShape:
         tools = response["result"]["tools"]
         # Subscribe is deferred out of the active surface until UMMAYA owns an
         # app/push delivery runtime. The MCP tool list mirrors the active
-        # registry: 68 tools after Spec #2798's 16-adapter live expansion.
-        assert len(tools) == 68, f"Tool list count drift: got {len(tools)}, expected 68"
+        # registry: 70 tools after Spec #2799 adds two KFTC OpenGiro send adapters.
+        assert len(tools) == 70, f"Tool list count drift: got {len(tools)}, expected 70"
 
     def test_tools_list_entries_have_required_keys(self, mcp_server: MCPServer) -> None:
         response = asyncio.run(

--- a/tests/lint/test_kftc_secret_redaction.py
+++ b/tests/lint/test_kftc_secret_redaction.py
@@ -1,0 +1,74 @@
+# SPDX-License-Identifier: Apache-2.0
+"""KFTC OpenGiro secret redaction checks."""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from ummaya.settings import UmmayaSettings
+from ummaya.tools.mock.kftc.opengiro import build_setup_readiness
+
+_ROOT = Path(__file__).resolve().parents[2]
+_SCANNED_PATHS = (
+    _ROOT / "src/ummaya/tools/mock/kftc/opengiro.py",
+    _ROOT / "src/ummaya/settings.py",
+    _ROOT / "docs/api/submit/kftc_opengiro.md",
+    _ROOT / "specs/2799-kftc-opengiro-send",
+    _ROOT / "tests/unit/tools/test_mock_kftc_opengiro.py",
+    _ROOT / "tests/integration/test_kftc_opengiro_discovery.py",
+)
+
+_FORBIDDEN_VALUE_PATTERNS = (
+    re.compile(r"(?i)bearer\s+[a-z0-9._-]{12,}"),
+    re.compile(r"(?i)(?<![a-z0-9_])client_secret\s*=\s*['\"][^'\"]{8,}['\"]"),
+    re.compile(r"(?i)(?<![a-z0-9_])access_token\s*=\s*['\"][^'\"]{8,}['\"]"),
+    re.compile(r"(?i)authorization:\s*[a-z0-9._-]{12,}"),
+)
+
+
+def _iter_text_files(path: Path) -> list[Path]:
+    if path.is_file():
+        return [path]
+    return [
+        child
+        for child in path.rglob("*")
+        if child.is_file()
+        and child.suffix in {".md", ".py", ".json"}
+        and "__pycache__" not in child.parts
+    ]
+
+
+@pytest.mark.parametrize("pattern", _FORBIDDEN_VALUE_PATTERNS)
+def test_kftc_artifacts_do_not_contain_secret_value_patterns(pattern: re.Pattern[str]) -> None:
+    offenders: list[str] = []
+    for base in _SCANNED_PATHS:
+        if not base.exists():
+            continue
+        for path in _iter_text_files(base):
+            text = path.read_text(encoding="utf-8")
+            if pattern.search(text):
+                offenders.append(str(path.relative_to(_ROOT)))
+
+    assert offenders == [], f"KFTC secret-like value pattern found in: {offenders}"
+
+
+def test_readiness_model_does_not_serialize_operator_secret_values() -> None:
+    cfg = UmmayaSettings(
+        _env_file=None,
+        kftc_opengiro_service_enabled=True,
+        kftc_opengiro_callback_url="https://operator.example/auth/kftc/opengiro/callback",
+        kftc_opengiro_api_key_registered=True,
+        kftc_opengiro_client_id="portal-client-id",
+        kftc_opengiro_client_secret="redacted-portal-credential",
+        kftc_opengiro_access_token="redacted-portal-token",
+        kftc_opengiro_documents_accessible=True,
+        kftc_opengiro_live_probe_enabled=True,
+    )
+    payload = build_setup_readiness(cfg).model_dump_json()
+
+    assert "portal-client-id" not in payload
+    assert "redacted-portal-credential" not in payload
+    assert "redacted-portal-token" not in payload

--- a/tests/tools/test_registration.py
+++ b/tests/tools/test_registration.py
@@ -38,10 +38,11 @@ class TestToolRegistration:
         # Spec #2797 verified public-data wave: + 14 direct-curl verified
         # data.go.kr/LINK adapters = 52.
         # Spec #2798 live expansion: + 16 approved data.go.kr adapters = 68.
+        # Spec #2799 KFTC OpenGiro: + 2 fixture-backed send adapters = 70.
         # is_core=False so the LLM's primary tool list stays at active
         # primitives + lookup-class; these participate in
         # lookup(mode="search") BM25 corpus only.
-        assert len(registry) == 68
+        assert len(registry) == 70
 
     def test_tool_ids_present(self) -> None:
         """Each expected tool_id is in the registry.
@@ -107,6 +108,9 @@ class TestToolRegistration:
             "ccourt_publication_documents",
             "moj_stay_person_counter",
             "msit_business_announcement_lookup",
+            # Spec #2799 KFTC OpenGiro send adapters
+            "mock_kftc_opengiro_bill_send_v1",
+            "mock_kftc_opengiro_payment_send_v1",
         }
         for tool_id in expected:
             assert tool_id in registry, f"{tool_id} not found in registry"

--- a/tests/tools/test_routing_consistency.py
+++ b/tests/tools/test_routing_consistency.py
@@ -170,7 +170,7 @@ class TestInvariant4UniqueToolId:
 
 
 class TestCheck7ToolListClosure:
-    """The Python-side registered tool set matches the 68-entry registry.
+    """The Python-side registered tool set matches the 70-entry registry.
 
     Divergence from this set indicates either an unauthorized addition or
     an inadvertent removal — both are CI failures.
@@ -226,7 +226,9 @@ class TestCheck7ToolListClosure:
             "mock_verify_ganpyeon_injeung",
             "mock_verify_mobile_id",
             "mock_verify_mydata",
-            # 5 submit wrappers
+            # 7 submit wrappers
+            "mock_kftc_opengiro_bill_send_v1",
+            "mock_kftc_opengiro_payment_send_v1",
             "mock_submit_module_hometax_taxreturn",
             "mock_submit_module_gov24_minwon",
             "mock_submit_module_public_mydata_action",

--- a/tests/unit/ipc/test_adapter_manifest_emitter.py
+++ b/tests/unit/ipc/test_adapter_manifest_emitter.py
@@ -212,7 +212,7 @@ def test_emit_manifest_exits_78_when_no_entries() -> None:
 
 
 def test_audit4_p0_9_mock_submits_have_policy_url(caplog: pytest.LogCaptureFixture) -> None:
-    """Pre-Audit-4: 5 Mock submit adapters lacked an AdapterRealDomainPolicy
+    """Pre-Audit-4: Mock submit adapters lacked an AdapterRealDomainPolicy
     citation, dropping them from the manifest with 10 warnings on every boot.
     Post-Audit-4: each REGISTRATION carries a populated ``policy=`` block, so
     the emitter walks them cleanly and emits zero ``policy_authority_url is
@@ -232,8 +232,10 @@ def test_audit4_p0_9_mock_submits_have_policy_url(caplog: pytest.LogCaptureFixtu
     with caplog.at_level(logging.WARNING, logger="ummaya.ipc.adapter_manifest_emitter"):
         entries = _build_entries(reg, warn_on_missing=True)
 
-    # Five Mock submit adapters MUST surface with policy_authority_url populated.
+    # Mock submit adapters MUST surface with policy_authority_url populated.
     expected_mock_submits = {
+        "mock_kftc_opengiro_bill_send_v1",
+        "mock_kftc_opengiro_payment_send_v1",
         "mock_submit_module_gov24_minwon",
         "mock_submit_module_hometax_taxreturn",
         "mock_submit_module_public_mydata_action",

--- a/tests/unit/tools/test_existing_submit_mocks_have_transparency.py
+++ b/tests/unit/tools/test_existing_submit_mocks_have_transparency.py
@@ -4,6 +4,8 @@
 Covers:
 - mock_traffic_fine_pay_v1 (data_go_kr.fines_pay)
 - mock_welfare_application_submit_v1 (mydata.welfare_application)
+- mock_kftc_opengiro_bill_send_v1 (kftc.opengiro)
+- mock_kftc_opengiro_payment_send_v1 (kftc.opengiro)
 
 Each is retrofitted via stamp_mock_response — this test asserts the six fields
 are present and non-empty in adapter_receipt after a successful invocation.
@@ -29,6 +31,25 @@ _TRANSPARENCY_FIELDS = (
 # ---------------------------------------------------------------------------
 
 _SUBMIT_ADAPTER_CASES = [
+    (
+        "mock_kftc_opengiro_bill_send_v1",
+        {
+            "operation": "create_bill",
+            "giro_no": "1234567",
+            "bill_reference": "MOCK-BILL-TRANSPARENCY",
+            "amount_krw": 15_000,
+            "due_date": "2026-06-30",
+        },
+    ),
+    (
+        "mock_kftc_opengiro_payment_send_v1",
+        {
+            "operation": "create_link_payment_url",
+            "giro_no": "1234567",
+            "payment_reference": "MOCK-PAY-TRANSPARENCY",
+            "amount_krw": 15_000,
+        },
+    ),
     (
         "mock_traffic_fine_pay_v1",
         {"fine_reference": "FINE-2026-001", "payment_method": "card"},
@@ -61,6 +82,7 @@ async def test_existing_submit_mock_has_six_transparency_fields(
     """
     # Ensure mock modules are imported (they self-register on import)
     import ummaya.tools.mock.data_go_kr.fines_pay  # noqa: F401
+    import ummaya.tools.mock.kftc.opengiro  # noqa: F401
     import ummaya.tools.mock.mydata.welfare_application  # noqa: F401
     from ummaya.primitives.submit import _ADAPTER_REGISTRY
 

--- a/tests/unit/tools/test_mock_kftc_opengiro.py
+++ b/tests/unit/tools/test_mock_kftc_opengiro.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+"""Unit tests for KFTC OpenGiro fixture-backed send adapters."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import BaseModel, ConfigDict
+
+import ummaya.tools.mock  # noqa: F401
+from ummaya.primitives._errors import AdapterInvocationError
+from ummaya.primitives.submit import SubmitOutput, SubmitStatus, submit
+from ummaya.settings import UmmayaSettings
+from ummaya.tools.mock.kftc.opengiro import (
+    build_setup_readiness,
+    invoke_bill,
+    invoke_payment,
+)
+
+_TRANSPARENCY_FIELDS = (
+    "_mode",
+    "_reference_implementation",
+    "_actual_endpoint_when_live",
+    "_security_wrapping_pattern",
+    "_policy_authority",
+    "_international_reference",
+)
+
+
+class _MinimalAuthContext(BaseModel):
+    """Minimal AuthContext carrying only the published tier needed by send."""
+
+    model_config = ConfigDict(frozen=True, extra="allow")
+    published_tier: str
+
+
+def _auth_context() -> _MinimalAuthContext:
+    return _MinimalAuthContext(published_tier="geumyung_injeungseo_personal_aal2")
+
+
+def _assert_transparency(receipt: dict[str, object]) -> None:
+    for field in _TRANSPARENCY_FIELDS:
+        value = receipt.get(field)
+        assert value is not None and isinstance(value, str) and value.strip(), (
+            f"adapter_receipt missing or empty {field!r}: {value!r}"
+        )
+    assert receipt["_mode"] == "mock"
+
+
+def test_setup_readiness_fails_closed_by_default() -> None:
+    cfg = UmmayaSettings(_env_file=None)
+    readiness = build_setup_readiness(cfg)
+
+    assert readiness.live_ready is False
+    assert "KFTC Callback URL is not registered" in readiness.blockers
+    assert "OpenGiro API Key registration is incomplete" in readiness.blockers
+    assert "KFTC Client Secret is not configured" in readiness.blockers
+
+
+def test_setup_readiness_exposes_only_booleans_not_secret_values() -> None:
+    cfg = UmmayaSettings(
+        _env_file=None,
+        kftc_opengiro_service_enabled=True,
+        kftc_opengiro_callback_url="https://operator.example/auth/kftc/opengiro/callback",
+        kftc_opengiro_api_key_registered=True,
+        kftc_opengiro_client_id="client-id-visible-in-portal",
+        kftc_opengiro_client_secret="redacted-test-credential",
+        kftc_opengiro_access_token="redacted-test-token",
+        kftc_opengiro_documents_accessible=True,
+        kftc_opengiro_live_probe_enabled=True,
+    )
+    readiness = build_setup_readiness(cfg)
+    serialized = readiness.model_dump_json()
+
+    assert readiness.live_ready is True
+    assert "redacted-test-credential" not in serialized
+    assert "redacted-test-token" not in serialized
+    assert "client-id-visible-in-portal" not in serialized
+
+
+@pytest.mark.asyncio
+async def test_bill_adapter_happy_path_uses_send_envelope() -> None:
+    result = await submit(
+        tool_id="mock_kftc_opengiro_bill_send_v1",
+        params={
+            "operation": "create_bill",
+            "giro_no": "1234567",
+            "bill_reference": "MOCK-BILL-2026-001",
+            "amount_krw": 25_000,
+            "due_date": "2026-06-30",
+        },
+        auth_context=_auth_context(),
+    )
+
+    assert isinstance(result, SubmitOutput)
+    assert result.status == SubmitStatus.succeeded
+    assert result.transaction_id.startswith("urn:ummaya:send:")
+    assert result.model_dump().keys() == {"transaction_id", "status", "adapter_receipt"}
+    assert result.adapter_receipt["status_detail"] == "created"
+    assert result.adapter_receipt["giro_no_masked"] == "123***67"
+    assert "MOCK-BILL-2026-001" not in str(result.adapter_receipt)
+    _assert_transparency(result.adapter_receipt)
+
+
+@pytest.mark.asyncio
+async def test_bill_adapter_validation_error_returns_structured_invocation_error() -> None:
+    result = await submit(
+        tool_id="mock_kftc_opengiro_bill_send_v1",
+        params={
+            "operation": "create_bill",
+            "giro_no": "1234567",
+            "bill_reference": "MOCK-BILL-VALIDATION",
+            "amount_krw": None,
+        },
+        auth_context=_auth_context(),
+    )
+
+    assert isinstance(result, AdapterInvocationError)
+    assert result.tool_id == "mock_kftc_opengiro_bill_send_v1"
+    assert result.reason == "adapter_invocation_failed"
+    assert "create_bill requires amount_krw" in result.message
+
+
+@pytest.mark.asyncio
+async def test_bill_adapter_live_probe_missing_setup_is_rejected() -> None:
+    result = await submit(
+        tool_id="mock_kftc_opengiro_bill_send_v1",
+        params={
+            "operation": "check_payment_status",
+            "giro_no": "1234567",
+            "bill_reference": "MOCK-BILL-LIVE-BLOCKED",
+            "live_probe_requested": True,
+        },
+        auth_context=_auth_context(),
+    )
+
+    assert isinstance(result, SubmitOutput)
+    assert result.status == SubmitStatus.rejected
+    assert result.adapter_receipt["status_detail"] == "setup_blocked"
+    assert "KFTC Callback URL is not registered" in str(result.adapter_receipt["setup_blockers"])
+    _assert_transparency(result.adapter_receipt)
+
+
+@pytest.mark.asyncio
+async def test_payment_adapter_url_creation_returns_pending_fixture() -> None:
+    result = await submit(
+        tool_id="mock_kftc_opengiro_payment_send_v1",
+        params={
+            "operation": "create_link_payment_url",
+            "giro_no": "1234567",
+            "payment_reference": "MOCK-PAY-2026-001",
+            "amount_krw": 25_000,
+        },
+        auth_context=_auth_context(),
+    )
+
+    assert isinstance(result, SubmitOutput)
+    assert result.status == SubmitStatus.pending
+    assert result.adapter_receipt["status_detail"] == "payment_url_issued"
+    assert str(result.adapter_receipt["payment_url"]).startswith(
+        "https://mock.open-giro.ummaya.local/pay/"
+    )
+    assert "MOCK-PAY-2026-001" not in str(result.adapter_receipt)
+    _assert_transparency(result.adapter_receipt)
+
+
+@pytest.mark.asyncio
+async def test_payment_adapter_rejected_and_expired_paths() -> None:
+    rejected = await invoke_payment(
+        {
+            "operation": "query_payment_result",
+            "giro_no": "1234567",
+            "payment_reference": "REJECT-PAY-001",
+        }
+    )
+    expired = await invoke_payment(
+        {
+            "operation": "query_payment_result",
+            "giro_no": "1234567",
+            "payment_reference": "EXPIRED-PAY-001",
+        }
+    )
+
+    assert rejected.status == SubmitStatus.rejected
+    assert rejected.adapter_receipt["status_detail"] == "rejected"
+    assert expired.status == SubmitStatus.failed
+    assert expired.adapter_receipt["status_detail"] == "expired"
+
+
+@pytest.mark.asyncio
+async def test_direct_bill_and_payment_invokes_have_policy_urls() -> None:
+    bill = await invoke_bill(
+        {
+            "operation": "cancel_bill",
+            "giro_no": "1234567",
+            "bill_reference": "MOCK-BILL-CANCEL-001",
+        }
+    )
+    payment = await invoke_payment(
+        {
+            "operation": "query_payment_result",
+            "giro_no": "1234567",
+            "payment_reference": "MOCK-PAY-QUERY-001",
+        }
+    )
+
+    assert bill.adapter_receipt["_policy_authority"].endswith("/open-giro/index")
+    assert payment.adapter_receipt["_policy_authority"].endswith("/open-giro/pay-service")

--- a/tests/unit/tools/test_mock_transparency_scan.py
+++ b/tests/unit/tools/test_mock_transparency_scan.py
@@ -3,7 +3,7 @@
 
 Parameterised over active mock adapter IDs:
   - 10 verify families  (ummaya.primitives.verify._VERIFY_ADAPTERS)
-  - 5  submit adapters  (ummaya.primitives.submit._ADAPTER_REGISTRY)
+  - 7  submit adapters  (ummaya.primitives.submit._ADAPTER_REGISTRY)
   - 2  lookup tools     (main ToolRegistry, adapter_mode='mock')
 
 Each adapter is invoked with minimal synthetic input and the six transparency
@@ -126,7 +126,7 @@ def test_verify_adapter_carries_six_transparency_fields(family: str) -> None:
 
 
 # ---------------------------------------------------------------------------
-# Submit surface — 5 adapters
+# Submit surface — 7 adapters
 # ---------------------------------------------------------------------------
 
 # Adapters that require a DelegationContext in params (new delegation-aware mocks)
@@ -168,6 +168,25 @@ _DELEGATION_SUBMIT_CASES: list[tuple[str, str, dict[str, Any]]] = [
 
 # Adapters that do NOT require a DelegationContext (existing pre-delegation mocks)
 _NODELEGATION_SUBMIT_CASES: list[tuple[str, dict[str, Any]]] = [
+    (
+        "mock_kftc_opengiro_bill_send_v1",
+        {
+            "operation": "create_bill",
+            "giro_no": "1234567",
+            "bill_reference": "MOCK-BILL-SCAN-001",
+            "amount_krw": 15_000,
+            "due_date": "2026-06-30",
+        },
+    ),
+    (
+        "mock_kftc_opengiro_payment_send_v1",
+        {
+            "operation": "create_link_payment_url",
+            "giro_no": "1234567",
+            "payment_reference": "MOCK-PAY-SCAN-001",
+            "amount_krw": 15_000,
+        },
+    ),
     (
         "mock_traffic_fine_pay_v1",
         {"fine_reference": "FINE-SCAN-001", "payment_method": "card"},
@@ -324,10 +343,10 @@ def _all_mock_adapter_ids() -> list[str]:
     )
 
 
-def test_canonical_mock_adapter_count_is_17() -> None:
-    """Guard: canonical active mock adapter list must total exactly 17 entries."""
+def test_canonical_mock_adapter_count_is_19() -> None:
+    """Guard: canonical active mock adapter list must total exactly 19 entries."""
     ids = _all_mock_adapter_ids()
-    assert len(ids) == 17, f"Expected 17 canonical Mock adapter IDs, got {len(ids)}. IDs: {ids}"
+    assert len(ids) == 19, f"Expected 19 canonical Mock adapter IDs, got {len(ids)}. IDs: {ids}"
     assert len(set(ids)) == len(ids), (
         "Duplicate adapter IDs detected in canonical list — each adapter must "
         f"appear exactly once. Duplicates: "

--- a/tests/unit/tools/test_registry_count_breakdown.py
+++ b/tests/unit/tools/test_registry_count_breakdown.py
@@ -2,9 +2,9 @@
 """T035 — Registry count breakdown assertion (SC-003).
 
 Boots the registry and asserts the active count breakdown from spec.md SC-003:
-  - Main ToolRegistry: 68 entries
+  - Main ToolRegistry: 70 entries
   - ummaya.primitives.verify._VERIFY_ADAPTERS: 10 families
-  - ummaya.primitives.submit._ADAPTER_REGISTRY: 5 families
+  - ummaya.primitives.submit._ADAPTER_REGISTRY: 7 families
 
 Test FAILS if any count is off-by-one.
 
@@ -16,7 +16,7 @@ do NOT silently adjust the expected values.
 from __future__ import annotations
 
 # ---------------------------------------------------------------------------
-# Main ToolRegistry count — 68 total
+# Main ToolRegistry count — 70 total
 # ---------------------------------------------------------------------------
 # Epic η #2298 — extended from 16 to 18 by adding `check` / `send`
 # to mvp_surface as `is_core=True` GovAPITool entries (FR-021).
@@ -30,7 +30,8 @@ from __future__ import annotations
 #     simple_auth,any_id_sso} + mock_verify_{gongdong,geumyung,ganpyeon,
 #     mobile_id,mydata}_*)
 #   - 5 submit wrappers (mock_submit_module_{hometax_taxreturn,gov24_minwon,
-#     public_mydata_action} + mock_traffic_fine_pay_v1 + mock_welfare_application_submit_v1)
+#     public_mydata_action} + mock_traffic_fine_pay_v1 + mock_welfare_application_submit_v1);
+#     Spec #2799 adds 2 OpenGiro submit wrappers, bringing wrapped submit tools to 7.
 # These wrappers are registered with is_core=False so the LLM's primary tool list
 # stays at active primitives + find-class Live; they participate in find(mode="search")
 # BM25 corpus so verify/submit candidates surface for citizen queries
@@ -42,7 +43,9 @@ from __future__ import annotations
 # verified public-data adapters under src/ummaya/tools/verified_data_go_kr/.
 # Spec #2798 — extended from 52 to 68 by registering sixteen additional
 # approved live public-data adapters from the 2026-05-16 direct evidence batch.
-_EXPECTED_MAIN_REGISTRY_COUNT = 68
+# Spec #2799 — extended from 68 to 70 by registering two fixture-backed KFTC
+# OpenGiro send adapters.
+_EXPECTED_MAIN_REGISTRY_COUNT = 70
 
 _EXPECTED_MAIN_REGISTRY_BREAKDOWN = {
     "live_adapters": 42,  # 12 existing Live + 30 verified public-data adapters
@@ -109,7 +112,7 @@ _EXPECTED_LOOKUP_MOCK_IDS = frozenset(
 
 
 def test_main_registry_total_count() -> None:
-    """Main ToolRegistry must have exactly 68 entries after register_all_tools()."""
+    """Main ToolRegistry must have exactly 70 entries after register_all_tools()."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.tools.executor import ToolExecutor
     from ummaya.tools.register_all import register_all_tools
@@ -256,16 +259,19 @@ def test_verify_digital_onepass_not_in_registry() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Submit sub-registry count — 5 adapters
+# Submit sub-registry count — 7 adapters
 # ---------------------------------------------------------------------------
 
-_EXPECTED_SUBMIT_COUNT = 5
+_EXPECTED_SUBMIT_COUNT = 7
 
 _EXPECTED_SUBMIT_IDS = frozenset(
     {
         # 2 existing (retrofitted, pre-delegation)
         "mock_traffic_fine_pay_v1",
         "mock_welfare_application_submit_v1",
+        # 2 KFTC OpenGiro fixture-backed send adapters
+        "mock_kftc_opengiro_bill_send_v1",
+        "mock_kftc_opengiro_payment_send_v1",
         # 3 new delegation-aware (Epic ε)
         "mock_submit_module_hometax_taxreturn",
         "mock_submit_module_gov24_minwon",
@@ -275,7 +281,7 @@ _EXPECTED_SUBMIT_IDS = frozenset(
 
 
 def test_submit_adapter_registry_count() -> None:
-    """ummaya.primitives.submit._ADAPTER_REGISTRY must have exactly 5 entries."""
+    """ummaya.primitives.submit._ADAPTER_REGISTRY must have exactly 7 entries."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.submit import _ADAPTER_REGISTRY
 
@@ -288,7 +294,7 @@ def test_submit_adapter_registry_count() -> None:
 
 
 def test_submit_adapter_registry_ids() -> None:
-    """All 5 expected submit adapter IDs must be present in _ADAPTER_REGISTRY."""
+    """All 7 expected submit adapter IDs must be present in _ADAPTER_REGISTRY."""
     import ummaya.tools.mock  # noqa: F401 — trigger side-effect registration
     from ummaya.primitives.submit import _ADAPTER_REGISTRY
 
@@ -340,14 +346,16 @@ def test_all_active_surface_counts_match_canonical() -> None:
         # Epic ζ #2297 path B (live smoke 2026-04-30) — main_registry extended
         # from 18 to 33 by discovery_bridge bridging 15 non-core mock adapters
         # (10 verify + 5 submit family wrappers) into the BM25
-        # corpus so find(mode="search") surfaces them. is_core=False so the
+        # corpus so find(mode="search") surfaces them. Spec #2799 adds two KFTC
+        # OpenGiro send wrappers, bringing the main ToolRegistry to 70 and the
+        # submit registry to 7. is_core=False so the
         # primary LLM tool list stays at active primitives + find-class Live.
         # Locate-provider adapters add five first-class registry entries.
         # Spec #2798 adds sixteen approved live data.go.kr adapters, bringing
         # the main ToolRegistry from 52 to 68.
-        "main_registry": 68,
+        "main_registry": 70,
         "verify_families": 10,
-        "submit_adapters": 5,
+        "submit_adapters": 7,
     }
 
     failures = []


### PR DESCRIPTION
## Summary
- add fixture-backed KFTC OpenGiro bill/payment send adapters under `mock_kftc_opengiro_*`
- document KFTC portal readiness, Callback URL/API Key blockers, and official OpenGiro source links
- export schemas, update registry counts, and add discovery/readiness/redaction tests

## Official sources
- KFTC starter workflow: https://developers.kftc.or.kr/dev/starter/starter
- OpenGiro bill service: https://developers.kftc.or.kr/dev/openapi/open-giro/index
- OpenGiro payment service: https://developers.kftc.or.kr/dev/openapi/open-giro/pay-service
- OpenGiro access notice: https://developers.kftc.or.kr/dev/support/notice/all/detail?id=44&boardCtgCd=all

## Verification
- `uv run pytest tests/unit/tools/test_mock_kftc_opengiro.py tests/integration/test_kftc_opengiro_discovery.py tests/lint/test_kftc_secret_redaction.py`
- `uv run python scripts/build_schemas.py --check`
- `uv run ruff check src tests`
- `uv run ruff format --check src tests`
- `uv run pytest` -> 4096 passed, 63 skipped, 3 xfailed

Closes #2951