### PR TITLE
fix: normalize LF enter keypress

### DIFF
--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ummaya" do
-  version "0.1.12"
-  sha256 "9e5c3d6ad0d1eb92e021a478656dc1fdf293636ad98a195c73c74b8b0111f40c"
+  version "0.1.13"
+  sha256 "710b48a8f311d98f3a25c886aeefd709789c7d4fe5c5cd7999ec2f43f7b1296c"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"
@@ -13,12 +13,14 @@ cask "ummaya" do
   depends_on formula: "oven-sh/bun/bun"
   depends_on formula: "uv"
 
+  binary "ummaya"
+
   preflight do
     install_args = ["install", "--production", "--cwd", "#{staged_path}/package"]
-    if File.exist?("#{staged_path}/package/bun.lock")
-      install_args << "--frozen-lockfile"
+    install_args << if File.exist?("#{staged_path}/package/bun.lock")
+      "--frozen-lockfile"
     else
-      install_args << "--no-save"
+      "--no-save"
     end
 
     system_command "#{HOMEBREW_PREFIX}/opt/bun/bin/bun",
@@ -32,8 +34,6 @@ cask "ummaya" do
     SH
     FileUtils.chmod 0755, wrapper
   end
-
-  binary "ummaya"
 
   zap trash: "~/.ummaya"
 end

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Conversational multi-agent harness for Korean public-service channels",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ummaya"
-version = "0.1.12"
+version = "0.1.13"
 description = "Conversational multi-agent platform for Korean public APIs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -314,7 +314,7 @@ min_confidence = 80
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.12"
+version = "0.1.13"
 tag_format = "v$version"
 
 # PyTorch CPU-only wheel for Docker image size discipline (SC-1: ≤ 2 GB).

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "engines": {

--- a/tui/src/ink/parse-keypress.ts
+++ b/tui/src/ink/parse-keypress.ts
@@ -698,11 +698,9 @@ function parseKeypress(s: string = ''): ParsedKey {
     return createNavKey(s, 'mouse', false)
   }
 
-  if (s === '\r') {
+  if (s === '\r' || s === '\n') {
     key.raw = undefined
     key.name = 'return'
-  } else if (s === '\n') {
-    key.name = 'enter'
   } else if (s === '\t') {
     key.name = 'tab'
   } else if (s === '\b' || s === '\x1b\b') {

--- a/tui/tests/ink/enter-normalization.test.ts
+++ b/tui/tests/ink/enter-normalization.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+
+import { InputEvent } from '../../src/ink/events/input-event'
+import { INITIAL_STATE, parseMultipleKeypresses } from '../../src/ink/parse-keypress'
+
+describe('Enter key normalization', () => {
+  test('treats LF as Return so terminal variants still submit input', () => {
+    const [parsed] = parseMultipleKeypresses(INITIAL_STATE, '\n')
+    const keypress = parsed[0]
+
+    expect(keypress?.kind).toBe('key')
+    if (keypress?.kind !== 'key') {
+      throw new Error('expected LF to parse as a keypress')
+    }
+
+    const event = new InputEvent(keypress)
+    expect(event.key.return).toBe(true)
+    expect(event.input).toBe('')
+  })
+})

--- a/uv.lock
+++ b/uv.lock
@@ -2725,7 +2725,7 @@ wheels = [
 
 [[package]]
 name = "ummaya"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Normalize LF (`\n`) terminal input as Return so prompt submission works in terminals that emit LF instead of CR.
- Add a regression test proving LF maps to `InputEvent.key.return`.
- Bump release metadata to 0.1.13 and update the existing tap cask SHA from the packed npm tarball.

## Verification
- `bun test tests/ink/enter-normalization.test.ts tests/components/PromptInput/SlashCommandSuggestions.test.tsx`
- `bun run typecheck`
- `bun run test`
- `bun run tui:smoke`
- `uv run pytest -m "not live"`
- `npm run package:check`
- `brew style --fix Casks/ummaya.rb`

## Release notes
- Intended release: `v0.1.13` after this lands on `main`.
- TUI verification: Enter parsing regression is covered in-process and by `tui:smoke`; no adapter/API behavior changed.