### PR TITLE
fix: normalize LF enter keypress

### DIFF
--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
 cask "ummaya" do
-  version "0.1.12"
-  sha256 "9e5c3d6ad0d1eb92e021a478656dc1fdf293636ad98a195c73c74b8b0111f40c"
+  version "0.1.13"
+  sha256 "691fdde26626f97f1bcc13b1c519e93bb029b4625c82d07f4fe981b3d3a2b566"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"
@@ -13,12 +13,14 @@ cask "ummaya" do
   depends_on formula: "oven-sh/bun/bun"
   depends_on formula: "uv"
 
+  binary "ummaya"
+
   preflight do
     install_args = ["install", "--production", "--cwd", "#{staged_path}/package"]
-    if File.exist?("#{staged_path}/package/bun.lock")
-      install_args << "--frozen-lockfile"
+    install_args << if File.exist?("#{staged_path}/package/bun.lock")
+      "--frozen-lockfile"
     else
-      install_args << "--no-save"
+      "--no-save"
     end
 
     system_command "#{HOMEBREW_PREFIX}/opt/bun/bin/bun",
@@ -32,8 +34,6 @@ cask "ummaya" do
     SH
     FileUtils.chmod 0755, wrapper
   end
-
-  binary "ummaya"
 
   zap trash: "~/.ummaya"
 end

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.12",
+      "version": "0.1.13",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "description": "Conversational multi-agent harness for Korean public-service channels",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ummaya"
-version = "0.1.12"
+version = "0.1.13"
 description = "Conversational multi-agent platform for Korean public APIs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -314,7 +314,7 @@ min_confidence = 80
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.12"
+version = "0.1.13"
 tag_format = "v$version"
 
 # PyTorch CPU-only wheel for Docker image size discipline (SC-1: ≤ 2 GB).

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.12",
+  "version": "0.1.13",
   "private": true,
   "type": "module",
   "engines": {

--- a/tui/src/ink/parse-keypress.ts
+++ b/tui/src/ink/parse-keypress.ts
@@ -698,11 +698,9 @@ function parseKeypress(s: string = ''): ParsedKey {
     return createNavKey(s, 'mouse', false)
   }
 
-  if (s === '\r') {
+  if (s === '\r' || s === '\n') {
     key.raw = undefined
     key.name = 'return'
-  } else if (s === '\n') {
-    key.name = 'enter'
   } else if (s === '\t') {
     key.name = 'tab'
   } else if (s === '\b' || s === '\x1b\b') {

--- a/tui/tests/ink/enter-normalization.test.ts
+++ b/tui/tests/ink/enter-normalization.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { describe, expect, test } from 'bun:test'
+
+import { InputEvent } from '../../src/ink/events/input-event'
+import { INITIAL_STATE, parseMultipleKeypresses } from '../../src/ink/parse-keypress'
+
+describe('Enter key normalization', () => {
+  test('treats LF as Return so terminal variants still submit input', () => {
+    const [parsed] = parseMultipleKeypresses(INITIAL_STATE, '\n')
+    const keypress = parsed[0]
+
+    expect(keypress?.kind).toBe('key')
+    if (keypress?.kind !== 'key') {
+      throw new Error('expected LF to parse as a keypress')
+    }
+
+    const event = new InputEvent(keypress)
+    expect(event.key.return).toBe(true)
+    expect(event.input).toBe('')
+  })
+})

--- a/uv.lock
+++ b/uv.lock
@@ -624,11 +624,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.11"
+version = "3.16"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/6f/6d/0703ccc57f3a7233505399edb88de3cbd678da106337b9fcde432b65ed60/idna-3.11.tar.gz", hash = "sha256:795dafcc9c04ed0c1fb032c2aa73654d8e8c5023a7df64a53f39190ada629902", size = 194582, upload-time = "2025-10-12T14:55:20.501Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1a/88/bcf9709822fe69d02c2a6a77956c98ce6ea8ca8767a9aadcedc7eb6a2390/idna-3.16.tar.gz", hash = "sha256:d7a6da03db833450fca25d2358ac9ff06cd624577a4aea3a596d5c0f77b8e03d", size = 203770, upload-time = "2026-05-22T00:16:18.781Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0e/61/66938bbb5fc52dbdf84594873d5b51fb1f7c7794e9c0f5bd885f30bc507b/idna-3.11-py3-none-any.whl", hash = "sha256:771a87f49d9defaf64091e6e6fe9c18d4833f140bd19464795bc32d966ca37ea", size = 71008, upload-time = "2025-10-12T14:55:18.883Z" },
+    { url = "https://files.pythonhosted.org/packages/94/16/70255075a9859a0e3adb789b68ceb0e210dec03934245fd98d248226572f/idna-3.16-py3-none-any.whl", hash = "sha256:cc246e3a3f89580c3a951b5ad298ca4638078b2cdd4f115654332b5c26daded5", size = 74165, upload-time = "2026-05-22T00:16:16.698Z" },
 ]
 
 [[package]]
@@ -2725,7 +2725,7 @@ wheels = [
 
 [[package]]
 name = "ummaya"
-version = "0.1.12"
+version = "0.1.13"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Normalize LF (`\n`) terminal input as Return so prompt submission works in terminals that emit LF instead of CR.
- Add a regression test proving LF maps to `InputEvent.key.return`.
- Bump release metadata to 0.1.13 and update the existing tap cask SHA from the packed npm tarball.

## Verification
- `bun test tests/ink/enter-normalization.test.ts tests/components/PromptInput/SlashCommandSuggestions.test.tsx`
- `bun run typecheck`
- `bun run test`
- `bun run tui:smoke`
- `uv run pytest -m "not live"`
- `npm run package:check`
- `brew style --fix Casks/ummaya.rb`

## Release notes
- Intended release: `v0.1.13` after this lands on `main`.
- TUI verification: Enter parsing regression is covered in-process and by `tui:smoke`; no adapter/API behavior changed.