### PR TITLE
chore(release): sync 0.1.13 cask sha

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ The UMMAYA migration-completion release. Initiative #1631 closed; the six Phase 
 - Auto-generated adapter spec stubs from Pydantic docstrings (#1975).
 - Shape-mirror migration of the OPAQUE mock stubs (`barocert/`, `npki_crypto/`, `omnione/`) into `docs/scenarios/` (#1976).
 
+## [v0.1.13] - 2026-05-22
+
+### Fixed
+
+- Normalized LF terminal keypresses to Return in the Ink input parser so prompt text submits correctly in terminals that send `\n`.
+- Synced the Homebrew cask SHA to the published `ummaya@0.1.13` npm registry tarball.
+
 ## [Unreleased]
 
 ### Added

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -2,7 +2,7 @@
 
 cask "ummaya" do
   version "0.1.13"
-  sha256 "691fdde26626f97f1bcc13b1c519e93bb029b4625c82d07f4fe981b3d3a2b566"
+  sha256 "1cb322d680342fd5fe8e1f7e82919b8aaa731181fb6ce41cf475f294b797e5f6"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"


### PR DESCRIPTION
## Summary
- Update the local Homebrew cask SHA to match the published npm registry tarball for ummaya@0.1.13.

## Verification
- npm view ummaya@0.1.13 version dist.tarball dist.integrity --json
- curl registry tarball + shasum -a 256 => 1cb322d680342fd5fe8e1f7e82919b8aaa731181fb6ce41cf475f294b797e5f6
- brew style --fix Casks/ummaya.rb
- npm run package:check

## Release note
- Repairs the cask checksum after npm registry publication so the v0.1.13 release surfaces match the immutable npm artifact.