### PR TITLE
chore(release): sync 0.1.14 cask sha

### DIFF
--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -2,7 +2,7 @@
 
 cask "ummaya" do
   version "0.1.14"
-  sha256 "2b757862d71e9bc1d5c3497aa7548e9ac05c4707f48a554fbc7af72ae5d7e690"
+  sha256 "5c6dc87292534e0bbea1acf46831f3bbcf654237f6c07f8174b3d4eac23e8891"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"

--- a/specs/lf-coalesced-enter/cask-sha-0.1.14.txt
+++ b/specs/lf-coalesced-enter/cask-sha-0.1.14.txt
@@ -1,0 +1,8 @@
+UMMAYA 0.1.14 Cask SHA evidence
+
+Command:
+curl -L https://registry.npmjs.org/ummaya/-/ummaya-0.1.14.tgz -o /tmp/ummaya-cask-sha-0.1.14.tgz
+shasum -a 256 /tmp/ummaya-cask-sha-0.1.14.tgz
+
+Output:
+5c6dc87292534e0bbea1acf46831f3bbcf654237f6c07f8174b3d4eac23e8891  /tmp/ummaya-cask-sha-0.1.14.tgz


### PR DESCRIPTION
## Summary
- Update `Casks/ummaya.rb` to the actual npm registry tarball SHA for `ummaya@0.1.14`.

## Verification
- `ruby -c Casks/ummaya.rb`
- `curl -L https://registry.npmjs.org/ummaya/-/ummaya-0.1.14.tgz -o /tmp/ummaya-cask-sha-0.1.14.tgz && shasum -a 256 /tmp/ummaya-cask-sha-0.1.14.tgz` -> `5c6dc87292534e0bbea1acf46831f3bbcf654237f6c07f8174b3d4eac23e8891`
- `git diff --check`

TUI no-change: this PR only touches the local Cask metadata.