### PR TITLE
chore(release): sync 0.1.15 cask sha

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ on:
       - "tui/**"
       - "specs/**"
       - "docs/**"
+      - "Casks/ummaya.rb"
       - "*.md"
       # Required CI contexts must materialize for workflow-only PRs too.
       - ".github/workflows/**"

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -2,7 +2,7 @@
 
 cask "ummaya" do
   version "0.1.15"
-  sha256 "92b7dd886519d1c7721f83ad0a5a302dede8bff6e0de9685b3f453c43b161490"
+  sha256 "83704be590b190dc1045babae85c28a9b4573e70d45b0df96b77df0753428e5d"
 
   url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
       verified: "registry.npmjs.org/ummaya/"


### PR DESCRIPTION
## Summary

- Syncs `Casks/ummaya.rb` to the published npm registry tarball SHA for `ummaya@0.1.15`.
- Adds `Casks/ummaya.rb` to the CI pull_request path filter so required branch-protection contexts materialize for Cask-only release PRs.

## Verification

- Downloaded `https://registry.npmjs.org/ummaya/-/ummaya-0.1.15.tgz`
- `shasum -a 256` -> `83704be590b190dc1045babae85c28a9b4573e70d45b0df96b77df0753428e5d`
- `ruby -c Casks/ummaya.rb`
- `npm run package:check`
- `git diff --check`

TUI no-change.
