### PR TITLE
chore(release): add prebuilt macOS cask artifacts

### DIFF
--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -17,9 +17,11 @@ on:
       - "Casks/ummaya.rb"
       - "install.sh"
       - "scripts/check-npm-package.mjs"
+      - "scripts/build-homebrew-cask-artifact.mjs"
       - "scripts/render-homebrew-cask.mjs"
       - ".github/workflows/package-npm.yml"
       - ".github/workflows/publish-npm.yml"
+      - ".github/workflows/publish-homebrew-cask-artifacts.yml"
       - ".github/workflows/publish-homebrew.yml"
   workflow_dispatch:
 

--- a/.github/workflows/publish-homebrew-cask-artifacts.yml
+++ b/.github/workflows/publish-homebrew-cask-artifacts.yml
@@ -1,0 +1,133 @@
+name: Publish Homebrew Cask Artifacts
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to build, without leading v"
+        required: true
+        type: string
+
+concurrency:
+  group: publish-homebrew-cask-artifacts-${{ github.ref }}-${{ github.event.inputs.version || github.ref_name }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+
+jobs:
+  build:
+    name: Build macOS ${{ matrix.arch }} cask artifact
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 30
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - arch: arm64
+            runner: macos-14
+          - arch: x64
+            runner: macos-15-intel
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          package-manager-cache: false
+
+      - name: Verify package version
+        run: |
+          package_version="$(node -p "require('./package.json').version")"
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            expected_version="${GITHUB_REF_NAME#v}"
+          else
+            expected_version="${{ github.event.inputs.version }}"
+          fi
+          if [ "${package_version}" != "${expected_version}" ]; then
+            echo "::error::package.json version ${package_version} does not match release version ${expected_version}"
+            exit 1
+          fi
+
+      - name: Install npm CLI
+        run: npm install --global npm@11.14.1
+
+      - name: Install release tooling dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Build prebuilt cask artifact
+        run: node scripts/build-homebrew-cask-artifact.mjs --arch "${{ matrix.arch }}" --out-dir dist/homebrew
+
+      - name: Verify archive shape
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          artifact="dist/homebrew/ummaya-${version}-macos-${{ matrix.arch }}.tar.gz"
+          mkdir -p "${RUNNER_TEMP}/ummaya-cask-smoke"
+          tar -xzf "${artifact}" -C "${RUNNER_TEMP}/ummaya-cask-smoke"
+          test -x "${RUNNER_TEMP}/ummaya-cask-smoke/ummaya"
+          test -x "${RUNNER_TEMP}/ummaya-cask-smoke/runtime/bun"
+          test -d "${RUNNER_TEMP}/ummaya-cask-smoke/package/node_modules"
+          test -f "${artifact}.sha256"
+          "${RUNNER_TEMP}/ummaya-cask-smoke/ummaya" --version
+          "${RUNNER_TEMP}/ummaya-cask-smoke/ummaya" --help >/dev/null
+
+      - name: Upload cask artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: homebrew-cask-${{ matrix.arch }}
+          path: |
+            dist/homebrew/ummaya-*-macos-${{ matrix.arch }}.tar.gz
+            dist/homebrew/ummaya-*-macos-${{ matrix.arch }}.tar.gz.sha256
+            dist/homebrew/ummaya-*-macos-${{ matrix.arch }}.json
+          if-no-files-found: error
+          retention-days: 90
+
+  release:
+    name: Attach cask artifacts to GitHub Release
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/download-artifact@v8
+        with:
+          pattern: homebrew-cask-*
+          path: dist/homebrew
+          merge-multiple: true
+
+      - name: Resolve tag
+        id: release
+        run: |
+          if [ "${GITHUB_REF_TYPE}" = "tag" ]; then
+            tag="${GITHUB_REF_NAME}"
+          else
+            tag="v${{ github.event.inputs.version }}"
+          fi
+          if ! printf '%s' "${tag}" | grep -Eq '^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$'; then
+            echo "::error::Invalid release tag: ${tag}"
+            exit 1
+          fi
+          echo "tag=${tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Ensure GitHub Release exists
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          tag="${{ steps.release.outputs.tag }}"
+          if ! gh release view "${tag}" >/dev/null 2>&1; then
+            gh release create "${tag}" --title "UMMAYA ${tag}" --target "${GITHUB_SHA}" --generate-notes
+          fi
+
+      - name: Upload release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release upload "${{ steps.release.outputs.tag }}" \
+            dist/homebrew/ummaya-*-macos-*.tar.gz \
+            dist/homebrew/ummaya-*-macos-*.tar.gz.sha256 \
+            dist/homebrew/ummaya-*-macos-*.json \
+            --clobber

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -42,19 +42,23 @@ jobs:
           fi
           echo "version=${version}" >> "${GITHUB_OUTPUT}"
 
-      - name: Download npm tarball
+      - name: Download prebuilt macOS artifacts
         run: |
           version="${{ steps.version.outputs.version }}"
-          url="https://registry.npmjs.org/ummaya/-/ummaya-${version}.tgz"
-          curl -fsSL "${url}" -o "ummaya-${version}.tgz"
-          sha256="$(sha256sum "ummaya-${version}.tgz" | cut -d ' ' -f1)"
-          echo "UMMAYA_TARBALL_SHA256=${sha256}" >> "${GITHUB_ENV}"
+          for arch in arm64 x64; do
+            url="https://github.com/umyunsang/UMMAYA/releases/download/v${version}/ummaya-${version}-macos-${arch}.tar.gz"
+            curl -fsSL "${url}" -o "ummaya-${version}-macos-${arch}.tar.gz"
+            sha256="$(sha256sum "ummaya-${version}-macos-${arch}.tar.gz" | cut -d ' ' -f1)"
+            key="UMMAYA_CASK_SHA256_${arch}"
+            echo "${key}=${sha256}" >> "${GITHUB_ENV}"
+          done
 
       - name: Render cask
         run: |
           node scripts/render-homebrew-cask.mjs \
             "${{ steps.version.outputs.version }}" \
-            "${UMMAYA_TARBALL_SHA256}" \
+            "${UMMAYA_CASK_SHA256_arm64}" \
+            "${UMMAYA_CASK_SHA256_x64}" \
             Casks/ummaya.rb
 
       - name: Fetch Homebrew tap token from Infisical

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -1,37 +1,19 @@
 # frozen_string_literal: true
 
 cask "ummaya" do
-  version "0.1.15"
-  sha256 "83704be590b190dc1045babae85c28a9b4573e70d45b0df96b77df0753428e5d"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
-      verified: "registry.npmjs.org/ummaya/"
+  version "0.1.16"
+  sha256 arm:   "8cf564d9c0ab7a695a0f34968911e2b9403fda8cc2de9ac053731a04e3573900",
+         intel: "e0fcf2e7a51689a9b06b185cc47353cb09f40533c8a7805b938ad6366a64ece4"
+
+  url "https://github.com/umyunsang/UMMAYA/releases/download/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz",
+      verified: "github.com/umyunsang/UMMAYA/"
   name "UMMAYA"
   desc "Conversational multi-agent harness for Korean public-service channels"
   homepage "https://github.com/umyunsang/UMMAYA"
 
-  depends_on formula: "oven-sh/bun/bun"
   depends_on formula: "uv"
-
-  preflight do
-    install_args = ["install", "--production", "--cwd", "#{staged_path}/package"]
-    if File.exist?("#{staged_path}/package/bun.lock")
-      install_args << "--frozen-lockfile"
-    else
-      install_args << "--no-save"
-    end
-
-    system_command "#{HOMEBREW_PREFIX}/opt/bun/bin/bun",
-                   args: install_args
-
-    wrapper = staged_path/"ummaya"
-    wrapper.write <<~SH
-      #!/bin/bash
-      export PATH="#{HOMEBREW_PREFIX}/opt/bun/bin:#{HOMEBREW_PREFIX}/opt/uv/bin:$PATH"
-      exec "#{HOMEBREW_PREFIX}/opt/bun/bin/bun" "#{staged_path}/package/bin/ummaya" "$@"
-    SH
-    FileUtils.chmod 0755, wrapper
-  end
 
   binary "ummaya"
 

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ Read the full documentation at [ummaya-docs.pages.dev/ko](https://ummaya-docs.pa
 npm install -g ummaya
 ```
 
-Homebrew:
+Homebrew on macOS:
 
 ```bash
-brew install --cask ummaya
+brew install --cask umyunsang/ummaya/ummaya
 ```
+
+The Homebrew cask installs a prebuilt macOS archive and does not run `npm install`
+or `bun install` during installation. The shorter `brew install --cask ummaya`
+form will work only after Homebrew accepts UMMAYA into `Homebrew/homebrew-cask`.
 
 Run `ummaya`, type `/login`, and paste your FriendliAI API key. Public CLI users should not need to prepare Kakao, JUSO, SGIS, data.go.kr, or other public API keys.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.15",
+      "version": "0.1.16",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "description": "Conversational multi-agent harness for Korean public-service channels",
   "license": "Apache-2.0",
   "type": "module",
@@ -41,7 +41,8 @@
     "docs:check": "uv run python scripts/docs_generate.py --check && cd docs-site && bun run build",
     "docs:build": "cd docs-site && bun run build",
     "package:dry-run": "mkdir -p package-evidence && npm pack --dry-run --json > package-evidence/npm-pack-dry-run.json",
-    "package:check": "npm run package:dry-run && node scripts/check-npm-package.mjs package-evidence/npm-pack-dry-run.json"
+    "package:check": "npm run package:dry-run && node scripts/check-npm-package.mjs package-evidence/npm-pack-dry-run.json",
+    "package:homebrew-cask": "node scripts/build-homebrew-cask-artifact.mjs --arch arm64 && node scripts/build-homebrew-cask-artifact.mjs --arch x64"
   },
   "engines": {
     "bun": ">=1.3.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ummaya"
-version = "0.1.15"
+version = "0.1.16"
 description = "Conversational multi-agent platform for Korean public APIs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -314,7 +314,7 @@ min_confidence = 80
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.15"
+version = "0.1.16"
 tag_format = "v$version"
 
 # PyTorch CPU-only wheel for Docker image size discipline (SC-1: ≤ 2 GB).

--- a/scripts/build-homebrew-cask-artifact.mjs
+++ b/scripts/build-homebrew-cask-artifact.mjs
@@ -1,0 +1,237 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import {
+  chmodSync,
+  copyFileSync,
+  createReadStream,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { basename, join, resolve } from 'node:path'
+import { spawnSync } from 'node:child_process'
+
+const BUN_VERSION = '1.3.14'
+const SUPPORTED_ARCHES = new Set(['arm64', 'x64'])
+const BUN_ASSETS = {
+  arm64: {
+    name: 'bun-darwin-aarch64.zip',
+    sha256: 'd8b96221828ad6f97ac7ac0ab7e95872341af763001e8803e8267652c2652620',
+  },
+  x64: {
+    name: 'bun-darwin-x64-baseline.zip',
+    sha256: '3e35ad6f53971a9834bf9e6786e2adf72b5f1921cc9a9c5fde073d2972944076',
+  },
+}
+
+function parseArgs(argv) {
+  const parsed = {
+    arch: process.arch,
+    outDir: 'dist/homebrew',
+    keepWorkdir: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--arch') {
+      parsed.arch = argv[++index]
+    } else if (arg === '--out-dir') {
+      parsed.outDir = argv[++index]
+    } else if (arg === '--keep-workdir') {
+      parsed.keepWorkdir = true
+    } else if (arg === '-h' || arg === '--help') {
+      usage()
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (!SUPPORTED_ARCHES.has(parsed.arch)) {
+    throw new Error(`Unsupported --arch ${parsed.arch}; expected arm64 or x64`)
+  }
+  return parsed
+}
+
+function usage() {
+  process.stdout.write(`Usage: scripts/build-homebrew-cask-artifact.mjs [--arch arm64|x64] [--out-dir dist/homebrew]\n`)
+}
+
+function run(command, args, options = {}) {
+  const result = spawnSync(command, args, {
+    encoding: 'utf8',
+    stdio: options.capture ? ['ignore', 'pipe', 'pipe'] : 'inherit',
+    ...options,
+  })
+  if (result.error) {
+    throw result.error
+  }
+  if (result.status !== 0) {
+    const details = options.capture
+      ? `\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`
+      : ''
+    throw new Error(`${command} ${args.join(' ')} failed with status ${result.status}${details}`)
+  }
+  return result
+}
+
+function sha256(path) {
+  return new Promise((resolve, reject) => {
+    const hash = createHash('sha256')
+    const stream = createReadStream(path)
+    stream.on('data', (chunk) => hash.update(chunk))
+    stream.on('error', reject)
+    stream.on('end', () => resolve(hash.digest('hex')))
+  })
+}
+
+function packageVersion() {
+  return JSON.parse(readFileSync('package.json', 'utf8')).version
+}
+
+async function downloadBunRuntime(workdir, arch) {
+  const asset = BUN_ASSETS[arch]
+  if (!asset) {
+    throw new Error(`Unsupported Bun runtime arch: ${arch}`)
+  }
+  const url = `https://github.com/oven-sh/bun/releases/download/bun-v${BUN_VERSION}/${asset.name}`
+  const zipPath = join(workdir, asset.name)
+  const unzipDir = join(workdir, 'bun-runtime')
+  run('curl', ['-fL', url, '-o', zipPath])
+  const digest = await sha256(zipPath)
+  if (digest !== asset.sha256) {
+    throw new Error(
+      `Bun ${BUN_VERSION} ${arch} archive SHA-256 mismatch: expected ${asset.sha256}, got ${digest}`,
+    )
+  }
+  mkdirSync(unzipDir, { recursive: true })
+  run('unzip', ['-q', zipPath, '-d', unzipDir])
+
+  const folder = asset.name.replace(/\.zip$/, '')
+  const binaryPath = join(unzipDir, folder, 'bun')
+  if (!existsSync(binaryPath)) {
+    throw new Error(`Downloaded Bun archive did not contain ${folder}/bun`)
+  }
+  return binaryPath
+}
+
+function writeWrapper(path) {
+  writeFileSync(
+    path,
+    `#!/bin/bash
+set -euo pipefail
+
+source_path="\${BASH_SOURCE[0]}"
+while [ -h "$source_path" ]; do
+  source_dir="$(cd -P "$(dirname "$source_path")" >/dev/null 2>&1 && pwd)"
+  target_path="$(readlink "$source_path")"
+  if [[ "$target_path" == /* ]]; then
+    source_path="$target_path"
+  else
+    source_path="$source_dir/$target_path"
+  fi
+done
+
+root_dir="$(cd -P "$(dirname "$source_path")" >/dev/null 2>&1 && pwd)"
+export PATH="$root_dir/runtime:$PATH"
+exec "$root_dir/runtime/bun" "$root_dir/package/bin/ummaya" "$@"
+`,
+  )
+  chmodSync(path, 0o755)
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  const version = packageVersion()
+  const root = process.cwd()
+  const outDir = resolve(args.outDir)
+  const workdir = mkdtempSync(join(tmpdir(), `ummaya-cask-${version}-${args.arch}-`))
+  const stageRoot = join(workdir, 'stage')
+  const artifactRoot = join(stageRoot, `ummaya-${version}-macos-${args.arch}`)
+  const packageDir = join(artifactRoot, 'package')
+  const runtimeDir = join(artifactRoot, 'runtime')
+
+  try {
+    mkdirSync(outDir, { recursive: true })
+    mkdirSync(stageRoot, { recursive: true })
+    mkdirSync(runtimeDir, { recursive: true })
+
+    const packReportPath = join(workdir, 'npm-pack.json')
+    const packReports = JSON.parse(run('npm', ['pack', '--json', '--pack-destination', workdir], {
+      cwd: root,
+      capture: true,
+    }).stdout)
+    writeFileSync(packReportPath, JSON.stringify(packReports, null, 2))
+    const pack = Array.isArray(packReports) ? packReports[0] : packReports
+    const tarball = join(workdir, pack.filename)
+
+    run('tar', ['-xzf', tarball, '-C', artifactRoot])
+    if (!existsSync(packageDir)) {
+      throw new Error(`npm tarball extraction did not create ${packageDir}`)
+    }
+
+    run(
+      'npm',
+      [
+        'install',
+        '--omit=dev',
+        '--legacy-peer-deps',
+        '--no-audit',
+        '--no-fund',
+        '--cpu',
+        args.arch,
+        '--os',
+        'darwin',
+      ],
+      {
+        cwd: packageDir,
+        env: {
+          ...process.env,
+          npm_config_cpu: args.arch,
+          npm_config_os: 'darwin',
+        },
+      },
+    )
+
+    const bunBinary = await downloadBunRuntime(workdir, args.arch)
+    copyFileSync(bunBinary, join(runtimeDir, 'bun'))
+    chmodSync(join(runtimeDir, 'bun'), 0o755)
+    writeWrapper(join(artifactRoot, 'ummaya'))
+
+    const artifactName = `ummaya-${version}-macos-${args.arch}.tar.gz`
+    const artifactPath = join(outDir, artifactName)
+    run('tar', ['-czf', artifactPath, '-C', artifactRoot, '.'])
+    const digest = await sha256(artifactPath)
+    writeFileSync(`${artifactPath}.sha256`, `${digest}  ${artifactName}\n`)
+    writeFileSync(
+      join(outDir, `ummaya-${version}-macos-${args.arch}.json`),
+      `${JSON.stringify(
+        {
+          version,
+          arch: args.arch,
+          artifact: basename(artifactPath),
+          sha256: digest,
+          bunVersion: BUN_VERSION,
+        },
+        null,
+        2,
+      )}\n`,
+    )
+    console.log(`${artifactPath}`)
+    console.log(`${digest}`)
+  } finally {
+    if (args.keepWorkdir) {
+      console.error(`kept workdir: ${workdir}`)
+    } else {
+      rmSync(workdir, { recursive: true, force: true })
+    }
+  }
+}
+
+main()

--- a/scripts/check-npm-package.mjs
+++ b/scripts/check-npm-package.mjs
@@ -53,11 +53,18 @@ function readHomebrewCaskVersion(path) {
 
 function readHomebrewCaskSha256(path) {
   const text = readFileSync(path, 'utf8')
-  const match = text.match(/^\s*sha256\s+"([^"]+)"\s*$/m)
-  if (!match) {
+  const single = text.match(/^\s*sha256\s+"([^"]+)"\s*$/m)
+  if (single) {
+    return [single[1]]
+  }
+
+  const arch = text.match(
+    /^\s*sha256\s+arm:\s+"([0-9a-f]{64})",\s*\n\s*intel:\s+"([0-9a-f]{64})"\s*$/m,
+  )
+  if (!arch) {
     throw new Error(`${path} missing cask sha256`)
   }
-  return match[1]
+  return [arch[1], arch[2]]
 }
 
 function assertSameVersion(label, actual, expected) {
@@ -96,10 +103,12 @@ assertSameVersion(
   rootPackageVersion,
 )
 
-const caskSha256 = readHomebrewCaskSha256('Casks/ummaya.rb')
+const caskSha256Values = readHomebrewCaskSha256('Casks/ummaya.rb')
 assertSameVersion('Casks/ummaya.rb', readHomebrewCaskVersion('Casks/ummaya.rb'), rootPackageVersion)
-if (!/^[0-9a-f]{64}$/.test(caskSha256)) {
-  throw new Error(`Casks/ummaya.rb sha256 is not a 64-character lowercase hex digest`)
+for (const caskSha256 of caskSha256Values) {
+  if (!/^[0-9a-f]{64}$/.test(caskSha256)) {
+    throw new Error(`Casks/ummaya.rb sha256 is not a 64-character lowercase hex digest`)
+  }
 }
 
 const required = [

--- a/scripts/render-homebrew-cask.mjs
+++ b/scripts/render-homebrew-cask.mjs
@@ -4,53 +4,42 @@
 import { mkdirSync, writeFileSync } from 'node:fs'
 import { dirname } from 'node:path'
 
-const [version, sha256, outputPath = 'Casks/ummaya.rb'] = process.argv.slice(2)
+const [version, arm64Sha256, x64Sha256, outputPath = 'Casks/ummaya.rb'] = process.argv.slice(2)
 
-if (!version || !sha256) {
-  throw new Error('Usage: scripts/render-homebrew-cask.mjs <version> <sha256> [output-path]')
+if (!version || !arm64Sha256 || !x64Sha256) {
+  throw new Error(
+    'Usage: scripts/render-homebrew-cask.mjs <version> <arm64-sha256> <x64-sha256> [output-path]',
+  )
 }
 
 if (!/^\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(version)) {
   throw new Error(`Invalid cask version: ${version}`)
 }
-if (!/^[0-9a-f]{64}$/.test(sha256)) {
-  throw new Error(`Invalid SHA-256: ${sha256}`)
+for (const [label, sha256] of [
+  ['arm64', arm64Sha256],
+  ['x64', x64Sha256],
+]) {
+  if (!/^[0-9a-f]{64}$/.test(sha256)) {
+    throw new Error(`Invalid ${label} SHA-256: ${sha256}`)
+  }
 }
 
 const cask = `# frozen_string_literal: true
 
 cask "ummaya" do
-  version "${version}"
-  sha256 "${sha256}"
+  arch arm: "arm64", intel: "x64"
 
-  url "https://registry.npmjs.org/ummaya/-/ummaya-#{version}.tgz",
-      verified: "registry.npmjs.org/ummaya/"
+  version "${version}"
+  sha256 arm:   "${arm64Sha256}",
+         intel: "${x64Sha256}"
+
+  url "https://github.com/umyunsang/UMMAYA/releases/download/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz",
+      verified: "github.com/umyunsang/UMMAYA/"
   name "UMMAYA"
   desc "Conversational multi-agent harness for Korean public-service channels"
   homepage "https://github.com/umyunsang/UMMAYA"
 
-  depends_on formula: "oven-sh/bun/bun"
   depends_on formula: "uv"
-
-  preflight do
-    install_args = ["install", "--production", "--cwd", "#{staged_path}/package"]
-    if File.exist?("#{staged_path}/package/bun.lock")
-      install_args << "--frozen-lockfile"
-    else
-      install_args << "--no-save"
-    end
-
-    system_command "#{HOMEBREW_PREFIX}/opt/bun/bin/bun",
-                   args: install_args
-
-    wrapper = staged_path/"ummaya"
-    wrapper.write <<~SH
-      #!/bin/bash
-      export PATH="#{HOMEBREW_PREFIX}/opt/bun/bin:#{HOMEBREW_PREFIX}/opt/uv/bin:$PATH"
-      exec "#{HOMEBREW_PREFIX}/opt/bun/bin/bun" "#{staged_path}/package/bin/ummaya" "$@"
-    SH
-    FileUtils.chmod 0755, wrapper
-  end
 
   binary "ummaya"
 

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.15",
+  "version": "0.1.16",
   "private": true,
   "type": "module",
   "engines": {

--- a/uv.lock
+++ b/uv.lock
@@ -2725,7 +2725,7 @@ wheels = [
 
 [[package]]
 name = "ummaya"
-version = "0.1.15"
+version = "0.1.16"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- Replace the Homebrew cask's npm tarball + install-time `bun install` preflight with architecture-specific prebuilt macOS release artifacts.
- Add a release workflow that builds `ummaya-<version>-macos-arm64.tar.gz` and `ummaya-<version>-macos-x64.tar.gz` on native macOS runners, smoke-checks `ummaya --version`/`--help`, and attaches the assets to the GitHub Release.
- Update the tap publishing workflow to compute Homebrew SHA-256 values from those release artifacts, and document the tap-qualified install command until the official cask is accepted.

## Homebrew review context
Homebrew/homebrew-cask#265674 was closed after the maintainer noted that `homebrew-cask` only installs prebuilt binaries. This PR removes the cask `preflight` package installation path and makes the cask install a prebuilt archive directly.

## Verification
- `node --check scripts/build-homebrew-cask-artifact.mjs && node --check scripts/render-homebrew-cask.mjs && node --check scripts/check-npm-package.mjs`
- `ruby -c Casks/ummaya.rb`
- `actionlint .github/workflows/package-npm.yml .github/workflows/publish-homebrew.yml .github/workflows/publish-homebrew-cask-artifacts.yml`
- `npm run package:check`
- `npm run package:homebrew-cask`
- `shasum -a 256 dist/homebrew/ummaya-0.1.16-macos-*.tar.gz`
- Extracted local arm64 archive and ran `ummaya --version` + `ummaya --help`
- Extracted local x64 archive and ran `arch -x86_64 ummaya --version`
- PTY smoke from extracted arm64 archive: submitted `/login` with bracketed paste + Enter and observed `Login successful`
