### PR TITLE
chore(release): preserve cask runtime quarantine fix

### DIFF
--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -4,8 +4,8 @@ cask "ummaya" do
   arch arm: "arm64", intel: "x64"
 
   version "0.1.16"
-  sha256 arm:   "8cf564d9c0ab7a695a0f34968911e2b9403fda8cc2de9ac053731a04e3573900",
-         intel: "e0fcf2e7a51689a9b06b185cc47353cb09f40533c8a7805b938ad6366a64ece4"
+  sha256 arm:   "66704302a670fa8efcbba36d7cbd6927d045179db46a51998106bfa202625ecb",
+         intel: "9ffe3b85d2e3da65434c1000bcd8831bccc8120ee755ad8faedf6c6a1262b31d"
 
   url "https://github.com/umyunsang/UMMAYA/releases/download/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz",
       verified: "github.com/umyunsang/UMMAYA/"
@@ -16,6 +16,12 @@ cask "ummaya" do
   depends_on formula: "uv"
 
   binary "ummaya"
+
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{staged_path}"],
+                   sudo: false
+  end
 
   zap trash: "~/.ummaya"
 end

--- a/scripts/render-homebrew-cask.mjs
+++ b/scripts/render-homebrew-cask.mjs
@@ -43,6 +43,12 @@ cask "ummaya" do
 
   binary "ummaya"
 
+  postflight do
+    system_command "/usr/bin/xattr",
+                   args: ["-dr", "com.apple.quarantine", "#{staged_path}"],
+                   sudo: false
+  end
+
   zap trash: "~/.ummaya"
 end
 `


### PR DESCRIPTION
## Summary
- Update `Casks/ummaya.rb` to the actual v0.1.16 GitHub Release artifact SHA-256 values produced by the successful macOS artifact workflow.
- Add the same postflight quarantine cleanup to `scripts/render-homebrew-cask.mjs` so future tap publishes preserve the working install path.

## Why
The prebuilt cask bundles a Bun runtime. Homebrew Cask applies `com.apple.quarantine` to downloaded artifacts; on macOS this caused the bundled runtime to be killed before `ummaya --version` could run. The tap has already been patched with this postflight and a reinstall smoke now passes without requiring users to pass `--no-quarantine`.

## Verification
- `node scripts/render-homebrew-cask.mjs 0.1.16 66704302a670fa8efcbba36d7cbd6927d045179db46a51998106bfa202625ecb 9ffe3b85d2e3da65434c1000bcd8831bccc8120ee755ad8faedf6c6a1262b31d Casks/ummaya.rb`
- `node --check scripts/render-homebrew-cask.mjs`
- `ruby -c Casks/ummaya.rb`
- `npm run package:check`
- `git diff --check`
- `HOMEBREW_NO_AUTO_UPDATE=1 brew reinstall --cask umyunsang/ummaya/ummaya`
- `ummaya --version`
- `ummaya --help`
- PTY smoke from installed cask: submitted `/login` with bracketed paste + Enter and observed `Login successful`
