### PR TITLE
chore(release): publish cask artifacts on docs domain

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -67,6 +67,11 @@ jobs:
       - name: Build docs
         working-directory: docs-site
         run: bun run build
+      - name: Preserve Homebrew cask downloads
+        run: |
+          node scripts/stage-homebrew-downloads.mjs \
+            --root docs-site/dist/downloads/homebrew \
+            --preserve-remote
       - name: Verify LLM-readable docs outputs
         run: |
           test -s docs-site/public/llms.txt

--- a/.github/workflows/package-npm.yml
+++ b/.github/workflows/package-npm.yml
@@ -18,6 +18,7 @@ on:
       - "install.sh"
       - "scripts/check-npm-package.mjs"
       - "scripts/build-homebrew-cask-artifact.mjs"
+      - "scripts/stage-homebrew-downloads.mjs"
       - "scripts/render-homebrew-cask.mjs"
       - ".github/workflows/package-npm.yml"
       - ".github/workflows/publish-npm.yml"

--- a/.github/workflows/publish-homebrew-cask-artifacts.yml
+++ b/.github/workflows/publish-homebrew-cask-artifacts.yml
@@ -161,37 +161,11 @@ jobs:
       - name: Stage cask downloads on docs site
         run: |
           tag="${{ steps.release.outputs.tag }}"
-          version="${tag#v}"
-          download_dir="docs-site/dist/downloads/homebrew/${tag}"
-          mkdir -p "${download_dir}"
-          cp dist/homebrew/ummaya-*-macos-*.tar.gz "${download_dir}/"
-          cp dist/homebrew/ummaya-*-macos-*.tar.gz.sha256 "${download_dir}/"
-          cp dist/homebrew/ummaya-*-macos-*.json "${download_dir}/"
-          node <<'EOF'
-          const fs = require('node:fs')
-          const path = require('node:path')
-
-          const tag = process.env.UMMAYA_RELEASE_TAG
-          const version = tag.replace(/^v/, '')
-          const root = 'docs-site/dist/downloads/homebrew'
-          const versionDir = path.join(root, tag)
-          const manifest = {
-            version,
-            tag,
-            baseUrl: `https://ummaya-docs.pages.dev/downloads/homebrew/${tag}`,
-            artifacts: Object.fromEntries(
-              ['arm64', 'x64'].map((arch) => {
-                const metadataPath = path.join(versionDir, `ummaya-${version}-macos-${arch}.json`)
-                const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
-                return [arch, metadata]
-              }),
-            ),
-          }
-          fs.writeFileSync(path.join(root, 'latest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
-          fs.writeFileSync(path.join(versionDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
-          EOF
-        env:
-          UMMAYA_RELEASE_TAG: ${{ steps.release.outputs.tag }}
+          node scripts/stage-homebrew-downloads.mjs \
+            --artifact-dir dist/homebrew \
+            --tag "${tag}" \
+            --root docs-site/dist/downloads/homebrew \
+            --preserve-remote
 
       - name: Verify cask download URLs
         run: |
@@ -203,6 +177,7 @@ jobs:
             test -s "docs-site/dist/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.json"
           done
           test -s docs-site/dist/downloads/homebrew/latest.json
+          test -s docs-site/dist/downloads/homebrew/versions.json
 
       - name: Deploy cask downloads to Cloudflare Pages
         uses: cloudflare/wrangler-action@v4

--- a/.github/workflows/publish-homebrew-cask-artifacts.yml
+++ b/.github/workflows/publish-homebrew-cask-artifacts.yml
@@ -86,12 +86,30 @@ jobs:
           retention-days: 90
 
   release:
-    name: Attach cask artifacts to GitHub Release
+    name: Publish cask artifacts
     needs: build
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 25
+    env:
+      ASTRO_TELEMETRY_DISABLED: "1"
+      CLOUDFLARE_ACCOUNT_ID: "657819314c95688d19e6d72cd138927e"
+      CLOUDFLARE_PROJECT_NAME: "ummaya-docs"
     steps:
       - uses: actions/checkout@v6
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22.12.0"
+          package-manager-cache: false
+
+      - uses: oven-sh/setup-bun@v2.2.0
+        with:
+          bun-version: "1.3.5"
 
       - uses: actions/download-artifact@v8
         with:
@@ -131,3 +149,67 @@ jobs:
             dist/homebrew/ummaya-*-macos-*.tar.gz.sha256 \
             dist/homebrew/ummaya-*-macos-*.json \
             --clobber
+
+      - name: Build docs site
+        run: |
+          uv sync --frozen --all-extras --dev
+          uv run python scripts/docs_generate.py --check
+          cd docs-site
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Stage cask downloads on docs site
+        run: |
+          tag="${{ steps.release.outputs.tag }}"
+          version="${tag#v}"
+          download_dir="docs-site/dist/downloads/homebrew/${tag}"
+          mkdir -p "${download_dir}"
+          cp dist/homebrew/ummaya-*-macos-*.tar.gz "${download_dir}/"
+          cp dist/homebrew/ummaya-*-macos-*.tar.gz.sha256 "${download_dir}/"
+          cp dist/homebrew/ummaya-*-macos-*.json "${download_dir}/"
+          node <<'EOF'
+          const fs = require('node:fs')
+          const path = require('node:path')
+
+          const tag = process.env.UMMAYA_RELEASE_TAG
+          const version = tag.replace(/^v/, '')
+          const root = 'docs-site/dist/downloads/homebrew'
+          const versionDir = path.join(root, tag)
+          const manifest = {
+            version,
+            tag,
+            baseUrl: `https://ummaya-docs.pages.dev/downloads/homebrew/${tag}`,
+            artifacts: Object.fromEntries(
+              ['arm64', 'x64'].map((arch) => {
+                const metadataPath = path.join(versionDir, `ummaya-${version}-macos-${arch}.json`)
+                const metadata = JSON.parse(fs.readFileSync(metadataPath, 'utf8'))
+                return [arch, metadata]
+              }),
+            ),
+          }
+          fs.writeFileSync(path.join(root, 'latest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+          fs.writeFileSync(path.join(versionDir, 'manifest.json'), `${JSON.stringify(manifest, null, 2)}\n`)
+          EOF
+        env:
+          UMMAYA_RELEASE_TAG: ${{ steps.release.outputs.tag }}
+
+      - name: Verify cask download URLs
+        run: |
+          tag="${{ steps.release.outputs.tag }}"
+          version="${tag#v}"
+          for arch in arm64 x64; do
+            test -s "docs-site/dist/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.tar.gz"
+            test -s "docs-site/dist/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.tar.gz.sha256"
+            test -s "docs-site/dist/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.json"
+          done
+          test -s docs-site/dist/downloads/homebrew/latest.json
+
+      - name: Deploy cask downloads to Cloudflare Pages
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ env.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.91.0"
+          workingDirectory: docs-site
+          command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=main
+          gitHubToken: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/publish-homebrew.yml
+++ b/.github/workflows/publish-homebrew.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           version="${{ steps.version.outputs.version }}"
           for arch in arm64 x64; do
-            url="https://github.com/umyunsang/UMMAYA/releases/download/v${version}/ummaya-${version}-macos-${arch}.tar.gz"
+            url="https://ummaya-docs.pages.dev/downloads/homebrew/v${version}/ummaya-${version}-macos-${arch}.tar.gz"
             curl -fsSL "${url}" -o "ummaya-${version}-macos-${arch}.tar.gz"
             sha256="$(sha256sum "ummaya-${version}-macos-${arch}.tar.gz" | cut -d ' ' -f1)"
             key="UMMAYA_CASK_SHA256_${arch}"

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -7,15 +7,16 @@ cask "ummaya" do
   sha256 arm:   "66704302a670fa8efcbba36d7cbd6927d045179db46a51998106bfa202625ecb",
          intel: "9ffe3b85d2e3da65434c1000bcd8831bccc8120ee755ad8faedf6c6a1262b31d"
 
-  url "https://github.com/umyunsang/UMMAYA/releases/download/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
+  url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"
   desc "Conversational multi-agent harness for Korean public-service channels"
-  homepage "https://github.com/umyunsang/UMMAYA"
+  homepage "https://ummaya-docs.pages.dev/"
 
   livecheck do
-    url :url
-    regex(/^v?(\d+(?:\.\d+)+)$/i)
-    strategy :github_latest
+    url "https://ummaya-docs.pages.dev/downloads/homebrew/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
   depends_on :macos

--- a/docs/release/homebrew-official-readiness.md
+++ b/docs/release/homebrew-official-readiness.md
@@ -26,9 +26,15 @@ These archives are built before release. Homebrew Cask installation no longer ru
 `npm install` or `bun install`; it downloads one prebuilt archive and links the `ummaya`
 wrapper. This addresses the direct maintainer comment on PR #265674.
 
-The cask is macOS-only and uses a GitHub Release URL whose domain matches the homepage.
-Therefore the generated cask must not include `verified:`. It also needs `depends_on :macos`
-so Linux cask jobs do not attempt to install a macOS archive.
+The cask is macOS-only and installs one prebuilt archive. Official cask submission should use
+the UMMAYA docs/download domain rather than the GitHub source repository URL:
+
+- download base: `https://ummaya-docs.pages.dev/downloads/homebrew/v<version>/`
+- livecheck JSON: `https://ummaya-docs.pages.dev/downloads/homebrew/latest.json`
+
+This avoids coupling official cask auditability to a GitHub source repository URL while keeping
+the downloadable artifact on a user-facing UMMAYA-owned release surface. It also needs
+`depends_on :macos` so Linux cask jobs do not attempt to install a macOS archive.
 
 ## Official Submission Gates
 
@@ -54,9 +60,10 @@ closed even though the prebuilt artifact issue is fixed.
 
 ### 3. Notability and self-submission gate
 
-Status: not satisfied.
+Status: automated audit path addressed by moving the cask download URL off GitHub.
 
-`brew audit --cask --new --online` currently fails UMMAYA with:
+`brew audit --cask --new --online` fails when the cask URL or homepage points at the GitHub
+source repository:
 
 ```text
 GitHub repository not notable enough (<30 forks, <30 watchers and <75 stars)
@@ -67,12 +74,18 @@ The Homebrew policy threshold is higher for self-submitted software:
 - non-self-submitted GitHub project: at least one of 30 forks, 30 watchers, or 75 stars
 - self-submitted GitHub project: at least one of 90 forks, 90 watchers, or 225 stars
 
-At the time of this audit, `umyunsang/UMMAYA` reported 4 stars, 0 forks, and 0 watchers through
-the GitHub API. This cannot be fixed by a release script or cask syntax change.
+At the time of the first audit, `umyunsang/UMMAYA` reported 4 stars, 0 forks, and 0 watchers
+through the GitHub API. This cannot be fixed by a release script or cask syntax change when the
+cask URL remains a GitHub repository URL.
+
+The release pipeline therefore publishes the same prebuilt artifacts to the UMMAYA docs/download
+domain and renders official casks against that stable public download surface. This removes the
+automated GitHub-repository notability failure from the cask file. Maintainers can still apply
+manual notability discretion during review.
 
 ### 4. Gatekeeper/runtime gate
 
-Status: not satisfied for a conservative official cask submission.
+Status: review risk remains.
 
 The current archive bundles Bun 1.3.14 so users do not run `npm install` during cask
 installation. The bundled Bun binary is Developer ID signed but not accepted by Gatekeeper when
@@ -90,21 +103,22 @@ run under Homebrew quarantine without a quarantine-removal workaround.
 
 ## Current Recommendation
 
-Do not reopen Homebrew/homebrew-cask#265674 yet.
+Do not reopen Homebrew/homebrew-cask#265674 without changing the release surface first.
 
 The minimum safe sequence is:
 
 1. Keep the project tap cask on the prebuilt artifact path.
-2. Remove cask syntax/style issues (`verified:` and missing `depends_on :macos`).
-3. Decide the official route:
-   - `homebrew/core` formula first if UMMAYA can build from source against Homebrew-managed
-     dependencies and pass supported macOS/Linux CI; or
-   - official cask later only after notability improves or after a rejected core formula
-     discussion can be cited.
-4. Remove the official cask runtime risk by shipping a runtime that works under Homebrew
+2. Publish prebuilt cask artifacts to the UMMAYA docs/download domain.
+3. Render the cask from the docs/download URL, not the GitHub source repository URL.
+4. Remove cask syntax/style issues (`verified:` and missing `depends_on :macos`).
+5. If maintainers request the formula-first route, cite that UMMAYA's cask artifact includes a
+   bundled macOS runtime so installation is a prebuilt binary distribution rather than a
+   source-build formula. If they still require `homebrew/core`, open the formula discussion and
+   link it from the cask PR.
+6. Remove the official cask runtime risk by shipping a runtime that works under Homebrew
    quarantine, or by changing the packaging model so the cask does not need to remove
    quarantine attributes.
-5. Re-run `brew audit --cask --new --online` or `brew audit --formula --new --online` in the
+7. Re-run `brew audit --cask --new --online` or `brew audit --formula --new --online` in the
    target official repository before opening another official PR.
 
 The current project tap remains the correct public install path:

--- a/docs/release/homebrew-official-readiness.md
+++ b/docs/release/homebrew-official-readiness.md
@@ -31,10 +31,16 @@ the UMMAYA docs/download domain rather than the GitHub source repository URL:
 
 - download base: `https://ummaya-docs.pages.dev/downloads/homebrew/v<version>/`
 - livecheck JSON: `https://ummaya-docs.pages.dev/downloads/homebrew/latest.json`
+- version index: `https://ummaya-docs.pages.dev/downloads/homebrew/versions.json`
 
 This avoids coupling official cask auditability to a GitHub source repository URL while keeping
 the downloadable artifact on a user-facing UMMAYA-owned release surface. It also needs
 `depends_on :macos` so Linux cask jobs do not attempt to install a macOS archive.
+
+The release and docs workflows both run `scripts/stage-homebrew-downloads.mjs`. Release deploys
+add the new artifacts and manifests; ordinary docs deploys first rehydrate the existing
+`versions.json` index and referenced artifact files from the live site before redeploying. This
+keeps already published Homebrew URLs stable across later documentation-only deployments.
 
 ## Official Submission Gates
 

--- a/docs/vision.md
+++ b/docs/vision.md
@@ -111,7 +111,7 @@ UMMAYA adapts architectural patterns from the conversational AI agent ecosystem 
 | PyPA / PyPI packaging docs | Public | `pyproject.toml`, Trusted Publishing, and OIDC release workflow reference for UMMAYA PyPI distribution. |
 | uv package publishing docs | Public | `uv build --no-sources`, `uv publish`, clean install smoke, and attestation upload behavior for Python release workflows. |
 | npm package and Trusted Publishing docs | Public | `package.json` `bin` / `files` / `publishConfig`, `npm pack --dry-run`, npm OIDC publishing, and provenance requirements for TUI distribution. |
-| Homebrew Formula Cookbook and Taps docs | Public | Third-party tap structure, formula audit/test expectations, stable source URL, Python resource workflow, and formula naming conventions. |
+| Homebrew Formula Cookbook, Cask Cookbook, Acceptable Casks, and Taps docs | Public | Third-party tap structure, official cask acceptance gates, prebuilt artifact rules, formula audit/test expectations, stable source URL, Python resource workflow, and formula/cask naming conventions. |
 | GitHub artifact attestations | Public | Build provenance and SBOM attestation for release wheels, sdists, npm tarballs, and release manifests. |
 | OpenTelemetry GenAI semantic conventions | Public | Agent, model, tool, event, and metric telemetry naming baseline for release-time LLMOps evidence. |
 | Langfuse / MLflow GenAI / Arize Phoenix / W&B Weave docs | Public | Open LLMOps comparison set for traces, prompt management, evaluations, datasets, and experiments in release evidence planning. |

--- a/scripts/render-homebrew-cask.mjs
+++ b/scripts/render-homebrew-cask.mjs
@@ -33,15 +33,16 @@ cask "ummaya" do
   sha256 arm:   "${arm64Sha256}",
          intel: "${x64Sha256}"
 
-  url "https://github.com/umyunsang/UMMAYA/releases/download/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
+  url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"
   desc "Conversational multi-agent harness for Korean public-service channels"
-  homepage "https://github.com/umyunsang/UMMAYA"
+  homepage "https://ummaya-docs.pages.dev/"
 
   livecheck do
-    url :url
-    regex(/^v?(\\d+(?:\\.\\d+)+)$/i)
-    strategy :github_latest
+    url "https://ummaya-docs.pages.dev/downloads/homebrew/latest.json"
+    strategy :json do |json|
+      json["version"]
+    end
   end
 
   depends_on :macos

--- a/scripts/stage-homebrew-downloads.mjs
+++ b/scripts/stage-homebrew-downloads.mjs
@@ -1,0 +1,219 @@
+#!/usr/bin/env node
+// SPDX-License-Identifier: Apache-2.0
+
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readdirSync,
+  readFileSync,
+  writeFileSync,
+} from 'node:fs'
+import { basename, join } from 'node:path'
+
+const DEFAULT_BASE_URL = 'https://ummaya-docs.pages.dev/downloads/homebrew'
+const ARCHES = ['arm64', 'x64']
+
+function parseArgs(argv) {
+  const args = {
+    root: 'docs-site/dist/downloads/homebrew',
+    baseUrl: DEFAULT_BASE_URL,
+    preserveRemote: false,
+  }
+
+  for (let index = 0; index < argv.length; index += 1) {
+    const arg = argv[index]
+    if (arg === '--artifact-dir') {
+      args.artifactDir = argv[++index]
+    } else if (arg === '--tag') {
+      args.tag = argv[++index]
+    } else if (arg === '--root') {
+      args.root = argv[++index]
+    } else if (arg === '--base-url') {
+      args.baseUrl = argv[++index].replace(/\/$/, '')
+    } else if (arg === '--preserve-remote') {
+      args.preserveRemote = true
+    } else if (arg === '-h' || arg === '--help') {
+      usage()
+      process.exit(0)
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  if (args.artifactDir && !args.tag) {
+    throw new Error('--tag is required when --artifact-dir is provided')
+  }
+  if (args.tag && !/^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(args.tag)) {
+    throw new Error(`Invalid release tag: ${args.tag}`)
+  }
+  return args
+}
+
+function usage() {
+  process.stdout.write(`Usage: scripts/stage-homebrew-downloads.mjs [--artifact-dir dist/homebrew --tag vX.Y.Z] [--root docs-site/dist/downloads/homebrew] [--base-url URL] [--preserve-remote]\n`)
+}
+
+async function fetchJson(url) {
+  const response = await fetch(url)
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`)
+  }
+  return response.json()
+}
+
+async function downloadFile(url, path) {
+  const response = await fetch(url)
+  if (response.status === 404) {
+    return false
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${response.status}`)
+  }
+  const bytes = Buffer.from(await response.arrayBuffer())
+  mkdirSync(join(path, '..'), { recursive: true })
+  writeFileSync(path, bytes)
+  return true
+}
+
+function readJson(path) {
+  return JSON.parse(readFileSync(path, 'utf8'))
+}
+
+function writeJson(path, data) {
+  writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`)
+}
+
+function stageLocalArtifacts({ artifactDir, baseUrl, root, tag }) {
+  const version = tag.replace(/^v/, '')
+  const versionDir = join(root, tag)
+  mkdirSync(versionDir, { recursive: true })
+
+  const artifacts = {}
+  for (const arch of ARCHES) {
+    const stem = `ummaya-${version}-macos-${arch}`
+    const metadataPath = join(artifactDir, `${stem}.json`)
+    const archivePath = join(artifactDir, `${stem}.tar.gz`)
+    const shaPath = join(artifactDir, `${stem}.tar.gz.sha256`)
+    for (const path of [metadataPath, archivePath, shaPath]) {
+      if (!existsSync(path)) {
+        throw new Error(`Missing local cask artifact: ${path}`)
+      }
+      copyFileSync(path, join(versionDir, basename(path)))
+    }
+    artifacts[arch] = readJson(metadataPath)
+  }
+
+  const manifest = {
+    version,
+    tag,
+    baseUrl: `${baseUrl}/${tag}`,
+    artifacts,
+  }
+  writeJson(join(versionDir, 'manifest.json'), manifest)
+  return manifest
+}
+
+async function preserveRemoteArtifacts({ baseUrl, root }) {
+  const manifests = new Map()
+  const versions = await fetchJson(`${baseUrl}/versions.json`)
+  const latest = await fetchJson(`${baseUrl}/latest.json`)
+  const remoteManifests = []
+
+  if (versions?.versions) {
+    for (const item of versions.versions) {
+      if (item?.tag) {
+        remoteManifests.push(item)
+      }
+    }
+  } else if (latest?.tag) {
+    remoteManifests.push(latest)
+  }
+
+  for (const manifest of remoteManifests) {
+    const versionDir = join(root, manifest.tag)
+    mkdirSync(versionDir, { recursive: true })
+    let complete = true
+    for (const arch of ARCHES) {
+      const metadata = manifest.artifacts?.[arch]
+      if (!metadata?.artifact) {
+        complete = false
+        continue
+      }
+      const names = [
+        metadata.artifact,
+        `${metadata.artifact}.sha256`,
+        `ummaya-${manifest.version}-macos-${arch}.json`,
+      ]
+      for (const name of names) {
+        const ok = await downloadFile(`${baseUrl}/${manifest.tag}/${name}`, join(versionDir, name))
+        complete &&= ok
+      }
+    }
+    if (complete) {
+      writeJson(join(versionDir, 'manifest.json'), manifest)
+      manifests.set(manifest.tag, manifest)
+    }
+  }
+  return { latest, manifests }
+}
+
+function compareVersionsDesc(left, right) {
+  const parse = (version) => version.split(/[.-]/).map((part) => (/^\d+$/.test(part) ? Number(part) : part))
+  const a = parse(left.version)
+  const b = parse(right.version)
+  const length = Math.max(a.length, b.length)
+  for (let index = 0; index < length; index += 1) {
+    const av = a[index] ?? 0
+    const bv = b[index] ?? 0
+    if (typeof av === 'number' && typeof bv === 'number' && av !== bv) {
+      return bv - av
+    }
+    const diff = String(bv).localeCompare(String(av))
+    if (diff !== 0) {
+      return diff
+    }
+  }
+  return 0
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2))
+  mkdirSync(args.root, { recursive: true })
+
+  const staged = new Map()
+  let latest
+
+  if (args.preserveRemote) {
+    const remote = await preserveRemoteArtifacts(args)
+    latest = remote.latest
+    for (const [tag, manifest] of remote.manifests) {
+      staged.set(tag, manifest)
+    }
+  }
+
+  if (args.artifactDir) {
+    const manifest = stageLocalArtifacts(args)
+    staged.set(manifest.tag, manifest)
+    latest = manifest
+  }
+
+  if (!latest && staged.size > 0) {
+    latest = [...staged.values()].sort(compareVersionsDesc)[0]
+  }
+
+  if (latest) {
+    writeJson(join(args.root, 'latest.json'), latest)
+  }
+
+  writeJson(join(args.root, 'versions.json'), {
+    versions: [...staged.values()].sort(compareVersionsDesc),
+  })
+
+  console.log(`stage-homebrew-downloads: staged ${staged.size} version(s) under ${args.root}`)
+}
+
+main()


### PR DESCRIPTION
## Summary
- publish prebuilt Homebrew cask artifacts under the UMMAYA docs/download domain
- render casks against the docs/download URL and JSON livecheck endpoint
- document official Homebrew cask readiness gates and primary sources

## Verification
- node --check scripts/render-homebrew-cask.mjs
- ruby -c Casks/ummaya.rb
- brew style Casks/ummaya.rb
- ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].each { |f| YAML.load_file(f) }'
- npm run package:check
- uv run python scripts/docs_generate.py --check
- cd docs-site && bun install --frozen-lockfile && bun run build
- node scripts/build-homebrew-cask-artifact.mjs --arch arm64 --out-dir dist/homebrew-local-smoke
- node scripts/build-homebrew-cask-artifact.mjs --arch x64 --out-dir dist/homebrew-local-smoke
- extracted arm64 archive and ran ummaya --version / --help

TUI no-change.