### PR TITLE
chore(release): bump version to 0.1.17

### DIFF
--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -3,9 +3,9 @@
 cask "ummaya" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.1.16"
-  sha256 arm:   "66704302a670fa8efcbba36d7cbd6927d045179db46a51998106bfa202625ecb",
-         intel: "9ffe3b85d2e3da65434c1000bcd8831bccc8120ee755ad8faedf6c6a1262b31d"
+  version "0.1.17"
+  sha256 arm:   "ded4fa8b48f8d6d4ad3e48b006b4cb6199cb5e2d50c1d23cb0f772c0deeba70a",
+         intel: "4e18032520490fe0452b24574f1d488a2674bc7dcec64dbb5c65be28c590f25f"
 
   url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.16",
+      "version": "0.1.17",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "description": "Conversational multi-agent harness for Korean public-service channels",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ummaya"
-version = "0.1.16"
+version = "0.1.17"
 description = "Conversational multi-agent platform for Korean public APIs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -314,7 +314,7 @@ min_confidence = 80
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.16"
+version = "0.1.17"
 tag_format = "v$version"
 
 # PyTorch CPU-only wheel for Docker image size discipline (SC-1: ≤ 2 GB).

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.16",
+  "version": "0.1.17",
   "private": true,
   "type": "module",
   "engines": {

--- a/uv.lock
+++ b/uv.lock
@@ -2725,7 +2725,7 @@ wheels = [
 
 [[package]]
 name = "ummaya"
-version = "0.1.16"
+version = "0.1.17"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump UMMAYA package metadata from 0.1.16 to 0.1.17
- keep npm, TUI, Python, uv lock, and committed cask version aligned
- render the local cask with SHA-256 values from locally built prebuilt macOS artifacts

## Verification
- `npm run package:check`
- `uv sync --frozen`
- `uv run pytest` (`4089 passed, 63 skipped, 3 xfailed`)
- `node scripts/build-homebrew-cask-artifact.mjs --arch arm64 --out-dir dist/homebrew-release-0.1.17`
- `node scripts/build-homebrew-cask-artifact.mjs --arch x64 --out-dir dist/homebrew-release-0.1.17`
- extracted arm64 prebuilt artifact and ran `ummaya --version` plus `ummaya --help`
- `ruby -c Casks/ummaya.rb`
- `brew style Casks/ummaya.rb`
- `git diff --check`

TUI no-change.
