### PR TITLE
fix(release): redirect cask archives from docs domain

### DIFF
--- a/.github/workflows/publish-homebrew-cask-artifacts.yml
+++ b/.github/workflows/publish-homebrew-cask-artifacts.yml
@@ -138,6 +138,8 @@ jobs:
           tag="${{ steps.release.outputs.tag }}"
           if ! gh release view "${tag}" >/dev/null 2>&1; then
             gh release create "${tag}" --title "UMMAYA ${tag}" --target "${GITHUB_SHA}" --generate-notes
+          else
+            gh release edit "${tag}" --title "UMMAYA ${tag}" --target "${GITHUB_SHA}" --latest
           fi
 
       - name: Upload release assets
@@ -172,9 +174,9 @@ jobs:
           tag="${{ steps.release.outputs.tag }}"
           version="${tag#v}"
           for arch in arm64 x64; do
-            test -s "docs-site/dist/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.tar.gz"
             test -s "docs-site/dist/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.tar.gz.sha256"
             test -s "docs-site/dist/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.json"
+            grep -F "/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.tar.gz https://github.com/umyunsang/UMMAYA/releases/download/${tag}/ummaya-${version}-macos-${arch}.tar.gz 302" docs-site/dist/_redirects
           done
           test -s docs-site/dist/downloads/homebrew/latest.json
           test -s docs-site/dist/downloads/homebrew/versions.json
@@ -188,3 +190,32 @@ jobs:
           workingDirectory: docs-site
           command: pages deploy dist --project-name=${{ env.CLOUDFLARE_PROJECT_NAME }} --branch=main
           gitHubToken: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify deployed cask download redirects
+        run: |
+          tag="${{ steps.release.outputs.tag }}"
+          version="${tag#v}"
+          for arch in arm64 x64; do
+            url="https://ummaya-docs.pages.dev/downloads/homebrew/${tag}/ummaya-${version}-macos-${arch}.tar.gz"
+            for attempt in {1..12}; do
+              if curl -fsSIL "${url}" | grep -F "https://github.com/umyunsang/UMMAYA/releases/download/${tag}/ummaya-${version}-macos-${arch}.tar.gz"; then
+                break
+              fi
+              if [ "${attempt}" = "12" ]; then
+                echo "::error::Published redirect did not become visible for ${url}"
+                exit 1
+              fi
+              sleep 5
+            done
+          done
+          for attempt in {1..12}; do
+            if curl -fsSL "https://ummaya-docs.pages.dev/downloads/homebrew/latest.json" \
+              | node -e 'const expected = process.argv[1]; let input = ""; process.stdin.on("data", c => input += c); process.stdin.on("end", () => { const json = JSON.parse(input); if (json.version !== expected) process.exit(1); });' "${version}"; then
+              break
+            fi
+            if [ "${attempt}" = "12" ]; then
+              echo "::error::latest.json did not become visible for ${version}"
+              exit 1
+            fi
+            sleep 5
+          done

--- a/.github/workflows/publish-homebrew-cask-artifacts.yml
+++ b/.github/workflows/publish-homebrew-cask-artifacts.yml
@@ -139,7 +139,7 @@ jobs:
           if ! gh release view "${tag}" >/dev/null 2>&1; then
             gh release create "${tag}" --title "UMMAYA ${tag}" --target "${GITHUB_SHA}" --generate-notes
           else
-            gh release edit "${tag}" --title "UMMAYA ${tag}" --target "${GITHUB_SHA}" --latest
+            gh release edit "${tag}" --title "UMMAYA ${tag}" --target "${GITHUB_SHA}"
           fi
 
       - name: Upload release assets

--- a/docs/release/homebrew-official-readiness.md
+++ b/docs/release/homebrew-official-readiness.md
@@ -17,7 +17,7 @@ not controlled by UMMAYA release automation alone.
 
 ## Current State
 
-UMMAYA v0.1.16 now publishes macOS release archives:
+UMMAYA v0.1.17 now publishes macOS release archives:
 
 - `ummaya-<version>-macos-arm64.tar.gz`
 - `ummaya-<version>-macos-x64.tar.gz`
@@ -34,13 +34,16 @@ the UMMAYA docs/download domain rather than the GitHub source repository URL:
 - version index: `https://ummaya-docs.pages.dev/downloads/homebrew/versions.json`
 
 This avoids coupling official cask auditability to a GitHub source repository URL while keeping
-the downloadable artifact on a user-facing UMMAYA-owned release surface. It also needs
+the downloadable artifact on a user-facing UMMAYA-owned release surface. Cloudflare Pages has
+a 25 MiB per-file limit, so Pages hosts only the small manifests, SHA files, and `_redirects`
+rules; the large tarballs are GitHub Release assets reached through first-party docs/download
+URLs. It also needs
 `depends_on :macos` so Linux cask jobs do not attempt to install a macOS archive.
 
 The release and docs workflows both run `scripts/stage-homebrew-downloads.mjs`. Release deploys
-add the new artifacts and manifests; ordinary docs deploys first rehydrate the existing
-`versions.json` index and referenced artifact files from the live site before redeploying. This
-keeps already published Homebrew URLs stable across later documentation-only deployments.
+add the new manifests, SHA files, and redirect rules; ordinary docs deploys first rehydrate the
+existing `versions.json` index and referenced small files from the live site before redeploying.
+This keeps already published Homebrew URLs stable across later documentation-only deployments.
 
 ## Official Submission Gates
 

--- a/scripts/stage-homebrew-downloads.mjs
+++ b/scripts/stage-homebrew-downloads.mjs
@@ -5,19 +5,23 @@ import {
   copyFileSync,
   existsSync,
   mkdirSync,
-  readdirSync,
   readFileSync,
+  statSync,
   writeFileSync,
 } from 'node:fs'
 import { basename, join } from 'node:path'
 
 const DEFAULT_BASE_URL = 'https://ummaya-docs.pages.dev/downloads/homebrew'
+const DEFAULT_RELEASE_BASE_URL = 'https://github.com/umyunsang/UMMAYA/releases/download'
 const ARCHES = ['arm64', 'x64']
+const REDIRECTS_BEGIN = '# BEGIN UMMAYA HOMEBREW DOWNLOAD REDIRECTS'
+const REDIRECTS_END = '# END UMMAYA HOMEBREW DOWNLOAD REDIRECTS'
 
 function parseArgs(argv) {
   const args = {
     root: 'docs-site/dist/downloads/homebrew',
     baseUrl: DEFAULT_BASE_URL,
+    releaseBaseUrl: DEFAULT_RELEASE_BASE_URL,
     preserveRemote: false,
   }
 
@@ -31,6 +35,10 @@ function parseArgs(argv) {
       args.root = argv[++index]
     } else if (arg === '--base-url') {
       args.baseUrl = argv[++index].replace(/\/$/, '')
+    } else if (arg === '--release-base-url') {
+      args.releaseBaseUrl = argv[++index].replace(/\/$/, '')
+    } else if (arg === '--redirects-path') {
+      args.redirectsPath = argv[++index]
     } else if (arg === '--preserve-remote') {
       args.preserveRemote = true
     } else if (arg === '-h' || arg === '--help') {
@@ -47,11 +55,12 @@ function parseArgs(argv) {
   if (args.tag && !/^v\d+\.\d+\.\d+(-[0-9A-Za-z.-]+)?$/.test(args.tag)) {
     throw new Error(`Invalid release tag: ${args.tag}`)
   }
+  args.redirectsPath ??= join(args.root, '..', '..', '_redirects')
   return args
 }
 
 function usage() {
-  process.stdout.write(`Usage: scripts/stage-homebrew-downloads.mjs [--artifact-dir dist/homebrew --tag vX.Y.Z] [--root docs-site/dist/downloads/homebrew] [--base-url URL] [--preserve-remote]\n`)
+  process.stdout.write(`Usage: scripts/stage-homebrew-downloads.mjs [--artifact-dir dist/homebrew --tag vX.Y.Z] [--root docs-site/dist/downloads/homebrew] [--base-url URL] [--release-base-url URL] [--redirects-path docs-site/dist/_redirects] [--preserve-remote]\n`)
 }
 
 async function fetchJson(url) {
@@ -87,7 +96,15 @@ function writeJson(path, data) {
   writeFileSync(path, `${JSON.stringify(data, null, 2)}\n`)
 }
 
-function stageLocalArtifacts({ artifactDir, baseUrl, root, tag }) {
+function assertSmallPagesFile(path) {
+  const maxPagesFileBytes = 25 * 1024 * 1024
+  const size = statSync(path).size
+  if (size > maxPagesFileBytes) {
+    throw new Error(`${path} is ${size} bytes; Cloudflare Pages supports files up to 25 MiB`)
+  }
+}
+
+function stageLocalArtifacts({ artifactDir, baseUrl, releaseBaseUrl, root, tag }) {
   const version = tag.replace(/^v/, '')
   const versionDir = join(root, tag)
   mkdirSync(versionDir, { recursive: true })
@@ -102,9 +119,17 @@ function stageLocalArtifacts({ artifactDir, baseUrl, root, tag }) {
       if (!existsSync(path)) {
         throw new Error(`Missing local cask artifact: ${path}`)
       }
+    }
+    for (const path of [metadataPath, shaPath]) {
+      assertSmallPagesFile(path)
       copyFileSync(path, join(versionDir, basename(path)))
     }
-    artifacts[arch] = readJson(metadataPath)
+    const metadata = readJson(metadataPath)
+    artifacts[arch] = {
+      ...metadata,
+      url: `${baseUrl}/${tag}/${metadata.artifact}`,
+      releaseUrl: `${releaseBaseUrl}/${tag}/${metadata.artifact}`,
+    }
   }
 
   const manifest = {
@@ -117,7 +142,7 @@ function stageLocalArtifacts({ artifactDir, baseUrl, root, tag }) {
   return manifest
 }
 
-async function preserveRemoteArtifacts({ baseUrl, root }) {
+async function preserveRemoteArtifacts({ baseUrl, releaseBaseUrl, root }) {
   const manifests = new Map()
   const versions = await fetchJson(`${baseUrl}/versions.json`)
   const latest = await fetchJson(`${baseUrl}/latest.json`)
@@ -144,7 +169,6 @@ async function preserveRemoteArtifacts({ baseUrl, root }) {
         continue
       }
       const names = [
-        metadata.artifact,
         `${metadata.artifact}.sha256`,
         `ummaya-${manifest.version}-macos-${arch}.json`,
       ]
@@ -154,6 +178,13 @@ async function preserveRemoteArtifacts({ baseUrl, root }) {
       }
     }
     if (complete) {
+      for (const arch of ARCHES) {
+        const metadata = manifest.artifacts?.[arch]
+        if (metadata?.artifact) {
+          metadata.url ??= `${baseUrl}/${manifest.tag}/${metadata.artifact}`
+          metadata.releaseUrl ??= `${releaseBaseUrl}/${manifest.tag}/${metadata.artifact}`
+        }
+      }
       writeJson(join(versionDir, 'manifest.json'), manifest)
       manifests.set(manifest.tag, manifest)
     }
@@ -178,6 +209,38 @@ function compareVersionsDesc(left, right) {
     }
   }
   return 0
+}
+
+function homebrewDownloadPath(baseUrl, manifest, artifact) {
+  const basePath = new URL(baseUrl).pathname.replace(/\/$/, '')
+  return `${basePath}/${manifest.tag}/${artifact}`
+}
+
+function buildRedirectBlock({ baseUrl, manifests }) {
+  const lines = [REDIRECTS_BEGIN]
+  const sorted = [...manifests.values()].sort(compareVersionsDesc)
+  for (const manifest of sorted) {
+    for (const arch of ARCHES) {
+      const metadata = manifest.artifacts?.[arch]
+      if (!metadata?.artifact) {
+        continue
+      }
+      const source = homebrewDownloadPath(baseUrl, manifest, metadata.artifact)
+      const target = metadata.releaseUrl ?? `${DEFAULT_RELEASE_BASE_URL}/${manifest.tag}/${metadata.artifact}`
+      lines.push(`${source} ${target} 302`)
+    }
+  }
+  lines.push(REDIRECTS_END)
+  return `${lines.join('\n')}\n`
+}
+
+function writeRedirects({ baseUrl, manifests, redirectsPath }) {
+  const existing = existsSync(redirectsPath) ? readFileSync(redirectsPath, 'utf8') : ''
+  const pattern = new RegExp(`${REDIRECTS_BEGIN}[\\s\\S]*?${REDIRECTS_END}\\n?`, 'm')
+  const retained = existing.replace(pattern, '').replace(/\s+$/, '')
+  const block = buildRedirectBlock({ baseUrl, manifests })
+  const next = retained ? `${retained}\n\n${block}` : block
+  writeFileSync(redirectsPath, next)
 }
 
 async function main() {
@@ -211,6 +274,11 @@ async function main() {
 
   writeJson(join(args.root, 'versions.json'), {
     versions: [...staged.values()].sort(compareVersionsDesc),
+  })
+  writeRedirects({
+    baseUrl: args.baseUrl,
+    manifests: staged,
+    redirectsPath: args.redirectsPath,
   })
 
   console.log(`stage-homebrew-downloads: staged ${staged.size} version(s) under ${args.root}`)


### PR DESCRIPTION
## Summary
- fix the v0.1.17 cask artifact deployment path for Cloudflare Pages' 25 MiB file limit
- keep Homebrew cask URLs on `ummaya-docs.pages.dev`, but publish large tarballs as GitHub Release assets reached through Pages `_redirects`
- keep only small manifest, SHA, and metadata files in the Pages deployment
- update existing GitHub Releases to the current tag target when rerunning a repaired release

## Verification
- `node --check scripts/stage-homebrew-downloads.mjs`
- workflow YAML parse over `.github/workflows/*.yml`
- `scripts/stage-homebrew-downloads.mjs --artifact-dir dist/homebrew-release-0.1.17 --tag v0.1.17 ...` and verified no tarball is staged under Pages output
- `uv run python scripts/docs_generate.py --check`
- `npm run package:check`
- `git diff --check`

TUI no-change.
