### PR TITLE
fix(release): run cask runtime from cache

### DIFF
--- a/.github/workflows/publish-homebrew-cask-artifacts.yml
+++ b/.github/workflows/publish-homebrew-cask-artifacts.yml
@@ -72,6 +72,7 @@ jobs:
           test -d "${RUNNER_TEMP}/ummaya-cask-smoke/package/node_modules"
           test -f "${artifact}.sha256"
           "${RUNNER_TEMP}/ummaya-cask-smoke/ummaya" --version
+          UMMAYA_FORCE_RUNTIME_CACHE=1 "${RUNNER_TEMP}/ummaya-cask-smoke/ummaya" --version
           "${RUNNER_TEMP}/ummaya-cask-smoke/ummaya" --help >/dev/null
 
       - name: Upload cask artifact

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -3,9 +3,9 @@
 cask "ummaya" do
   arch arm: "arm64", intel: "x64"
 
-  version "0.1.17"
-  sha256 arm:   "ded4fa8b48f8d6d4ad3e48b006b4cb6199cb5e2d50c1d23cb0f772c0deeba70a",
-         intel: "4e18032520490fe0452b24574f1d488a2674bc7dcec64dbb5c65be28c590f25f"
+  version "0.1.18"
+  sha256 arm:   "6209badf537de8b841cac38a5c8042b34f619c56fcc80ce481c4990d2856aee6",
+         intel: "97563edb508b6078aa6933d149eb85a1811fd19f60dba8cf87b182a009102b1a"
 
   url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"
@@ -23,12 +23,6 @@ cask "ummaya" do
   depends_on formula: "uv"
 
   binary "ummaya"
-
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", staged_path.to_s],
-                   sudo: false
-  end
 
   zap trash: "~/.ummaya"
 end

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -4,8 +4,8 @@ cask "ummaya" do
   arch arm: "arm64", intel: "x64"
 
   version "0.1.18"
-  sha256 arm:   "6209badf537de8b841cac38a5c8042b34f619c56fcc80ce481c4990d2856aee6",
-         intel: "97563edb508b6078aa6933d149eb85a1811fd19f60dba8cf87b182a009102b1a"
+  sha256 arm:   "85da24e2240f0fcbf7e4c6098f36db74bb7e4dcaebe138237644167131c4ef0f",
+         intel: "23793a77722904e368cfe241c3d8039b382296c65e3482981efcfa4d664d1f15"
 
   url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"

--- a/docs/release/homebrew-official-readiness.md
+++ b/docs/release/homebrew-official-readiness.md
@@ -17,7 +17,7 @@ not controlled by UMMAYA release automation alone.
 
 ## Current State
 
-UMMAYA v0.1.17 now publishes macOS release archives:
+UMMAYA v0.1.18 now publishes macOS release archives:
 
 - `ummaya-<version>-macos-arm64.tar.gz`
 - `ummaya-<version>-macos-x64.tar.gz`
@@ -49,7 +49,7 @@ This keeps already published Homebrew URLs stable across later documentation-onl
 
 ### 1. Prebuilt artifact gate
 
-Status: satisfied for the current tap cask.
+Status: satisfied for the current tap and official cask candidate.
 
 The original rejected cask used the npm registry tarball and a `preflight` block that ran
 `npm install`. Official casks install prebuilt software artifacts, so that shape was not
@@ -94,21 +94,17 @@ manual notability discretion during review.
 
 ### 4. Gatekeeper/runtime gate
 
-Status: review risk remains.
+Status: addressed in the v0.1.18 release artifact.
 
-The current archive bundles Bun 1.3.14 so users do not run `npm install` during cask
-installation. The bundled Bun binary is Developer ID signed but not accepted by Gatekeeper when
-Homebrew quarantine is present:
+The archive bundles Bun 1.3.14 so users do not run `npm install` during cask installation.
+Earlier tap-only casks removed `com.apple.quarantine` in `postflight` to make the bundled
+runtime work from `Caskroom`, but official casks should not bypass Homebrew's quarantine model.
+The v0.1.18 wrapper therefore keeps the cask DSL free of quarantine-stripping hooks and, when
+running from Homebrew `Caskroom`, copies the bundled runtime into a SHA-256-addressed user cache
+with `cp -X` before execution. The copied runtime SHA is checked before reuse, and the archive
+itself is still verified by the cask SHA.
 
-```text
-spctl: rejected
-source=Unnotarized Developer ID
-```
-
-The tap cask removes `com.apple.quarantine` in `postflight` to make the installed runtime work.
-That is acceptable for the project tap only as an operational workaround. For official
-homebrew-cask, this is a review risk because accepted CLI casks generally install binaries that
-run under Homebrew quarantine without a quarantine-removal workaround.
+Official cask candidates must not include a `postflight` stanza that strips quarantine.
 
 ## Current Recommendation
 
@@ -119,14 +115,14 @@ The minimum safe sequence is:
 1. Keep the project tap cask on the prebuilt artifact path.
 2. Publish prebuilt cask artifacts to the UMMAYA docs/download domain.
 3. Render the cask from the docs/download URL, not the GitHub source repository URL.
-4. Remove cask syntax/style issues (`verified:` and missing `depends_on :macos`).
+4. Remove cask syntax/style issues (`verified:`, missing `depends_on :macos`, and quarantine
+   removal hooks).
 5. If maintainers request the formula-first route, cite that UMMAYA's cask artifact includes a
    bundled macOS runtime so installation is a prebuilt binary distribution rather than a
    source-build formula. If they still require `homebrew/core`, open the formula discussion and
    link it from the cask PR.
-6. Remove the official cask runtime risk by shipping a runtime that works under Homebrew
-   quarantine, or by changing the packaging model so the cask does not need to remove
-   quarantine attributes.
+6. Use the v0.1.18+ wrapper so the official cask can run without a quarantine-removal
+   `postflight`.
 7. Re-run `brew audit --cask --new --online` or `brew audit --formula --new --online` in the
    target official repository before opening another official PR.
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ummaya",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ummaya",
-      "version": "0.1.17",
+      "version": "0.1.18",
       "license": "Apache-2.0",
       "dependencies": {
         "@alcalzone/ansi-tokenize": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "description": "Conversational multi-agent harness for Korean public-service channels",
   "license": "Apache-2.0",
   "type": "module",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ummaya"
-version = "0.1.17"
+version = "0.1.18"
 description = "Conversational multi-agent platform for Korean public APIs"
 readme = "README.md"
 license = "Apache-2.0"
@@ -314,7 +314,7 @@ min_confidence = 80
 
 [tool.commitizen]
 name = "cz_conventional_commits"
-version = "0.1.17"
+version = "0.1.18"
 tag_format = "v$version"
 
 # PyTorch CPU-only wheel for Docker image size discipline (SC-1: ≤ 2 GB).

--- a/scripts/build-homebrew-cask-artifact.mjs
+++ b/scripts/build-homebrew-cask-artifact.mjs
@@ -153,17 +153,16 @@ if [[ "$use_cached_runtime" == "1" && -n "\${HOME:-}" ]]; then
   cache_home="\${XDG_CACHE_HOME:-$HOME/.cache}"
   cache_dir="$cache_home/ummaya/runtime/bun-$runtime_sha256"
   cache_bun="$cache_dir/bun"
+  cache_marker="$cache_dir/.sha256"
   cache_ok=0
-  if [[ -x "$cache_bun" ]]; then
-    cached_sha="$(/usr/bin/shasum -a 256 "$cache_bun" | /usr/bin/awk '{print $1}')"
-    if [[ "$cached_sha" == "$runtime_sha256" ]]; then
-      cache_ok=1
-    fi
+  if [[ -x "$cache_bun" && -f "$cache_marker" && "$(cat "$cache_marker")" == "$runtime_sha256" ]]; then
+    cache_ok=1
   fi
   if [[ "$cache_ok" != "1" ]]; then
     mkdir -p "$cache_dir"
     /bin/cp -X "$runtime_bun" "$cache_bun"
     chmod 0755 "$cache_bun"
+    printf '%s\n' "$runtime_sha256" > "$cache_marker"
   fi
   export PATH="$cache_dir:$PATH"
   exec "$cache_bun" "$root_dir/package/bin/ummaya" "$@"

--- a/scripts/build-homebrew-cask-artifact.mjs
+++ b/scripts/build-homebrew-cask-artifact.mjs
@@ -121,7 +121,7 @@ async function downloadBunRuntime(workdir, arch) {
   return binaryPath
 }
 
-function writeWrapper(path) {
+function writeWrapper(path, runtimeSha256) {
   writeFileSync(
     path,
     `#!/bin/bash
@@ -139,8 +139,38 @@ while [ -h "$source_path" ]; do
 done
 
 root_dir="$(cd -P "$(dirname "$source_path")" >/dev/null 2>&1 && pwd)"
+runtime_bun="$root_dir/runtime/bun"
+runtime_sha256="${runtimeSha256}"
+
+use_cached_runtime=0
+if [[ "\${UMMAYA_FORCE_RUNTIME_CACHE:-}" == "1" ]]; then
+  use_cached_runtime=1
+elif [[ "$root_dir" == */Caskroom/ummaya/* ]]; then
+  use_cached_runtime=1
+fi
+
+if [[ "$use_cached_runtime" == "1" && -n "\${HOME:-}" ]]; then
+  cache_home="\${XDG_CACHE_HOME:-$HOME/.cache}"
+  cache_dir="$cache_home/ummaya/runtime/bun-$runtime_sha256"
+  cache_bun="$cache_dir/bun"
+  cache_ok=0
+  if [[ -x "$cache_bun" ]]; then
+    cached_sha="$(/usr/bin/shasum -a 256 "$cache_bun" | /usr/bin/awk '{print $1}')"
+    if [[ "$cached_sha" == "$runtime_sha256" ]]; then
+      cache_ok=1
+    fi
+  fi
+  if [[ "$cache_ok" != "1" ]]; then
+    mkdir -p "$cache_dir"
+    /bin/cp -X "$runtime_bun" "$cache_bun"
+    chmod 0755 "$cache_bun"
+  fi
+  export PATH="$cache_dir:$PATH"
+  exec "$cache_bun" "$root_dir/package/bin/ummaya" "$@"
+fi
+
 export PATH="$root_dir/runtime:$PATH"
-exec "$root_dir/runtime/bun" "$root_dir/package/bin/ummaya" "$@"
+exec "$runtime_bun" "$root_dir/package/bin/ummaya" "$@"
 `,
   )
   chmodSync(path, 0o755)
@@ -200,9 +230,11 @@ async function main() {
     )
 
     const bunBinary = await downloadBunRuntime(workdir, args.arch)
-    copyFileSync(bunBinary, join(runtimeDir, 'bun'))
-    chmodSync(join(runtimeDir, 'bun'), 0o755)
-    writeWrapper(join(artifactRoot, 'ummaya'))
+    const runtimePath = join(runtimeDir, 'bun')
+    copyFileSync(bunBinary, runtimePath)
+    chmodSync(runtimePath, 0o755)
+    const runtimeSha256 = await sha256(runtimePath)
+    writeWrapper(join(artifactRoot, 'ummaya'), runtimeSha256)
 
     const artifactName = `ummaya-${version}-macos-${args.arch}.tar.gz`
     const artifactPath = join(outDir, artifactName)

--- a/scripts/render-homebrew-cask.mjs
+++ b/scripts/render-homebrew-cask.mjs
@@ -50,12 +50,6 @@ cask "ummaya" do
 
   binary "ummaya"
 
-  postflight do
-    system_command "/usr/bin/xattr",
-                   args: ["-dr", "com.apple.quarantine", staged_path.to_s],
-                   sudo: false
-  end
-
   zap trash: "~/.ummaya"
 end
 `

--- a/tui/package.json
+++ b/tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ummaya",
-  "version": "0.1.17",
+  "version": "0.1.18",
   "private": true,
   "type": "module",
   "engines": {

--- a/uv.lock
+++ b/uv.lock
@@ -2725,7 +2725,7 @@ wheels = [
 
 [[package]]
 name = "ummaya"
-version = "0.1.17"
+version = "0.1.18"
 source = { editable = "." }
 dependencies = [
     { name = "httpx" },


### PR DESCRIPTION
## Summary
- bump UMMAYA to 0.1.18 for a Homebrew cask runtime fix
- remove quarantine-stripping cask postflight generation
- make the prebuilt cask wrapper copy bundled Bun to a SHA-256-addressed runtime cache when launched from Homebrew Caskroom
- add release workflow smoke coverage for the runtime-cache path

## Verification
- `npm run package:check`
- `uv sync --frozen`
- `uv run pytest` -> 4089 passed, 63 skipped, 3 xfailed
- `node scripts/build-homebrew-cask-artifact.mjs --arch arm64 --out-dir dist/homebrew-release-0.1.18`
- `node scripts/build-homebrew-cask-artifact.mjs --arch x64 --out-dir dist/homebrew-release-0.1.18`
- fake Caskroom smoke: `0.1.18 (UMMAYA)` for direct and `UMMAYA_FORCE_RUNTIME_CACHE=1` launches
- `ruby -c Casks/ummaya.rb`
- `brew style Casks/ummaya.rb`
- `git diff --check`

TUI no-change.
