### PR TITLE
fix(release): make cask artifacts deterministic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   follow-up calls while preserving KMA's grid-based weather path.
 - Hardened packaged npm and Homebrew launchers against stale backend environment variables
   and verified the 0.2.2 package metadata across npm, Python, TUI, uv, and Cask files.
+- Made Homebrew cask artifact archives deterministic and omitted optional native canvas builds
+  so committed Cask SHA values match the published macOS artifacts.
 
 ## [v0.2.0] - 2026-05-25
 

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -4,8 +4,8 @@ cask "ummaya" do
   arch arm: "arm64", intel: "x64"
 
   version "0.2.2"
-  sha256 arm:   "119ea56b8c2e183fe40e3ca5ef17b2f2b19034f7bc9c51bb2ec3f4e62fad9b23",
-         intel: "f2aaca9567f40a7d9dad50f8e6bb9b9bd040b353922112ed9b267b8bc0bd1567"
+  sha256 arm:   "9c3187c6b98402b8c41b9f9451e5d61c1cd52f8cc0c3175f023151bf9b50708c",
+         intel: "ce26812af397804701a8a984c3d77ffccf608ad0ec1e9148810b48ab0c8ac7c4"
 
   url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"

--- a/scripts/build-homebrew-cask-artifact.mjs
+++ b/scripts/build-homebrew-cask-artifact.mjs
@@ -7,11 +7,16 @@ import {
   copyFileSync,
   createReadStream,
   existsSync,
+  lstatSync,
+  lutimesSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
+  renameSync,
   readFileSync,
   realpathSync,
   rmSync,
+  utimesSync,
   writeFileSync,
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -19,6 +24,7 @@ import { basename, join, resolve } from 'node:path'
 import { spawnSync } from 'node:child_process'
 
 const BUN_VERSION = '1.3.14'
+const ARCHIVE_MTIME = new Date('2020-01-01T00:00:00.000Z')
 const SUPPORTED_ARCHES = new Set(['arm64', 'x64'])
 const BUN_ASSETS = {
   arm64: {
@@ -90,6 +96,37 @@ function sha256(path) {
     stream.on('error', reject)
     stream.on('end', () => resolve(hash.digest('hex')))
   })
+}
+
+function collectArchiveEntries(root) {
+  const entries = []
+
+  function visit(relativeDir) {
+    const absoluteDir = join(root, relativeDir)
+    const names = readdirSync(absoluteDir).sort((left, right) => left.localeCompare(right))
+    for (const name of names) {
+      const relativePath = relativeDir === '.' ? `./${name}` : `${relativeDir}/${name}`
+      entries.push(relativePath)
+      if (lstatSync(join(root, relativePath)).isDirectory()) {
+        visit(relativePath)
+      }
+    }
+  }
+
+  visit('.')
+  return entries
+}
+
+function normalizeArchiveMetadata(root, entries) {
+  for (const entry of ['.', ...entries]) {
+    const absolutePath = join(root, entry)
+    const stat = lstatSync(absolutePath)
+    if (stat.isSymbolicLink()) {
+      lutimesSync(absolutePath, ARCHIVE_MTIME, ARCHIVE_MTIME)
+    } else {
+      utimesSync(absolutePath, ARCHIVE_MTIME, ARCHIVE_MTIME)
+    }
+  }
 }
 
 function packageVersion() {
@@ -287,6 +324,7 @@ async function main() {
       [
         'install',
         '--omit=dev',
+        '--omit=optional',
         '--legacy-peer-deps',
         '--no-audit',
         '--no-fund',
@@ -315,7 +353,32 @@ async function main() {
 
     const artifactName = `ummaya-${version}-macos-${args.arch}.tar.gz`
     const artifactPath = join(outDir, artifactName)
-    run('tar', ['-czf', artifactPath, '-C', artifactRoot, '.'])
+    const archiveEntries = collectArchiveEntries(artifactRoot)
+    normalizeArchiveMetadata(artifactRoot, archiveEntries)
+    const archiveListPath = join(workdir, 'archive-files.txt')
+    const tarPath = join(outDir, `ummaya-${version}-macos-${args.arch}.tar`)
+    writeFileSync(archiveListPath, `${archiveEntries.join('\n')}\n`)
+    rmSync(tarPath, { force: true })
+    rmSync(artifactPath, { force: true })
+    run('tar', [
+      '--no-recursion',
+      '--uid',
+      '0',
+      '--gid',
+      '0',
+      '--uname',
+      'root',
+      '--gname',
+      'wheel',
+      '-cf',
+      tarPath,
+      '-C',
+      artifactRoot,
+      '-T',
+      archiveListPath,
+    ])
+    run('gzip', ['-n', '-9', tarPath])
+    renameSync(`${tarPath}.gz`, artifactPath)
     const digest = await sha256(artifactPath)
     writeFileSync(`${artifactPath}.sha256`, `${digest}  ${artifactName}\n`)
     writeFileSync(


### PR DESCRIPTION
## Summary
- make Homebrew cask archive creation deterministic with sorted entries, fixed mtimes, fixed uid/gid, and gzip -n
- omit optional native canvas builds from cask artifacts so archive contents are stable
- update v0.2.2 Cask SHA values from repeated deterministic local builds

## Verification
- npm run package:homebrew-cask
- repeated arm64/x64 cask artifact builds produced identical SHA-256 values
- npm run package:check
- ruby -c Casks/ummaya.rb
- uv run python scripts/docs_generate.py --check
- git diff --check

## Release repair
- After CI passes and this merges, move v0.2.2 to the final main commit and rerun tag release workflows so npm, GitHub Release, and Homebrew metadata are all aligned.