### PR TITLE
fix(release): install cask package from lockfile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,7 @@ on:
       - "uv.lock"
       - "src/**"
       - "tests/**"
+      - "scripts/**"
       - "prompts/**"
       - "tools/**"
       - "tui/**"

--- a/scripts/build-homebrew-cask-artifact.mjs
+++ b/scripts/build-homebrew-cask-artifact.mjs
@@ -322,7 +322,7 @@ async function main() {
     run(
       'npm',
       [
-        'install',
+        'ci',
         '--omit=dev',
         '--omit=optional',
         '--legacy-peer-deps',


### PR DESCRIPTION
## Summary
- use npm ci for Homebrew cask artifact staging so package node_modules are lockfile-derived in CI and local release builds

## Verification
- npm run package:homebrew-cask
- repeated arm64/x64 cask artifact builds produced identical SHA-256 values
- npm run package:check
- uv run python scripts/docs_generate.py --check
- git diff --check

## Release repair
- After this merges and main CI passes, move v0.2.2 to the final main commit and rerun tag release workflows.