### PR TITLE
fix(release): gate cask sha parity

### DIFF
--- a/.github/workflows/publish-homebrew-cask-artifacts.yml
+++ b/.github/workflows/publish-homebrew-cask-artifacts.yml
@@ -128,6 +128,18 @@ jobs:
           path: dist/homebrew
           merge-multiple: true
 
+      - name: Verify committed cask matches artifacts
+        run: |
+          version="$(node -p "require('./package.json').version")"
+          arm64_sha="$(node -e 'const fs = require("node:fs"); const json = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); console.log(json.sha256);' "dist/homebrew/ummaya-${version}-macos-arm64.json")"
+          x64_sha="$(node -e 'const fs = require("node:fs"); const json = JSON.parse(fs.readFileSync(process.argv[1], "utf8")); console.log(json.sha256);' "dist/homebrew/ummaya-${version}-macos-x64.json")"
+          expected="$(mktemp)"
+          node scripts/render-homebrew-cask.mjs "${version}" "${arm64_sha}" "${x64_sha}" "${expected}"
+          if ! diff -u Casks/ummaya.rb "${expected}"; then
+            echo "::error::Casks/ummaya.rb does not match generated Homebrew artifacts"
+            exit 1
+          fi
+
       - name: Resolve tag
         id: release
         run: |

--- a/Casks/ummaya.rb
+++ b/Casks/ummaya.rb
@@ -4,8 +4,8 @@ cask "ummaya" do
   arch arm: "arm64", intel: "x64"
 
   version "0.2.2"
-  sha256 arm:   "877529f12189112a6f96f9b10d3dde4f597cdd2d022350ec0d0710ca596c7f6a",
-         intel: "444ff4de80fda270d9e4bb43db146d54b484b9cc353a09cc04f4e786cffe161d"
+  sha256 arm:   "5d63459476890cd5f97573afb80ece50d940ff299a135f847283ce851fbc4a3e",
+         intel: "dadb3e7f6db1909963d9a1379367dcb8500277f09d43e36188cda212a24a19c8"
 
   url "https://ummaya-docs.pages.dev/downloads/homebrew/v#{version}/ummaya-#{version}-macos-#{arch}.tar.gz"
   name "UMMAYA"


### PR DESCRIPTION
## Summary
- update the committed Homebrew Cask SHA values to match the v0.2.2 artifacts currently deployed through the release workflow
- add a release workflow check that compares the committed Cask against the generated cask artifact metadata before upload/deploy

## Verification
- ruby -c Casks/ummaya.rb
- npm run package:check
- node scripts/render-homebrew-cask.mjs 0.2.2 <arm64-sha> <x64-sha> <tmp> && diff -u Casks/ummaya.rb <tmp>
- git diff --check
- downloaded deployed Homebrew arm64/x64 tarballs and verified SHA-256 matches latest.json and Casks/ummaya.rb

TUI no-change.