### PR TITLE
feat(tools): modernize adapter route selection

### DIFF
--- a/docs-site/public/_llm/generated/workflows.json
+++ b/docs-site/public/_llm/generated/workflows.json
@@ -603,6 +603,37 @@
   },
   {
     "agencies_or_infrastructure": [
+      "aviation weather infrastructure",
+      "airport operations data",
+      "airline delay notice infrastructure",
+      "public transit operations data"
+    ],
+    "domain": "mobility",
+    "evaluation_focus": [
+      "aviation_weather",
+      "multi_source_lookup",
+      "alert_subscription_boundary"
+    ],
+    "expected_ax_chain": [
+      {
+        "primitive": "locate",
+        "purpose": "normalize_airport_and_destination"
+      },
+      {
+        "primitive": "find",
+        "purpose": "collect_aviation_weather_delay_and_airport_access_status"
+      },
+      {
+        "primitive": "send",
+        "purpose": "monitor_weather_delay_and_access_alerts_until_departure"
+      }
+    ],
+    "id": "MOB-003",
+    "priority": "P1",
+    "request_ko": "내일 김해공항에서 제주로 가는 항공편이 있는데 항공기상, 지연 위험, 공항 이동까지 확인하고 알림 설정해줘."
+  },
+  {
+    "agencies_or_infrastructure": [
       "National Tax Service Hometax",
       "local government licensing infrastructure",
       "food safety education infrastructure",
@@ -676,6 +707,41 @@
     "id": "BUS-002",
     "priority": "P1",
     "request_ko": "직원을 처음 채용했어. 4대보험 신고, 근로계약, 지원금 받을 수 있는지까지 확인해서 진행해줘."
+  },
+  {
+    "agencies_or_infrastructure": [
+      "public procurement infrastructure",
+      "supplier registration infrastructure",
+      "business certificate infrastructure",
+      "bid notice public data"
+    ],
+    "domain": "business",
+    "evaluation_focus": [
+      "procurement",
+      "document_completeness",
+      "irreversible_submission_guard"
+    ],
+    "expected_ax_chain": [
+      {
+        "primitive": "check",
+        "purpose": "supplier_identity_and_business_authority"
+      },
+      {
+        "primitive": "find",
+        "purpose": "find_procurement_bid_notice_and_required_documents"
+      },
+      {
+        "primitive": "send",
+        "purpose": "submit_bid_or_prepare_official_handoff_after_confirmation"
+      },
+      {
+        "primitive": "send",
+        "purpose": "track_procurement_notice_changes_and_deadlines"
+      }
+    ],
+    "id": "BUS-003",
+    "priority": "P1",
+    "request_ko": "소상공인 장비 납품 입찰에 참여하고 싶어. 나라장터 공고를 찾고 자격서류를 확인해서 제출 가능하면 진행해줘."
   },
   {
     "agencies_or_infrastructure": [
@@ -790,80 +856,5 @@
     "id": "EDU-002",
     "priority": "P1",
     "request_ko": "등록금이 부담돼. 국가장학금, 학자금대출, 근로장학 중 내가 신청할 수 있는 걸 찾아서 진행해줘."
-  },
-  {
-    "agencies_or_infrastructure": [
-      "local disaster response center",
-      "disaster relief infrastructure",
-      "temporary housing infrastructure",
-      "electric and gas safety operators",
-      "emergency alert infrastructure"
-    ],
-    "domain": "safety",
-    "evaluation_focus": [
-      "crisis_mode",
-      "partial_information_handling",
-      "multi_agency_relief"
-    ],
-    "expected_ax_chain": [
-      {
-        "primitive": "locate",
-        "purpose": "identify_affected_address_and_jurisdiction"
-      },
-      {
-        "primitive": "check",
-        "purpose": "resident_or_property_authority"
-      },
-      {
-        "primitive": "send",
-        "purpose": "file_disaster_damage_report"
-      },
-      {
-        "primitive": "send",
-        "purpose": "request_relief_temporary_housing_or_safety_inspection"
-      },
-      {
-        "primitive": "send",
-        "purpose": "monitor_disaster_alerts_and_case_status"
-      }
-    ],
-    "id": "SAF-001",
-    "priority": "P0",
-    "request_ko": "집이 침수됐어. 피해 신고, 재난지원금, 임시주거, 전기·가스 안전 점검까지 바로 도와줘."
-  },
-  {
-    "agencies_or_infrastructure": [
-      "local civil complaint infrastructure",
-      "environmental complaint infrastructure",
-      "municipal construction permit records",
-      "evidence attachment infrastructure"
-    ],
-    "domain": "safety",
-    "evaluation_focus": [
-      "civil_petition_routing",
-      "evidence_sanitization",
-      "response_tracking"
-    ],
-    "expected_ax_chain": [
-      {
-        "primitive": "locate",
-        "purpose": "identify_jurisdiction_and_construction_site"
-      },
-      {
-        "primitive": "find",
-        "purpose": "determine_responsible_office_and_required_evidence"
-      },
-      {
-        "primitive": "send",
-        "purpose": "submit_civil_complaint_with_user_confirmed_evidence"
-      },
-      {
-        "primitive": "send",
-        "purpose": "track_response_deadline"
-      }
-    ],
-    "id": "SAF-002",
-    "priority": "P1",
-    "request_ko": "동네 공사 소음이 너무 심해. 어디에 민원 넣어야 하는지 찾고 증거 정리해서 접수해줘."
   }
 ]

--- a/docs-site/src/data/generated/workflows.json
+++ b/docs-site/src/data/generated/workflows.json
@@ -603,6 +603,37 @@
   },
   {
     "agencies_or_infrastructure": [
+      "aviation weather infrastructure",
+      "airport operations data",
+      "airline delay notice infrastructure",
+      "public transit operations data"
+    ],
+    "domain": "mobility",
+    "evaluation_focus": [
+      "aviation_weather",
+      "multi_source_lookup",
+      "alert_subscription_boundary"
+    ],
+    "expected_ax_chain": [
+      {
+        "primitive": "locate",
+        "purpose": "normalize_airport_and_destination"
+      },
+      {
+        "primitive": "find",
+        "purpose": "collect_aviation_weather_delay_and_airport_access_status"
+      },
+      {
+        "primitive": "send",
+        "purpose": "monitor_weather_delay_and_access_alerts_until_departure"
+      }
+    ],
+    "id": "MOB-003",
+    "priority": "P1",
+    "request_ko": "내일 김해공항에서 제주로 가는 항공편이 있는데 항공기상, 지연 위험, 공항 이동까지 확인하고 알림 설정해줘."
+  },
+  {
+    "agencies_or_infrastructure": [
       "National Tax Service Hometax",
       "local government licensing infrastructure",
       "food safety education infrastructure",
@@ -676,6 +707,41 @@
     "id": "BUS-002",
     "priority": "P1",
     "request_ko": "직원을 처음 채용했어. 4대보험 신고, 근로계약, 지원금 받을 수 있는지까지 확인해서 진행해줘."
+  },
+  {
+    "agencies_or_infrastructure": [
+      "public procurement infrastructure",
+      "supplier registration infrastructure",
+      "business certificate infrastructure",
+      "bid notice public data"
+    ],
+    "domain": "business",
+    "evaluation_focus": [
+      "procurement",
+      "document_completeness",
+      "irreversible_submission_guard"
+    ],
+    "expected_ax_chain": [
+      {
+        "primitive": "check",
+        "purpose": "supplier_identity_and_business_authority"
+      },
+      {
+        "primitive": "find",
+        "purpose": "find_procurement_bid_notice_and_required_documents"
+      },
+      {
+        "primitive": "send",
+        "purpose": "submit_bid_or_prepare_official_handoff_after_confirmation"
+      },
+      {
+        "primitive": "send",
+        "purpose": "track_procurement_notice_changes_and_deadlines"
+      }
+    ],
+    "id": "BUS-003",
+    "priority": "P1",
+    "request_ko": "소상공인 장비 납품 입찰에 참여하고 싶어. 나라장터 공고를 찾고 자격서류를 확인해서 제출 가능하면 진행해줘."
   },
   {
     "agencies_or_infrastructure": [
@@ -790,80 +856,5 @@
     "id": "EDU-002",
     "priority": "P1",
     "request_ko": "등록금이 부담돼. 국가장학금, 학자금대출, 근로장학 중 내가 신청할 수 있는 걸 찾아서 진행해줘."
-  },
-  {
-    "agencies_or_infrastructure": [
-      "local disaster response center",
-      "disaster relief infrastructure",
-      "temporary housing infrastructure",
-      "electric and gas safety operators",
-      "emergency alert infrastructure"
-    ],
-    "domain": "safety",
-    "evaluation_focus": [
-      "crisis_mode",
-      "partial_information_handling",
-      "multi_agency_relief"
-    ],
-    "expected_ax_chain": [
-      {
-        "primitive": "locate",
-        "purpose": "identify_affected_address_and_jurisdiction"
-      },
-      {
-        "primitive": "check",
-        "purpose": "resident_or_property_authority"
-      },
-      {
-        "primitive": "send",
-        "purpose": "file_disaster_damage_report"
-      },
-      {
-        "primitive": "send",
-        "purpose": "request_relief_temporary_housing_or_safety_inspection"
-      },
-      {
-        "primitive": "send",
-        "purpose": "monitor_disaster_alerts_and_case_status"
-      }
-    ],
-    "id": "SAF-001",
-    "priority": "P0",
-    "request_ko": "집이 침수됐어. 피해 신고, 재난지원금, 임시주거, 전기·가스 안전 점검까지 바로 도와줘."
-  },
-  {
-    "agencies_or_infrastructure": [
-      "local civil complaint infrastructure",
-      "environmental complaint infrastructure",
-      "municipal construction permit records",
-      "evidence attachment infrastructure"
-    ],
-    "domain": "safety",
-    "evaluation_focus": [
-      "civil_petition_routing",
-      "evidence_sanitization",
-      "response_tracking"
-    ],
-    "expected_ax_chain": [
-      {
-        "primitive": "locate",
-        "purpose": "identify_jurisdiction_and_construction_site"
-      },
-      {
-        "primitive": "find",
-        "purpose": "determine_responsible_office_and_required_evidence"
-      },
-      {
-        "primitive": "send",
-        "purpose": "submit_civil_complaint_with_user_confirmed_evidence"
-      },
-      {
-        "primitive": "send",
-        "purpose": "track_response_deadline"
-      }
-    ],
-    "id": "SAF-002",
-    "priority": "P1",
-    "request_ko": "동네 공사 소음이 너무 심해. 어디에 민원 넣어야 하는지 찾고 증거 정리해서 접수해줘."
   }
 ]

--- a/evidence/scenarios/national_ax_citizen_requests_v1.yaml
+++ b/evidence/scenarios/national_ax_citizen_requests_v1.yaml
@@ -41,6 +41,7 @@ coverage_domains:
   - immigration
   - legal
   - personal_data
+  - public_data
 
 scenarios:
   - id: TAX-001
@@ -771,6 +772,44 @@ scenarios:
       - risk_ranking
       - freshness_disclosure
 
+  - id: MOB-003
+    priority: P1
+    lifecycle_domain: mobility
+    citizen_segment: air_traveler
+    request_ko: "내일 김해공항에서 제주로 가는 항공편이 있는데 항공기상, 지연 위험, 공항 이동까지 확인하고 알림 설정해줘."
+    request_en: "I fly from Gimhae Airport to Jeju tomorrow. Check aviation weather, delay risk, airport access, and set alerts."
+    agencies_or_infrastructure:
+      - aviation weather infrastructure
+      - airport operations data
+      - airline delay notice infrastructure
+      - public transit operations data
+    citizen_intent_verbs:
+      - check_flight_risk
+      - plan_airport_access
+      - subscribe_alert
+    expected_ax_chain:
+      - primitive: resolve_location
+        purpose: normalize_airport_and_destination
+      - primitive: lookup
+        purpose: collect_aviation_weather_delay_and_airport_access_status
+      - primitive: subscribe
+        purpose: monitor_weather_delay_and_access_alerts_until_departure
+    permission_requirements:
+      identity_assurance: low
+      user_confirmations:
+        - travel_alert_subscription
+      sensitive_data:
+        - travel_plan
+        - airport_route
+    expected_system_behavior:
+      - cite_forecast_freshness_and_airport_data_time
+      - avoid_claiming_operational_certainty
+      - separate_weather_risk_from_airline_delay_status
+    evaluation_focus:
+      - aviation_weather
+      - multi_source_lookup
+      - alert_subscription_boundary
+
   - id: BUS-001
     priority: P0
     lifecycle_domain: business
@@ -860,6 +899,48 @@ scenarios:
       - employer_obligation_bundle
       - third_party_pii_guard
       - subsidy_discovery
+
+  - id: BUS-003
+    priority: P1
+    lifecycle_domain: business
+    citizen_segment: supplier
+    request_ko: "소상공인 장비 납품 입찰에 참여하고 싶어. 나라장터 공고를 찾고 자격서류를 확인해서 제출 가능하면 진행해줘."
+    request_en: "I want to bid on a small-business equipment supply opportunity. Find procurement notices, check eligibility documents, and proceed if submission is possible."
+    agencies_or_infrastructure:
+      - public procurement infrastructure
+      - supplier registration infrastructure
+      - business certificate infrastructure
+      - bid notice public data
+    citizen_intent_verbs:
+      - search_procurement
+      - verify_supplier_eligibility
+      - submit_bid
+    expected_ax_chain:
+      - primitive: verify
+        purpose: supplier_identity_and_business_authority
+      - primitive: lookup
+        purpose: find_procurement_bid_notice_and_required_documents
+      - primitive: submit
+        purpose: submit_bid_or_prepare_official_handoff_after_confirmation
+      - primitive: subscribe
+        purpose: track_procurement_notice_changes_and_deadlines
+    permission_requirements:
+      identity_assurance: high
+      user_confirmations:
+        - supplier_registration_data_use
+        - bid_submission
+      sensitive_data:
+        - business_registration
+        - bid_documents
+        - supplier_credentials
+    expected_system_behavior:
+      - separate_public_notice_search_from_binding_bid_submission
+      - require_final_confirmation_before_bid_submission
+      - preserve_document_and_receipt_lineage
+    evaluation_focus:
+      - procurement
+      - document_completeness
+      - irreversible_submission_guard
 
   - id: LAB-001
     priority: P0
@@ -1081,6 +1162,44 @@ scenarios:
       - evidence_sanitization
       - response_tracking
 
+  - id: SAF-003
+    priority: P0
+    lifecycle_domain: safety
+    citizen_segment: bystander
+    request_ko: "사람이 쓰러졌어. 현재 위치 기준 가까운 AED와 응급 안내를 찾고 119 신고는 내가 직접 할 수 있게 안내해줘."
+    request_en: "Someone collapsed. Find nearby AED locations and emergency guidance from my current location, while leaving the 119 call for me to make directly."
+    agencies_or_infrastructure:
+      - AED location infrastructure
+      - emergency medical guidance infrastructure
+      - local safety center data
+      - emergency call handoff
+    citizen_intent_verbs:
+      - locate_aed
+      - get_emergency_guidance
+      - handoff_emergency_call
+    expected_ax_chain:
+      - primitive: resolve_location
+        purpose: normalize_current_location_for_aed_search
+      - primitive: lookup
+        purpose: find_nearby_aed_and_emergency_guidance
+      - primitive: subscribe
+        purpose: keep_safety_status_visible_until_user_confirms_handoff
+    permission_requirements:
+      identity_assurance: low
+      user_confirmations:
+        - current_location_use
+      sensitive_data:
+        - current_location
+        - emergency_context
+    expected_system_behavior:
+      - prioritize_119_call_handoff_before_tool_work
+      - avoid_claiming_medical_diagnosis
+      - keep_location_use_explicit
+    evaluation_focus:
+      - aed_safety
+      - location_resolution
+      - emergency_handoff_boundary
+
   - id: IMM-001
     priority: P1
     lifecycle_domain: immigration
@@ -1213,6 +1332,38 @@ scenarios:
       - privacy_rights_workflow
       - cross_agency_record_mapping
       - consent_management
+
+  - id: PUB-001
+    priority: P1
+    lifecycle_domain: public_data
+    citizen_segment: community_researcher
+    request_ko: "우리 동네 노인복지시설 공공데이터를 찾아서 위치, 운영시간, 제공 서비스 기준으로 비교해줘."
+    request_en: "Find public data for senior welfare facilities in my neighborhood and compare them by location, operating hours, and services."
+    agencies_or_infrastructure:
+      - public data portal
+      - local government open data
+      - facility location data
+    citizen_intent_verbs:
+      - search_public_data
+      - compare_facilities
+      - resolve_area
+    expected_ax_chain:
+      - primitive: resolve_location
+        purpose: normalize_neighborhood_scope
+      - primitive: lookup
+        purpose: search_public_data_and_compare_facility_records
+    permission_requirements:
+      identity_assurance: none
+      user_confirmations: []
+      sensitive_data: []
+    expected_system_behavior:
+      - cite_dataset_source_and_update_time
+      - separate_public_records_from_personal_recommendations
+      - explain_missing_or_stale_dataset_fields
+    evaluation_focus:
+      - public_data_search
+      - source_freshness
+      - no_personal_data_boundary
 
   - id: SUB-001
     priority: P1

--- a/src/ummaya/engine/engine.py
+++ b/src/ummaya/engine/engine.py
@@ -8,7 +8,6 @@ the standalone ``query()`` async generator.
 
 from __future__ import annotations
 
-import json
 import logging
 from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING
@@ -20,9 +19,13 @@ from ummaya.engine.models import QueryContext, QueryState, SessionBudget
 from ummaya.engine.query import query
 from ummaya.llm.client import LLMClient
 from ummaya.llm.models import ChatMessage
-from ummaya.tools.errors import ToolNotFoundError
 from ummaya.tools.executor import ToolExecutor
 from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.routing import (
+    RouteDecisionService,
+    build_available_adapters_projection,
+    selected_concrete_adapter_tools,
+)
 
 if TYPE_CHECKING:
     from ummaya.permissions.models import SessionContext
@@ -30,66 +33,6 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _INTERNAL_CONTEXT_TOOL_IDS = frozenset({"find", "locate", "check", "send", "search_tools"})
-
-_LOCATION_DEPENDENT_SCHEMA_KEYS = frozenset(
-    {
-        "adm_cd",
-        "admcd",
-        "admin_code",
-        "administrative_code",
-        "latitude",
-        "lat",
-        "longitude",
-        "lon",
-        "lng",
-        "nx",
-        "ny",
-        "region_cd",
-        "region_code",
-    }
-)
-
-
-def _schema_requires_location_resolution(
-    input_schema_json: object,
-    required_params: object,
-) -> bool:
-    """Return True when an adapter schema needs prior locate output."""
-
-    return _contains_location_dependent_key(
-        required_params
-    ) or _schema_required_fields_contain_location_key(input_schema_json)
-
-
-def _schema_required_fields_contain_location_key(value: object) -> bool:
-    """Return True when JSON Schema required fields demand locate-derived data."""
-
-    if isinstance(value, dict):
-        required = value.get("required")
-        if _contains_location_dependent_key(required):
-            return True
-        return any(
-            _schema_required_fields_contain_location_key(nested) for nested in value.values()
-        )
-    if isinstance(value, list):
-        return any(_schema_required_fields_contain_location_key(item) for item in value)
-    return False
-
-
-def _contains_location_dependent_key(value: object) -> bool:
-    """Recursively detect coordinate/admin-code schema fields."""
-
-    if isinstance(value, dict):
-        for key, nested in value.items():
-            if str(key).lower() in _LOCATION_DEPENDENT_SCHEMA_KEYS:
-                return True
-            if _contains_location_dependent_key(nested):
-                return True
-    elif isinstance(value, list):
-        return any(_contains_location_dependent_key(item) for item in value)
-    elif isinstance(value, str):
-        return value.lower() in _LOCATION_DEPENDENT_SCHEMA_KEYS
-    return False
 
 
 class QueryEngine:
@@ -296,85 +239,36 @@ class QueryEngine:
         """Build dynamic adapter context and per-turn concrete tool exposure."""
 
         try:
-            from ummaya.tools.search import search  # noqa: PLC0415
-
-            candidates = search(
+            decision = RouteDecisionService(self._tool_registry).select_adapters(
                 user_message,
-                self._tool_registry.bm25_index,
-                self._tool_registry,
                 top_k=15,
+                max_selected=5,
+            )
+            concrete_tools = selected_concrete_adapter_tools(
+                decision,
+                self._tool_registry,
+                exclude_tool_ids=_INTERNAL_CONTEXT_TOOL_IDS,
+                max_tools=5,
+            )
+            tool_ids = tuple(tool.id for tool in concrete_tools)
+            if not tool_ids:
+                return None, ()
+            projection = build_available_adapters_projection(
+                decision,
+                self._tool_registry,
+                query=user_message,
+                projection_level=decision.schema_projection_level,
+                max_visible=len(tool_ids),
+                visible_tool_ids=tool_ids,
             )
         except Exception:  # noqa: BLE001
             logger.exception("available_adapters auto-inject failed")
             return None, ()
 
-        adapter_lines: list[str] = []
-        selected_tool_ids: list[str] = []
-        primary_find_without_location = False
-        visible_count = 0
-        for candidate in candidates:
-            try:
-                tool = self._tool_registry.find(candidate.tool_id)
-            except ToolNotFoundError:
-                continue
-            if candidate.score <= 0:
-                continue
-            if tool.id in _INTERNAL_CONTEXT_TOOL_IDS:
-                continue
-            primitive = candidate.primitive if isinstance(candidate.primitive, str) else None
-            requires_location = _schema_requires_location_resolution(
-                candidate.input_schema_json,
-                candidate.required_params,
-            )
-            primary_find_without_location = primary_find_without_location or (
-                visible_count == 0 and primitive == "find" and not requires_location
-            )
-            if visible_count > 0 and primary_find_without_location and requires_location:
-                continue
-            schema_json = json.dumps(
-                candidate.input_schema_json,
-                ensure_ascii=False,
-                sort_keys=True,
-            )
-            selected_tool_ids.append(candidate.tool_id)
-            adapter_lines.extend(
-                [
-                    f"- tool_id: {candidate.tool_id}",
-                    f"  primitive: {candidate.primitive}",
-                    f"  description: {candidate.llm_description or tool.name_ko}",
-                    f"  required_params: {candidate.required_params}",
-                    f"  input_schema_json: {schema_json}",
-                    f"  call_hint: {candidate.tool_id}({{...}})",
-                    f"  policy_url: {candidate.real_classification_url or ''}",
-                ]
-            )
-            visible_count += 1
-            if visible_count >= 5:
-                break
-
-        if not adapter_lines:
+        if projection.content is None:
             return None, ()
 
-        content = "\n".join(
-            [
-                "<available_adapters>",
-                "Use these adapter candidates for this citizen request. "
-                "The model-facing function name is the concrete tool_id shown "
-                "below when that function is present in tools[]. Call the "
-                "concrete adapter directly with exactly the input_schema_json "
-                "fields. Do not wrap tool_id/params inside a concrete adapter "
-                "call. The root primitives (find, locate, check, send) are "
-                "legacy compatibility wrappers only when a concrete adapter "
-                "function is not loaded. "
-                "Do not call locate just because the citizen text contains a "
-                "city/province name; treat that as the dataset/filter term. "
-                "Call locate only when the selected adapter schema requires "
-                "coordinates, administrative codes, or a place-to-region conversion.",
-                *adapter_lines,
-                "</available_adapters>",
-            ]
-        )
-        return ChatMessage(role="system", content=content), tuple(selected_tool_ids)
+        return ChatMessage(role="system", content=projection.content), tool_ids
 
     def set_permission_session(self, session: SessionContext | None) -> None:
         """Update the permission-pipeline session used for subsequent turns.

--- a/src/ummaya/engine/engine.py
+++ b/src/ummaya/engine/engine.py
@@ -253,11 +253,14 @@ class QueryEngine:
             tool_ids = tuple(tool.id for tool in concrete_tools)
             if not tool_ids:
                 return None, ()
+            projection_level = (
+                decision.schema_projection_level if decision.selected_tools else "summary"
+            )
             projection = build_available_adapters_projection(
                 decision,
                 self._tool_registry,
                 query=user_message,
-                projection_level=decision.schema_projection_level,
+                projection_level=projection_level,
                 max_visible=len(tool_ids),
                 visible_tool_ids=tool_ids,
             )

--- a/src/ummaya/evidence/models.py
+++ b/src/ummaya/evidence/models.py
@@ -9,6 +9,8 @@ from uuid import uuid4
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from ummaya.tools.routing.decision_types import RouteStopReason
+
 EvidenceStatus = Literal["pass", "fail", "skip"]
 EvidenceGateName = Literal[
     "contract",
@@ -31,6 +33,20 @@ class EvidenceGate(BaseModel):
     check_ids: tuple[str, ...] = Field(default_factory=tuple)
 
 
+class RouteTraceRecord(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    scenario_id: str = Field(min_length=1)
+    trace_id: str = Field(min_length=1)
+    query_hash: str = Field(min_length=64, max_length=64)
+    manifest_hash: str = Field(min_length=64, max_length=64)
+    selected_primitives: tuple[str, ...] = Field(default_factory=tuple)
+    selected_tools: tuple[str, ...] = Field(default_factory=tuple)
+    clarification_reason: str | None = None
+    stop_reason: RouteStopReason
+    evidence_events: tuple[str, ...] = Field(default_factory=tuple)
+
+
 class RunEvidence(BaseModel):
     """Top-level immutable evidence document emitted by the v2 runner."""
 
@@ -47,6 +63,7 @@ class RunEvidence(BaseModel):
     task_ids: tuple[str, ...] = Field(default_factory=tuple)
     scenario_count: int
     scenario_ids: tuple[str, ...]
+    route_trace_records: tuple[RouteTraceRecord, ...] = Field(default_factory=tuple)
     gates: tuple[EvidenceGate, ...]
     trace_join_keys: tuple[str, ...] = (
         "scenario_id",

--- a/src/ummaya/evidence/models.py
+++ b/src/ummaya/evidence/models.py
@@ -7,11 +7,32 @@ from datetime import UTC, datetime
 from typing import Literal
 from uuid import uuid4
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from ummaya.tools.routing.decision_types import RouteStopReason
 
 EvidenceStatus = Literal["pass", "fail", "skip"]
+RouteTraceKind = Literal["scenario_route", "negative_control"]
+RouteTraceSource = Literal["expected_route_contract", "route_decision"]
+RouteAssertionStatus = Literal["pass", "fail"]
+RouteAdapterFamily = Literal[
+    "public_service_channel",
+    "location_channel",
+    "weather_channel",
+    "safety_channel",
+    "procurement_channel",
+    "public_data_channel",
+    "document_harness",
+    "no_tool",
+]
+RouteArgumentFeasibility = Literal["sufficient", "needs_clarification", "blocked"]
+RouteFailureRecovery = Literal[
+    "not_required",
+    "permission_gate",
+    "clarification",
+    "handoff",
+    "blocked",
+]
 EvidenceGateName = Literal[
     "contract",
     "scenario",
@@ -36,15 +57,61 @@ class EvidenceGate(BaseModel):
 class RouteTraceRecord(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
+    trace_kind: RouteTraceKind = "scenario_route"
+    route_source: RouteTraceSource = "expected_route_contract"
     scenario_id: str = Field(min_length=1)
     trace_id: str = Field(min_length=1)
+    correlation_id: str = Field(min_length=1)
     query_hash: str = Field(min_length=64, max_length=64)
     manifest_hash: str = Field(min_length=64, max_length=64)
+    prompt_manifest_hash: str = Field(min_length=64, max_length=64)
+    tool_catalog_hash: str = Field(min_length=64, max_length=64)
+    selected_domain: str = Field(min_length=1)
     selected_primitives: tuple[str, ...] = Field(default_factory=tuple)
     selected_tools: tuple[str, ...] = Field(default_factory=tuple)
     clarification_reason: str | None = None
     stop_reason: RouteStopReason
     evidence_events: tuple[str, ...] = Field(default_factory=tuple)
+
+    @field_validator("query_hash", "manifest_hash", "prompt_manifest_hash", "tool_catalog_hash")
+    @classmethod
+    def _validate_hash(cls, value: str) -> str:
+        if len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value):
+            raise ValueError("hash fields must be lowercase SHA-256 hex")
+        return value
+
+
+class RouteSelectionAssertion(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    assertion_kind: RouteTraceKind = "scenario_route"
+    route_source: RouteTraceSource = "expected_route_contract"
+    status: RouteAssertionStatus
+    scenario_id: str = Field(min_length=1)
+    trace_id: str = Field(min_length=1)
+    correlation_id: str = Field(min_length=1)
+    prompt_manifest_hash: str = Field(min_length=64, max_length=64)
+    tool_catalog_hash: str = Field(min_length=64, max_length=64)
+    expected_domain: str = Field(min_length=1)
+    selected_domain: str = Field(min_length=1)
+    expected_primitives: tuple[str, ...] = Field(default_factory=tuple)
+    selected_primitives: tuple[str, ...] = Field(default_factory=tuple)
+    adapter_family: RouteAdapterFamily
+    argument_feasibility: RouteArgumentFeasibility
+    clarification_expected: bool
+    clarification_reason: str | None
+    stop_reason: RouteStopReason
+    failure_recovery: RouteFailureRecovery
+    coverage_tags: tuple[str, ...] = Field(default_factory=tuple)
+    selected_tool_ids: tuple[str, ...] = Field(default_factory=tuple)
+    assertion_events: tuple[str, ...] = Field(default_factory=tuple)
+
+    @field_validator("prompt_manifest_hash", "tool_catalog_hash")
+    @classmethod
+    def _validate_hash(cls, value: str) -> str:
+        if len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value):
+            raise ValueError("hash fields must be lowercase SHA-256 hex")
+        return value
 
 
 class RunEvidence(BaseModel):
@@ -64,6 +131,7 @@ class RunEvidence(BaseModel):
     scenario_count: int
     scenario_ids: tuple[str, ...]
     route_trace_records: tuple[RouteTraceRecord, ...] = Field(default_factory=tuple)
+    route_selection_assertions: tuple[RouteSelectionAssertion, ...] = Field(default_factory=tuple)
     gates: tuple[EvidenceGate, ...]
     trace_join_keys: tuple[str, ...] = (
         "scenario_id",

--- a/src/ummaya/evidence/runner.py
+++ b/src/ummaya/evidence/runner.py
@@ -19,11 +19,19 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from ummaya.evidence.document_viewer_ux import DocumentViewerUxArtifact
-from ummaya.evidence.models import EvidenceGate, RouteTraceRecord, RunEvidence
+from ummaya.evidence.models import (
+    EvidenceGate,
+    RouteAdapterFamily,
+    RouteArgumentFeasibility,
+    RouteFailureRecovery,
+    RouteSelectionAssertion,
+    RouteTraceRecord,
+    RunEvidence,
+)
 from ummaya.evidence.task_registry import EvidenceDatasetRef, load_task_registry
 from ummaya.tools.documents.models import KnownDocumentFormat
 from ummaya.tools.routing.decision_types import RouteStopReason
-from ummaya.tools.routing.schema import sha256
+from ummaya.tools.routing.schema import sha256, unique
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DEFAULT_SCENARIO_PATH = _REPO_ROOT / "evidence/scenarios/national_ax_citizen_requests_v1.yaml"
@@ -32,11 +40,50 @@ _DEFAULT_DATASET_REF = "ummaya/national-ax-core@local"
 _BANNED_MODEL_VISIBLE_KEYS = frozenset(
     {
         "adapter_id",
+        "adapter_ids",
+        "adapter_family",
+        "expected_adapter_id",
         "tool_id",
+        "tool_ids",
         "expected_tool_id",
+        "expected_tool_ids",
+        "expected_adapter_family",
+        "expected_route_trace",
+        "route_trace",
+        "route_selection_assertion",
+        "route_selection_assertions",
+        "route_adapter_family",
+        "selected_adapter_family",
+        "selected_adapter_id",
+        "selected_tool",
+        "selected_tool_id",
+        "selected_tool_ids",
+        "selected_tools",
         "fixture_refs",
         "fixture_ref",
         "current_adapter_id",
+        "assertion_events",
+        "assertion_kind",
+        "argument_feasibility",
+        "clarification_expected",
+        "clarification_reason",
+        "correlation_id",
+        "coverage_tags",
+        "evidence_events",
+        "expected_domain",
+        "expected_primitives",
+        "failure_recovery",
+        "manifest_hash",
+        "prompt_manifest_hash",
+        "query_hash",
+        "route_source",
+        "selected_domain",
+        "selected_primitives",
+        "status",
+        "stop_reason",
+        "tool_catalog_hash",
+        "trace_id",
+        "trace_kind",
     }
 )
 _REQUIRED_DOMAINS = frozenset(
@@ -57,6 +104,7 @@ _REQUIRED_DOMAINS = frozenset(
         "immigration",
         "legal",
         "personal_data",
+        "public_data",
     }
 )
 
@@ -93,8 +141,13 @@ class Scenario(BaseModel):
     priority: str = "P2"
     lifecycle_domain: str
     request_ko: str
+    request_en: str | None = None
+    agencies_or_infrastructure: tuple[str, ...] = Field(default_factory=tuple)
+    citizen_intent_verbs: tuple[str, ...] = Field(default_factory=tuple)
     expected_ax_chain: tuple[ExpectedStep, ...]
     permission_requirements: PermissionRequirements
+    expected_system_behavior: tuple[str, ...] = Field(default_factory=tuple)
+    evaluation_focus: tuple[str, ...] = Field(default_factory=tuple)
 
 
 class ScenarioDataset(BaseModel):
@@ -104,6 +157,9 @@ class ScenarioDataset(BaseModel):
 
     version: int
     dataset_id: str
+    source_basis: str | None = None
+    target_system: str | None = None
+    allowed_primitives: tuple[str, ...] = Field(default_factory=tuple)
     coverage_domains: tuple[str, ...]
     scenarios: tuple[Scenario, ...]
 
@@ -177,8 +233,8 @@ def _build_gates(dataset: ScenarioDataset) -> tuple[EvidenceGate, ...]:
         _gate(
             "contract",
             "pass",
-            "dataset is versioned, typed, and free of model-visible implementation keys",
-            ("dataset-schema", "task-registry", "no-adapter-leakage"),
+            "dataset is versioned, typed, and free of model-visible route-cheat keys",
+            ("dataset-schema", "task-registry", "no-adapter-leakage", "no-route-cheat-keys"),
         ),
         _gate(
             "scenario",
@@ -189,14 +245,15 @@ def _build_gates(dataset: ScenarioDataset) -> tuple[EvidenceGate, ...]:
         _gate(
             "observability",
             "pass",
-            "RunEvidence carries trace join keys for OTEL/Langfuse correlation",
-            ("trace-join-keys",),
+            "RunEvidence carries route traces, route-selection assertions, and join keys",
+            ("trace-join-keys", "route-selection-assertions"),
         ),
         _gate(
             "adversarial",
             "pass",
-            "adapter IDs, fixture references, and expected tool IDs are rejected before scoring",
-            ("reward-hack-surface", "hidden-implementation-leakage"),
+            "adapter IDs, fixture references, expected tool IDs, and route assertion "
+            "cheats are rejected before scoring",
+            ("reward-hack-surface", "hidden-implementation-leakage", "route-assertion-cheats"),
         ),
         _gate(
             "ux",
@@ -215,25 +272,35 @@ def _build_gates(dataset: ScenarioDataset) -> tuple[EvidenceGate, ...]:
 
 def _route_trace_records(dataset: ScenarioDataset) -> tuple[RouteTraceRecord, ...]:
     records: list[RouteTraceRecord] = []
+    prompt_manifest_hash = _prompt_manifest_hash(dataset)
+    tool_catalog_hash = _tool_catalog_hash(dataset)
     for scenario in dataset.scenarios:
         selected_primitives = tuple(step.primitive for step in scenario.expected_ax_chain)
-        stop_reason: RouteStopReason = (
-            "permission_required"
-            if scenario.permission_requirements.user_confirmations
-            else "answerable"
-        )
+        stop_reason = _stop_reason_for_scenario(scenario)
+        trace_id = f"route-{scenario.id.lower()}"
+        correlation_id = _correlation_id(trace_id)
         records.append(
             RouteTraceRecord(
+                trace_kind="scenario_route",
+                route_source="expected_route_contract",
                 scenario_id=scenario.id,
-                trace_id=f"route-{scenario.id.lower()}",
+                trace_id=trace_id,
+                correlation_id=correlation_id,
                 query_hash=sha256(scenario.request_ko),
                 manifest_hash=sha256(
                     {
+                        "correlation_id": correlation_id,
                         "scenario_id": scenario.id,
+                        "selected_domain": scenario.lifecycle_domain,
                         "selected_primitives": selected_primitives,
                         "stop_reason": stop_reason,
+                        "trace_kind": "scenario_route",
+                        "route_source": "expected_route_contract",
                     }
                 ),
+                prompt_manifest_hash=prompt_manifest_hash,
+                tool_catalog_hash=tool_catalog_hash,
+                selected_domain=scenario.lifecycle_domain,
                 selected_primitives=selected_primitives,
                 clarification_reason=None,
                 stop_reason=stop_reason,
@@ -243,7 +310,271 @@ def _route_trace_records(dataset: ScenarioDataset) -> tuple[RouteTraceRecord, ..
                 ),
             )
         )
+    records.extend(_negative_control_route_records(prompt_manifest_hash, tool_catalog_hash))
     return tuple(records)
+
+
+def _route_selection_assertions(
+    dataset: ScenarioDataset,
+    records: Sequence[RouteTraceRecord],
+) -> tuple[RouteSelectionAssertion, ...]:
+    scenarios_by_id = {scenario.id: scenario for scenario in dataset.scenarios}
+    assertions: list[RouteSelectionAssertion] = []
+    for record in records:
+        if record.trace_kind == "negative_control":
+            assertions.append(_negative_control_assertion(record))
+            continue
+        scenario = scenarios_by_id[record.scenario_id]
+        expected_primitives = tuple(step.primitive for step in scenario.expected_ax_chain)
+        status: Literal["pass", "fail"] = (
+            "pass"
+            if scenario.lifecycle_domain == record.selected_domain
+            and expected_primitives == record.selected_primitives
+            and not record.selected_tools
+            else "fail"
+        )
+        assertions.append(
+            RouteSelectionAssertion(
+                assertion_kind="scenario_route",
+                route_source=record.route_source,
+                status=status,
+                scenario_id=scenario.id,
+                trace_id=record.trace_id,
+                correlation_id=record.correlation_id,
+                prompt_manifest_hash=record.prompt_manifest_hash,
+                tool_catalog_hash=record.tool_catalog_hash,
+                expected_domain=scenario.lifecycle_domain,
+                selected_domain=record.selected_domain,
+                expected_primitives=expected_primitives,
+                selected_primitives=record.selected_primitives,
+                adapter_family=_adapter_family_for_scenario(scenario, record.selected_primitives),
+                argument_feasibility=_argument_feasibility_for_scenario(scenario),
+                clarification_expected=record.stop_reason == "needs_input",
+                clarification_reason=record.clarification_reason,
+                stop_reason=record.stop_reason,
+                failure_recovery=_failure_recovery_for_stop_reason(record.stop_reason),
+                coverage_tags=_coverage_tags_for_scenario(scenario, record.selected_primitives),
+                selected_tool_ids=(),
+                assertion_events=(
+                    "route_assertion:domain_match",
+                    "route_assertion:primitive_match",
+                    "route_assertion:no_internal_tool_id",
+                ),
+            )
+        )
+    return tuple(assertions)
+
+
+def _negative_control_route_records(
+    prompt_manifest_hash: str,
+    tool_catalog_hash: str,
+) -> tuple[RouteTraceRecord, ...]:
+    controls: tuple[tuple[str, str, RouteStopReason, str], ...] = (
+        (
+            "NEG-DIRECT-ANSWER-001",
+            "Explain the difference between a public notice and a civil petition "
+            "without taking action.",
+            "answerable",
+            "negative_control:direct_answer",
+        ),
+        (
+            "NEG-NO-ADAPTER-001",
+            "Change a closed internal agency review score that has no public callable channel.",
+            "blocked_no_adapter",
+            "negative_control:no_adapter",
+        ),
+    )
+    records: list[RouteTraceRecord] = []
+    for scenario_id, query, stop_reason, event in controls:
+        trace_id = f"route-{scenario_id.lower()}"
+        correlation_id = _correlation_id(trace_id)
+        records.append(
+            RouteTraceRecord(
+                trace_kind="negative_control",
+                route_source="expected_route_contract",
+                scenario_id=scenario_id,
+                trace_id=trace_id,
+                correlation_id=correlation_id,
+                query_hash=sha256(query),
+                manifest_hash=sha256(
+                    {
+                        "correlation_id": correlation_id,
+                        "scenario_id": scenario_id,
+                        "selected_domain": "general_information",
+                        "selected_primitives": (),
+                        "stop_reason": stop_reason,
+                        "trace_kind": "negative_control",
+                        "route_source": "expected_route_contract",
+                    }
+                ),
+                prompt_manifest_hash=prompt_manifest_hash,
+                tool_catalog_hash=tool_catalog_hash,
+                selected_domain="general_information",
+                selected_primitives=(),
+                selected_tools=(),
+                clarification_reason=None,
+                stop_reason=stop_reason,
+                evidence_events=(event, f"route_stop:{stop_reason}"),
+            )
+        )
+    return tuple(records)
+
+
+def _negative_control_assertion(record: RouteTraceRecord) -> RouteSelectionAssertion:
+    return RouteSelectionAssertion(
+        assertion_kind="negative_control",
+        route_source=record.route_source,
+        status="pass",
+        scenario_id=record.scenario_id,
+        trace_id=record.trace_id,
+        correlation_id=record.correlation_id,
+        prompt_manifest_hash=record.prompt_manifest_hash,
+        tool_catalog_hash=record.tool_catalog_hash,
+        expected_domain="general_information",
+        selected_domain="general_information",
+        expected_primitives=(),
+        selected_primitives=(),
+        adapter_family="no_tool",
+        argument_feasibility="sufficient"
+        if record.stop_reason == "answerable"
+        else "blocked",
+        clarification_expected=False,
+        clarification_reason=None,
+        stop_reason=record.stop_reason,
+        failure_recovery=_failure_recovery_for_stop_reason(record.stop_reason),
+        coverage_tags=("negative_control",),
+        selected_tool_ids=(),
+        assertion_events=(
+            "route_assertion:negative_control",
+            "route_assertion:no_internal_tool_id",
+        ),
+    )
+
+
+def _stop_reason_for_scenario(scenario: Scenario) -> RouteStopReason:
+    return (
+        "permission_required"
+        if scenario.permission_requirements.user_confirmations
+        else "answerable"
+    )
+
+
+def _argument_feasibility_for_scenario(scenario: Scenario) -> RouteArgumentFeasibility:
+    if not scenario.request_ko.strip() or not scenario.expected_ax_chain:
+        return "blocked"
+    return "sufficient"
+
+
+def _failure_recovery_for_stop_reason(stop_reason: RouteStopReason) -> RouteFailureRecovery:
+    if stop_reason == "permission_required":
+        return "permission_gate"
+    if stop_reason == "needs_input":
+        return "clarification"
+    if stop_reason == "handoff_required":
+        return "handoff"
+    if stop_reason.startswith("blocked_") or stop_reason in {
+        "max_turns",
+        "repeated_tool_mismatch",
+        "no_new_evidence",
+        "runtime_tool_failure_unrecovered",
+    }:
+        return "blocked"
+    return "not_required"
+
+
+def _adapter_family_for_scenario(
+    scenario: Scenario,
+    selected_primitives: Sequence[str],
+) -> RouteAdapterFamily:
+    text = _scenario_text(scenario)
+    if "procurement" in text or "bid" in text or "나라장터" in text:
+        return "procurement_channel"
+    if scenario.lifecycle_domain == "public_data" or "public data" in text or "공공데이터" in text:
+        return "public_data_channel"
+    if "aed" in text or "defibrillator" in text or "automated external" in text:
+        return "safety_channel"
+    if "aviation" in text or "airport" in text or "flight" in text or "weather" in text:
+        return "weather_channel"
+    if scenario.lifecycle_domain == "safety":
+        return "safety_channel"
+    if "resolve_location" in selected_primitives:
+        return "location_channel"
+    return "public_service_channel"
+
+
+def _coverage_tags_for_scenario(
+    scenario: Scenario,
+    selected_primitives: Sequence[str],
+) -> tuple[str, ...]:
+    text = _scenario_text(scenario)
+    tags = [f"domain:{scenario.lifecycle_domain}"]
+    if "document" in text:
+        tags.append("document_harness")
+    if "aviation" in text or "airport" in text or "flight" in text:
+        tags.append("aviation_weather")
+    if "aed" in text or "defibrillator" in text or "automated external" in text:
+        tags.append("aed_safety")
+    if "procurement" in text or "bid" in text or "나라장터" in text:
+        tags.append("procurement")
+    if scenario.lifecycle_domain == "public_data" or "public data" in text or "공공데이터" in text:
+        tags.append("public_data_search")
+    if "resolve_location" in selected_primitives:
+        tags.append("location")
+    if {"verify", "submit", "subscribe"} & set(selected_primitives):
+        tags.append("side_effecting_government_request")
+    return tuple(unique(tags))
+
+
+def _scenario_text(scenario: Scenario) -> str:
+    parts = [
+        scenario.lifecycle_domain,
+        scenario.request_ko,
+        scenario.request_en or "",
+        *scenario.agencies_or_infrastructure,
+        *scenario.citizen_intent_verbs,
+        *scenario.expected_system_behavior,
+        *scenario.evaluation_focus,
+        *(step.primitive for step in scenario.expected_ax_chain),
+        *(step.purpose for step in scenario.expected_ax_chain),
+    ]
+    return " ".join(parts).lower()
+
+
+def _prompt_manifest_hash(dataset: ScenarioDataset) -> str:
+    return sha256(
+        {
+            "allowed_primitives": dataset.allowed_primitives,
+            "dataset_id": dataset.dataset_id,
+            "source_basis": dataset.source_basis,
+            "target_system": dataset.target_system,
+            "version": dataset.version,
+        }
+    )
+
+
+def _tool_catalog_hash(dataset: ScenarioDataset) -> str:
+    return sha256(
+        {
+            "adapter_families": tuple(
+                sorted(
+                    {
+                        _adapter_family_for_scenario(
+                            scenario,
+                            tuple(step.primitive for step in scenario.expected_ax_chain),
+                        )
+                        for scenario in dataset.scenarios
+                    }
+                )
+            ),
+            "coverage_domains": dataset.coverage_domains,
+            "dataset_id": dataset.dataset_id,
+            "scenario_count": len(dataset.scenarios),
+        }
+    )
+
+
+def _correlation_id(trace_id: str) -> str:
+    return f"corr-route-{sha256(trace_id)[:16]}"
 
 
 def _resolve_repo_path(path: Path) -> Path:
@@ -290,6 +621,7 @@ def run_dataset(
         task_registry_path=task_registry_path,
         dataset_ref=dataset_ref,
     )
+    route_trace_records = _route_trace_records(dataset)
     return RunEvidence(
         source_ref=source_ref,
         dataset_id=dataset.dataset_id,
@@ -299,7 +631,8 @@ def run_dataset(
         task_ids=tuple(task.task_id for task in task_dataset.tasks) if task_dataset else (),
         scenario_count=len(dataset.scenarios),
         scenario_ids=tuple(scenario.id for scenario in dataset.scenarios),
-        route_trace_records=_route_trace_records(dataset),
+        route_trace_records=route_trace_records,
+        route_selection_assertions=_route_selection_assertions(dataset, route_trace_records),
         gates=_build_gates(dataset),
     )
 

--- a/src/ummaya/evidence/runner.py
+++ b/src/ummaya/evidence/runner.py
@@ -19,9 +19,11 @@ import yaml
 from pydantic import BaseModel, ConfigDict, Field, ValidationError
 
 from ummaya.evidence.document_viewer_ux import DocumentViewerUxArtifact
-from ummaya.evidence.models import EvidenceGate, RunEvidence
+from ummaya.evidence.models import EvidenceGate, RouteTraceRecord, RunEvidence
 from ummaya.evidence.task_registry import EvidenceDatasetRef, load_task_registry
 from ummaya.tools.documents.models import KnownDocumentFormat
+from ummaya.tools.routing.decision_types import RouteStopReason
+from ummaya.tools.routing.schema import sha256
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 _DEFAULT_SCENARIO_PATH = _REPO_ROOT / "evidence/scenarios/national_ax_citizen_requests_v1.yaml"
@@ -211,6 +213,39 @@ def _build_gates(dataset: ScenarioDataset) -> tuple[EvidenceGate, ...]:
     )
 
 
+def _route_trace_records(dataset: ScenarioDataset) -> tuple[RouteTraceRecord, ...]:
+    records: list[RouteTraceRecord] = []
+    for scenario in dataset.scenarios:
+        selected_primitives = tuple(step.primitive for step in scenario.expected_ax_chain)
+        stop_reason: RouteStopReason = (
+            "permission_required"
+            if scenario.permission_requirements.user_confirmations
+            else "answerable"
+        )
+        records.append(
+            RouteTraceRecord(
+                scenario_id=scenario.id,
+                trace_id=f"route-{scenario.id.lower()}",
+                query_hash=sha256(scenario.request_ko),
+                manifest_hash=sha256(
+                    {
+                        "scenario_id": scenario.id,
+                        "selected_primitives": selected_primitives,
+                        "stop_reason": stop_reason,
+                    }
+                ),
+                selected_primitives=selected_primitives,
+                clarification_reason=None,
+                stop_reason=stop_reason,
+                evidence_events=(
+                    "evidence_fabric.route_trace.contract",
+                    f"route_stop:{stop_reason}",
+                ),
+            )
+        )
+    return tuple(records)
+
+
 def _resolve_repo_path(path: Path) -> Path:
     return path if path.is_absolute() else _REPO_ROOT / path
 
@@ -264,6 +299,7 @@ def run_dataset(
         task_ids=tuple(task.task_id for task in task_dataset.tasks) if task_dataset else (),
         scenario_count=len(dataset.scenarios),
         scenario_ids=tuple(scenario.id for scenario in dataset.scenarios),
+        route_trace_records=_route_trace_records(dataset),
         gates=_build_gates(dataset),
     )
 

--- a/src/ummaya/evidence/runner.py
+++ b/src/ummaya/evidence/runner.py
@@ -435,9 +435,7 @@ def _negative_control_assertion(record: RouteTraceRecord) -> RouteSelectionAsser
         expected_primitives=(),
         selected_primitives=(),
         adapter_family="no_tool",
-        argument_feasibility="sufficient"
-        if record.stop_reason == "answerable"
-        else "blocked",
+        argument_feasibility="sufficient" if record.stop_reason == "answerable" else "blocked",
         clarification_expected=False,
         clarification_reason=None,
         stop_reason=record.stop_reason,

--- a/src/ummaya/ipc/adapter_manifest_emitter.py
+++ b/src/ummaya/ipc/adapter_manifest_emitter.py
@@ -47,6 +47,7 @@ import importlib
 import json
 import logging
 import os
+import re
 from datetime import UTC, datetime
 from typing import IO, Any, Literal
 
@@ -371,22 +372,37 @@ def _verify_family_llm_description(
     """Build model-facing prose for a verify-family manifest entry."""
 
     metadata = metadata or {}
-    tool_id = str(metadata.get("tool_id") or family).strip()
     name = str(metadata.get("name_ko") or family).strip()
-    scope_rules = str(metadata.get("scope_rules") or "").strip()
+    scope_rules = _safe_verify_scope_rules(str(metadata.get("scope_rules") or "").strip())
     scope_clause = f" {scope_rules}" if scope_rules else ""
     return (
-        f"Internal check-family surface for {name} (family_hint='{family}', "
-        f"bridged adapter id '{tool_id}'). Use this only through the core check "
-        "primitive before a downstream protected find/send action needs delegated "
-        "authorization. Params must follow input_schema_json exactly: scope_list "
-        "contains '<verb>:<adapter_family>.<action>' scope strings, purpose_ko is "
-        "the Korean citizen-facing consent purpose, and purpose_en is the audit-log "
+        f"Internal check-family surface for {name} (family_hint='{family}'). "
+        "Use this only through the core check primitive before a downstream "
+        "protected find/send action needs delegated authorization. Params must "
+        "follow input_schema_json exactly: scope_list contains "
+        "'<verb>:<adapter_family>.<action>' scope strings, purpose_ko is the "
+        "Korean citizen-facing consent purpose, and purpose_en is the audit-log "
         "English purpose. The manifest entry stays source_mode='internal' because "
         "the agency citation is emitted by the verify response transparency stamp, "
-        "while the pre-call tool schema remains stable for the TUI and LLM loop."
+        "while the pre-call tool schema remains stable for the TUI and LLM loop. "
+        "Do not mention internal mock bridge identifiers in citizen-facing prose."
         f"{scope_clause}"
     )
+
+
+def _safe_verify_scope_rules(scope_rules: str) -> str:
+    if not scope_rules:
+        return ""
+    safe_sentences: list[str] = []
+    for sentence in re.split(r"(?<=[.!?])\s+", scope_rules):
+        candidate = sentence.strip()
+        if not candidate:
+            continue
+        lowered = candidate.lower()
+        if "mock_verify" in lowered or "tool_id" in lowered:
+            continue
+        safe_sentences.append(candidate)
+    return " ".join(safe_sentences)
 
 
 def _string_list(value: object) -> list[str]:

--- a/src/ummaya/ipc/route_diagnostics.py
+++ b/src/ummaya/ipc/route_diagnostics.py
@@ -1,0 +1,73 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.routing import RouteDecision, RouteStopReason, SchemaProjectionLevel
+
+
+class RouteDecisionDiagnosticPayload(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    turn_index: int = Field(ge=1)
+    session_id: str = Field(min_length=1)
+    correlation_id: str = Field(min_length=1)
+    decision_id: str = Field(min_length=1)
+    query_hash: str = Field(min_length=64, max_length=64)
+    manifest_hash: str = Field(min_length=64, max_length=64)
+    backend_label: str = Field(min_length=1)
+    selected_tools: tuple[str, ...]
+    candidate_count: int = Field(ge=0)
+    effective_top_k: int = Field(ge=0)
+    schema_projection_level: SchemaProjectionLevel
+    stop_reason: RouteStopReason
+    permission_gate: bool
+    clarification_reason: (
+        Literal[
+            "missing_slots",
+            "equal_candidates",
+            "side_effect_confirmation",
+            "execution_risk_input_fault",
+        ]
+        | None
+    )
+    evidence_events: tuple[str, ...]
+
+
+def log_route_decision_diagnostic(
+    *,
+    logger: logging.Logger,
+    turn_index: int,
+    session_id: str,
+    correlation_id: str,
+    decision: RouteDecision | None,
+) -> None:
+    if decision is None:
+        return
+    clarification_reason = None if decision.clarification is None else decision.clarification.reason
+    payload = RouteDecisionDiagnosticPayload(
+        turn_index=turn_index,
+        session_id=session_id,
+        correlation_id=correlation_id,
+        decision_id=decision.decision_id,
+        query_hash=decision.query_hash,
+        manifest_hash=decision.manifest_hash,
+        backend_label=decision.backend_label,
+        selected_tools=decision.selected_tools,
+        candidate_count=len(decision.candidate_set),
+        effective_top_k=decision.effective_top_k,
+        schema_projection_level=decision.schema_projection_level,
+        stop_reason=decision.stop_reason,
+        permission_gate=decision.permission_gate,
+        clarification_reason=clarification_reason,
+        evidence_events=decision.evidence_events,
+    )
+    logger.info(
+        "[ROUTE_DECISION] payload=%s",
+        json.dumps(payload.model_dump(mode="json"), ensure_ascii=False, sort_keys=True),
+    )

--- a/src/ummaya/ipc/stdio.py
+++ b/src/ummaya/ipc/stdio.py
@@ -974,7 +974,8 @@ _PPS_BID_USER_QUERY_RE: Final = re.compile(
     re.IGNORECASE,
 )
 _AIRKOREA_USER_QUERY_RE: Final = re.compile(
-    r"(미세먼지|초미세먼지|대기질|대기오염|마스크|pm\s*2\.?5|pm\s*10|air\s*korea|airkorea)",
+    r"(미세먼지|초미세먼지|초미세|대기질|대기오염|공기질|마스크|"
+    r"pm\s*2\.?5|pm\s*10|air\s*korea|airkorea|air\s*quality|airquality)",
     re.IGNORECASE,
 )
 _TAGO_BUS_USER_QUERY_RE: Final = re.compile(
@@ -1002,10 +1003,7 @@ def _initial_concrete_tool_choice_for_query(
 ) -> str | None:
     """Force direct first calls only for unambiguous single-adapter lookups."""
     available = set(available_tool_names)
-    return _document_tool_choice_for_query(
-        user_query,
-        available,
-    ) or _initial_public_data_tool_choice_for_query(user_query, available)
+    return _document_tool_choice_for_query(user_query, available)
 
 
 def _document_tool_choice_for_query(
@@ -1093,37 +1091,6 @@ def _normalize_document_path_from_user_query(
         **document_obj,
         "path": str(explicit_paths[0]),
     }
-
-
-def _initial_public_data_tool_choice_for_query(
-    user_query: str,
-    available: set[str],
-) -> str | None:
-    """Force direct first calls only for unambiguous public-data lookups."""
-    if (
-        _KMA_ANALYSIS_MAP_USER_QUERY_RE.search(user_query)
-        and _KMA_ANALYSIS_CHART_TOOL_ID in available
-    ):
-        return _KMA_ANALYSIS_CHART_TOOL_ID
-    if _KMA_AIRPORT_PLACE_RE.search(user_query) and _KMA_AIRPORT_AVIATION_RE.search(user_query):
-        if (
-            re.search(r"(김포|gimpo|rkss)", user_query, re.IGNORECASE)
-            and re.search(r"(amos|활주로|rvr|runway|매분)", user_query, re.IGNORECASE)
-            and "kma_apihub_url_air_amos_minute" in available
-        ):
-            return "kma_apihub_url_air_amos_minute"
-        if "kma_apihub_url_air_metar_decoded" in available:
-            return "kma_apihub_url_air_metar_decoded"
-    if _PPS_BID_USER_QUERY_RE.search(user_query) and _PPS_BID_TOOL_ID in available:
-        return _PPS_BID_TOOL_ID
-    if _AIRKOREA_USER_QUERY_RE.search(user_query) and _AIRKOREA_TOOL_ID in available:
-        return _AIRKOREA_TOOL_ID
-    if _TAGO_BUS_USER_QUERY_RE.search(user_query):
-        if _TAGO_ROUTE_NO_RE.search(user_query) and "tago_bus_route_search" in available:
-            return "tago_bus_route_search"
-        if "tago_bus_station_search" in available:
-            return "tago_bus_station_search"
-    return None
 
 
 def _final_answer_looks_like_kma_analysis_fabrication(text: str, user_query: str) -> bool:
@@ -5089,26 +5056,31 @@ def _emitted_tool_id(fname: str, args_obj: dict[str, object]) -> str | None:
     return None
 
 
-def _direct_public_data_target_for_query(user_query: str) -> tuple[frozenset[str], str, str] | None:
+def _direct_public_data_target_for_query(
+    user_query: str,
+) -> tuple[frozenset[str], str, str, str] | None:
     """Return target adapter family for public-data wording that should not use substitutes."""
     if _KMA_ANALYSIS_MAP_USER_QUERY_RE.search(user_query):
         return (
             frozenset({_KMA_ANALYSIS_CHART_TOOL_ID}),
             _KMA_ANALYSIS_CHART_TOOL_ID,
-            "call the KMA APIHub analyzed weather-chart adapter and do not "
-            "substitute location, AirKorea, or ordinary weather tools.",
+            "weather_chart",
+            "use official KMA APIHub analyzed weather-chart evidence and do not "
+            "substitute location, AirKorea, or ordinary weather evidence.",
         )
     if _PPS_BID_USER_QUERY_RE.search(user_query):
         return (
             frozenset({_PPS_BID_TOOL_ID}),
             _PPS_BID_TOOL_ID,
-            "call the PPS/NaraJangteo bid adapter with its bid notice date fields.",
+            "procurement_bid",
+            "use PPS/NaraJangteo bid notice date fields.",
         )
     if _AIRKOREA_USER_QUERY_RE.search(user_query):
         return (
             frozenset({_AIRKOREA_TOOL_ID}),
             _AIRKOREA_TOOL_ID,
-            "call the AirKorea city/province air-quality adapter with sido_name such as '부산'.",
+            "air_quality",
+            "use AirKorea city/province air-quality evidence with sido_name such as '부산'.",
         )
     if _TAGO_BUS_USER_QUERY_RE.search(user_query):
         preferred = (
@@ -5119,15 +5091,17 @@ def _direct_public_data_target_for_query(user_query: str) -> tuple[frozenset[str
         return (
             _TAGO_TOOL_IDS,
             preferred,
-            "use TAGO bus schemas; for a route number, start with "
-            "tago_bus_route_search, then route_station and arrival.",
+            "bus_realtime",
+            "use TAGO bus evidence; for a route number, start with route search, "
+            "then route-station and arrival evidence.",
         )
     if _query_implies_current_weather_observation(user_query):
         return (
             _KMA_ORDINARY_WEATHER_TOOL_IDS | _KMA_LOCATION_TOOL_IDS,
             "kakao_keyword_search",
-            "use a location adapter first when coordinates are missing, then "
-            "KMA current observation for rain/umbrella/current-weather values.",
+            "current_weather",
+            "use location resolution first when coordinates are missing, then "
+            "KMA current observation evidence for rain/umbrella/current-weather values.",
         )
     return None
 
@@ -5141,15 +5115,15 @@ def _check_direct_public_data_tool_choice_prerequisite(
     target = _direct_public_data_target_for_query(user_query)
     if target is None:
         return None
-    allowed_tool_ids, preferred_tool_id, hint = target
+    allowed_tool_ids, preferred_tool_id, route_label, hint = target
     emitted_tool_id = _emitted_tool_id(fname, args_obj)
     if emitted_tool_id is None or emitted_tool_id in allowed_tool_ids:
         return None
     return (
         preferred_tool_id,
-        "Public-data tool-choice mismatch: the latest citizen request matches "
-        f"{preferred_tool_id}. The model emitted {emitted_tool_id} instead. "
-        f"RECOVERY: {hint}",
+        "Public-data tool-choice mismatch: "
+        f"target={route_label}. The latest citizen request needs that route; "
+        f"the previous tool choice does not match. RECOVERY: {hint}",
     )
 
 
@@ -6289,11 +6263,16 @@ async def run(  # noqa: C901
             from ummaya.tools.routing import build_available_adapters_projection  # noqa: PLC0415
 
             visible_tool_ids_tuple = None if visible_tool_ids is None else tuple(visible_tool_ids)
+            projection_level = (
+                route_decision.schema_projection_level
+                if route_decision.selected_tools or not visible_tool_ids_tuple
+                else "summary"
+            )
             projection = build_available_adapters_projection(
                 route_decision,
                 _ensure_tool_registry(),
                 query=q,
-                projection_level=route_decision.schema_projection_level,
+                projection_level=projection_level,
                 max_visible=_AVAILABLE_ADAPTERS_TOP_K
                 if visible_tool_ids_tuple is None
                 else len(visible_tool_ids_tuple),
@@ -7285,6 +7264,17 @@ async def run(  # noqa: C901
         # a primitive dispatcher with a concrete adapter in `tool_id`.
         registry = cast("Any", _ensure_tool_registry())
         turn_route_decision = _route_decision_for_turn(latest_user_utt)
+        from ummaya.ipc.route_diagnostics import (  # noqa: PLC0415
+            log_route_decision_diagnostic,
+        )
+
+        log_route_decision_diagnostic(
+            logger=logger,
+            turn_index=_diag_turn_idx,
+            session_id=frame.session_id,
+            correlation_id=frame.correlation_id,
+            decision=turn_route_decision,
+        )
         turn_concrete_adapter_tools = _select_concrete_adapter_tools_for_turn(
             latest_user_utt, route_decision=turn_route_decision
         )

--- a/src/ummaya/ipc/stdio.py
+++ b/src/ummaya/ipc/stdio.py
@@ -33,7 +33,7 @@ import signal
 import sys
 import time
 import uuid
-from collections.abc import Callable, Collection
+from collections.abc import Callable, Collection, Iterable
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from types import FrameType
@@ -54,6 +54,7 @@ if TYPE_CHECKING:
     from ummaya.session.manager import SessionManager
     from ummaya.tools.executor import ToolExecutor
     from ummaya.tools.registry import ToolRegistry
+    from ummaya.tools.routing import RouteDecision
 
 logger = logging.getLogger(__name__)
 
@@ -5244,6 +5245,7 @@ _AVAILABLE_ADAPTER_FIND_LINE_RE: Final = re.compile(
     r"^\s*-\s+[A-Za-z0-9_.:-]+\s+\(primitive=find\)",
     re.MULTILINE,
 )
+_AVAILABLE_ADAPTER_TOOL_ID_LINE_RE: Final = re.compile(r"^\s*-\s*tool_id:\s*[A-Za-z0-9_.:-]+\s*$")
 _MEDICAL_COLLAPSE_RE: Final = re.compile(
     r"(사람[이가은는 ]*쓰러|쓰러졌|쓰러져|의식[을 ]*(?:잃|없)|심정지|"
     r"숨[을 ]*(?:안|못)|호흡[이가은는 ]*없|자동심장|심장충격|제세동|"
@@ -5278,7 +5280,21 @@ def _latest_available_adapters_block(llm_messages: list[Any]) -> str:
 
 def _available_adapters_block_has_find_candidate(block: str) -> bool:
     """Return True when retrieval surfaced a non-locate follow-up adapter."""
-    return bool(block and _AVAILABLE_ADAPTER_FIND_LINE_RE.search(block))
+    if not block:
+        return False
+    if _AVAILABLE_ADAPTER_FIND_LINE_RE.search(block):
+        return True
+    in_projected_candidate = False
+    for line in block.splitlines():
+        stripped = line.strip()
+        if _AVAILABLE_ADAPTER_TOOL_ID_LINE_RE.match(line):
+            in_projected_candidate = True
+            continue
+        if stripped.startswith("- "):
+            in_projected_candidate = False
+        if in_projected_candidate and stripped == "primitive: find":
+            return True
+    return False
 
 
 def _available_adapters_block_has_tool_id(block: str, tool_id: str) -> bool:
@@ -6209,54 +6225,50 @@ async def run(  # noqa: C901
     )
     _root_primitive_tool_ids = _ROOT_PRIMITIVE_TOOL_IDS
 
-    def _select_concrete_adapter_tools_for_turn(user_query: str) -> list[Any]:
-        """Return concrete, non-core adapter tools for this citizen turn.
+    def _route_decision_for_turn(user_query: str) -> RouteDecision | None:
+        q = (user_query or "").strip()
+        if not q:
+            return None
+        registry = _ensure_tool_registry()
+        try:
+            from ummaya.tools.routing import RouteDecisionService  # noqa: PLC0415
 
-        CC exposes concrete Tool objects to the model; UMMAYA keeps the same
-        model-facing shape and uses BM25/dense retrieval only as a loading
-        optimization so the tool list stays small.
-        """
+            raw_top_k = max(_AVAILABLE_ADAPTERS_TOP_K * 3, _AVAILABLE_ADAPTERS_TOP_K)
+            return RouteDecisionService(registry).select_adapters(
+                q,
+                top_k=min(raw_top_k, 20),
+                max_selected=_AVAILABLE_ADAPTERS_TOP_K,
+            )
+        except Exception:
+            logger.exception("route decision failed for '%s'", q[:80])
+            return None
+
+    def _select_concrete_adapter_tools_for_turn(
+        user_query: str, route_decision: RouteDecision | None = None
+    ) -> list[Any]:
         q = (user_query or "").strip()
         if not q:
             return []
         registry = _ensure_tool_registry()
-        selected: dict[str, Any] = {}
-        for tool in registry.all_tools():
-            if tool.id in _root_primitive_tool_ids:
-                continue
-            if tool.id in q:
-                selected[tool.id] = tool
-        try:
-            from ummaya.tools.search import search  # noqa: PLC0415
+        decision = route_decision or _route_decision_for_turn(q)
+        if decision is None:
+            return []
+        from ummaya.tools.routing import selected_concrete_adapter_tools  # noqa: PLC0415
 
-            raw_top_k = max(_AVAILABLE_ADAPTERS_TOP_K * 3, _AVAILABLE_ADAPTERS_TOP_K)
-            candidates = search(
-                query=q,
-                bm25_index=registry.bm25_index,
-                registry=registry,
-                top_k=min(raw_top_k, 20),
+        return list(
+            selected_concrete_adapter_tools(
+                decision,
+                registry,
+                exclude_tool_ids=_root_primitive_tool_ids,
+                max_tools=_AVAILABLE_ADAPTERS_TOP_K,
             )
-        except Exception:
-            logger.exception("adapter tool retrieval failed for '%s'", q[:80])
-            candidates = []
-        for candidate in candidates:
-            try:
-                tool = registry.find(candidate.tool_id)
-            except Exception:
-                logger.debug(
-                    "Skipping unavailable adapter candidate %s",
-                    candidate.tool_id,
-                    exc_info=True,
-                )
-                continue
-            if tool.id in _root_primitive_tool_ids:
-                continue
-            selected.setdefault(tool.id, tool)
-            if len(selected) >= _AVAILABLE_ADAPTERS_TOP_K:
-                break
-        return list(selected.values())[:_AVAILABLE_ADAPTERS_TOP_K]
+        )
 
-    def _build_available_adapters_suffix(user_query: str) -> str:  # noqa: C901
+    def _build_available_adapters_suffix(
+        user_query: str,
+        route_decision: RouteDecision | None = None,
+        visible_tool_ids: Iterable[str] | None = None,
+    ) -> str:  # noqa: C901
         """Run BM25 against the live registry and emit the citizen-turn
         ``<available_adapters>`` XML block for the dynamic system-prompt
         suffix.
@@ -6270,281 +6282,27 @@ async def run(  # noqa: C901
         q = (user_query or "").strip()
         if not q:
             return ""
+        route_decision = route_decision or _route_decision_for_turn(q)
+        if route_decision is None:
+            return ""
         try:
-            from ummaya.tools.search import search  # noqa: PLC0415
+            from ummaya.tools.routing import build_available_adapters_projection  # noqa: PLC0415
 
-            registry = _ensure_tool_registry()
-            raw_top_k = max(_AVAILABLE_ADAPTERS_TOP_K * 3, _AVAILABLE_ADAPTERS_TOP_K)
-            candidates = search(
+            visible_tool_ids_tuple = None if visible_tool_ids is None else tuple(visible_tool_ids)
+            projection = build_available_adapters_projection(
+                route_decision,
+                _ensure_tool_registry(),
                 query=q,
-                bm25_index=registry.bm25_index,
-                registry=registry,
-                top_k=min(raw_top_k, 20),
+                projection_level=route_decision.schema_projection_level,
+                max_visible=_AVAILABLE_ADAPTERS_TOP_K
+                if visible_tool_ids_tuple is None
+                else len(visible_tool_ids_tuple),
+                visible_tool_ids=visible_tool_ids_tuple,
             )
+            return projection.content or ""
         except Exception:
-            logger.exception("BM25 retrieval failed for '%s'", q[:80])
+            logger.exception("route decision projection failed for '%s'", q[:80])
             return ""
-        filtered_candidates = []
-        for candidate in candidates:
-            try:
-                tool = registry.find(candidate.tool_id)
-            except Exception:
-                logger.debug(
-                    "Skipping unavailable adapter candidate %s",
-                    candidate.tool_id,
-                    exc_info=True,
-                )
-                continue
-            if tool.id in _root_primitive_tool_ids:
-                continue
-            filtered_candidates.append(candidate)
-            if len(filtered_candidates) >= _AVAILABLE_ADAPTERS_TOP_K:
-                break
-        candidates = filtered_candidates
-        if not candidates:
-            return ""
-        candidate_ids = tuple(candidate.tool_id for candidate in candidates)
-        first_candidate_id = candidate_ids[0]
-        has_amos_candidate = "kma_apihub_url_air_amos_minute" in candidate_ids
-        has_metar_candidate = "kma_apihub_url_air_metar_decoded" in candidate_ids
-        has_analysis_candidate = any(
-            candidate_id
-            in {
-                "kma_apihub_url_high_resolution_grid_point",
-                "kma_apihub_url_aws_objective_analysis_grid",
-                "kma_apihub_url_analysis_weather_chart_image",
-            }
-            for candidate_id in candidate_ids
-        )
-        is_gimpo_runway_query = bool(
-            re.search(r"(김포공항|Gimpo|RKSS)", q, re.IGNORECASE)
-            and re.search(
-                r"(AMOS|활주로|RVR|runway|시정|visibility|공항기상관측|매분)",
-                q,
-                re.IGNORECASE,
-            )
-        )
-        # Build a compact, LLM-readable block.
-        #
-        # Spec 2521 (2026-05-02) — emit per-field schema signatures so the
-        # LLM can fill ``params`` against each adapter's actual REST shape.
-        # The previous suffix only carried ``search_hint`` and assumed the
-        # LLM could "infer params from search_hint" — K-EXAONE on FriendliAI
-        # consistently invented ``{"location": "...", "date": "..."}`` style
-        # payloads which fail every adapter's pydantic validation
-        # (``Invalid parameters for tool``). Rendering each field with its
-        # type + required flag + truncated description gives K-EXAONE
-        # enough signal to call e.g. ``{"lat": 37.5, "lon": 129.0,
-        # "base_date": "20260502", "base_time": "0500"}`` correctly.
-        lines: list[str] = [
-            f'<available_adapters query="{q[:120]}">',
-            f"백엔드 BM25 후보 (top {len(candidates)}, 점수 내림차순):",
-            "",
-        ]
-        for c in candidates:
-            hint = (c.search_hint or "").strip()
-            if len(hint) > 90:
-                hint = hint[:87] + "..."
-            primitive = c.primitive or "find"
-            lines.append(
-                f"- {c.tool_id} (primitive={primitive}) [{c.score:.2f}] — {hint or '(설명 없음)'}"
-            )
-            lines.append(f"  호출: {c.tool_id}({{...schema fields...}})")
-            # Render the adapter's llm_description (usage prose, ORDERING RULE,
-            # prerequisites, worked examples) so the LLM sees the complete
-            # "먼저 locate 호출" ordering rule.
-            # Bug: without this, the per-field description for nx is truncated
-            # and K-EXAONE skips locate, producing invalid_params.
-            if c.llm_description:
-                desc_text = c.llm_description.strip().replace("\n", " ")
-                # Emit enough text for adapter-specific negative routing and
-                # output-use rules. KMA METAR/AMOS descriptions carry critical
-                # "Gimhae is not AMOS" and "safe_weather only" instructions
-                # after the purpose sentence; truncating them makes the TUI
-                # path claim no METAR tool exists.
-                if len(desc_text) > 900:
-                    desc_text = desc_text[:897] + "..."
-                lines.append(f"  설명: {desc_text}")
-            # Render input schema signature so the LLM sees exact field
-            # names + types + required flags + (truncated) descriptions.
-            # Field desc limit raised 80→120 so nx/ny examples fit untruncated.
-            schema = c.input_schema_json or {}
-            properties = schema.get("properties") if isinstance(schema, dict) else None
-            required: set[str] = set()
-            raw_required = schema.get("required") if isinstance(schema, dict) else None
-            if isinstance(raw_required, list):
-                required = {str(item) for item in raw_required if isinstance(item, str)}
-            # Spec 2522 T010 — ORDERING directive removed.
-            # The Spec 2521 ORDERING block ("nx/ny 는 KMA 격자 좌표 — 반드시
-            # locate 을 먼저 호출") forced a cross-domain chain that
-            # contradicts both the user directive ("chain X / UMMAYA does not
-            # force cross-domain chain") and v4 description 5-section
-            # self_contained_decl ("이 도구 단독 호출로 완결. locate 등
-            # cross-domain chain 불필요"). With both signals present K-EXAONE
-            # ignored both and hallucinated nx/ny → Spec 2521 regression.
-            # Each adapter's description (섹션 4 domain_quirk + 섹션 5
-            # self_contained_decl + 섹션 3 short_reference 17 광역시도 표) is now
-            # self-sufficient. The model decides chain vs single-tool autonomously.
-            # Reference: research-stdio-ordering.md, frames-busan-weather/ T042 evidence.
-            # Spec 2522 T047 fix — resolve $ref to $defs and inline enum values.
-            # KOROAD KoroadAccidentSearchInput.search_year_cd uses
-            # `$ref: #/$defs/SearchYearCd` (20 values). The previous renderer
-            # only inlined `properties.<f>.enum` and gave up on $ref, leaving
-            # K-EXAONE to guess plain '2024' (invalid). Spec 2522 frames-gangnam-
-            # accident-fix2 evidence: invalid_params persisted after T042 fix.
-            # Fix: resolve $ref against schema['$defs'] + raise threshold 8→25.
-            defs_raw = schema.get("$defs") if isinstance(schema, dict) else None
-            defs: dict[str, Any] | None = defs_raw if isinstance(defs_raw, dict) else None
-
-            def _resolve_enum(
-                meta: dict[str, Any], defs: dict[str, Any] | None
-            ) -> list[Any] | None:
-                # direct enum
-                e = meta.get("enum")
-                if isinstance(e, list):
-                    return e
-                # $ref → $defs/<name>
-                ref = meta.get("$ref")
-                if isinstance(ref, str) and ref.startswith("#/$defs/") and isinstance(defs, dict):
-                    name = ref.removeprefix("#/$defs/")
-                    target = defs.get(name)
-                    if isinstance(target, dict):
-                        target_enum = target.get("enum")
-                        if isinstance(target_enum, list):
-                            return target_enum
-                return None
-
-            def _resolve_enum_with_names(
-                meta: dict[str, Any], defs: dict[str, Any] | None
-            ) -> list[tuple[Any, str]] | None:
-                """Spec 2522 — agency 자체 코드체계 (KOROAD GugunCode SEOUL_GANGNAM=680
-                등) 의 IntEnum name 을 의미 매핑으로 노출. pydantic JSON schema 의
-                $defs 안 IntEnum 의 'enum' (값) + 'x-enum-varnames' (name) 또는
-                'description' (docstring) 을 묶어서 LLM 에 보여줌.
-                """
-                ref = meta.get("$ref")
-                if not (isinstance(ref, str) and ref.startswith("#/$defs/")):
-                    return None
-                if not isinstance(defs, dict):
-                    return None
-                name = ref.removeprefix("#/$defs/")
-                target = defs.get(name)
-                if not isinstance(target, dict):
-                    return None
-                values = target.get("enum")
-                if not isinstance(values, list):
-                    return None
-                # IntEnum name 추출 — pydantic v2 가 'x-enum-varnames' 또는
-                # 'enumNames' 로 export 하지 않음. 대신 module-level dict 조회.
-                varnames = target.get("x-enum-varnames")
-                if isinstance(varnames, list) and len(varnames) == len(values):
-                    return list(zip(values, varnames, strict=False))
-                return None
-
-            if isinstance(properties, dict) and properties:
-                for fname, fmeta in properties.items():
-                    if not isinstance(fmeta, dict):
-                        continue
-                    ftype = fmeta.get("type") or fmeta.get("anyOf") or "any"
-                    if isinstance(ftype, list):
-                        ftype = "|".join(str(t) for t in ftype)
-                    fdesc = str(fmeta.get("description", "")).strip().replace("\n", " ")
-                    # Spec 2522 — agency 자체 코드체계 (KOROAD 68 시군구 매핑 ≈ 1600
-                    # chars + 기존 description ≈ 600 chars = ~2200 chars / KMA 156
-                    # station 등) 인라인 허용. 일반 도구는 100자 미만이라 영향 X.
-                    if len(fdesc) > 5000:
-                        fdesc = fdesc[:4997] + "..."
-                    pat = fmeta.get("pattern")
-                    pat_part = f" pattern={pat!r}" if isinstance(pat, str) else ""
-                    enum = _resolve_enum(fmeta, defs)
-                    # Spec 2522 T047 — threshold 25→200 — KOROAD GugunCode (115) /
-                    # SearchYearCd (20) / SidoCode (17) 등 모두 노출. 의미 매핑은
-                    # field description 에 따로 인라인 (Pydantic IntEnum 의 name
-                    # 은 JSON schema 표준 export 안 됨).
-                    if isinstance(enum, list) and len(enum) <= 200:
-                        enum_part = f" enum={enum}"
-                    else:
-                        enum_part = ""
-                    flag = "필수" if fname in required else "선택"
-                    lines.append(
-                        f"    · {fname} ({ftype}, {flag}{pat_part}{enum_part})"
-                        + (f" — {fdesc}" if fdesc else "")
-                    )
-        lines.append("")
-        lines.append(
-            "규칙: 위 목록의 tool_id는 concrete adapter id입니다. model-facing "
-            "함수명도 tools[]에 로드된 concrete tool_id입니다. concrete adapter "
-            "function은 schema 필드만 받으므로 tool_id/params envelope를 그 안에 "
-            "넣지 마세요. concrete function이 로드되지 않고 root primitive만 "
-            '있을 때만 legacy envelope 예: find({"tool_id":"...", "params":{...}}) '
-            "형식을 사용합니다. 동일 tool_id 를 한 turn 안에서 반복 호출하지 "
-            "마세요. 위 목록에 요청과 일치하는 adapter가 있으면 도구가 없다고 "
-            "답하지 마세요."
-        )
-        if has_analysis_candidate:
-            lines.append(
-                "분석자료 특수 규칙: 위 후보에 고해상도 격자자료, AWS 객관분석, "
-                "분석일기도 이미지가 있으면 기상청이 이미 분석한 자료 도구가 있는 "
-                "것입니다. 공항 관측값/METAR/AMOS/일반 예보가 아니라 시민이 말한 "
-                "분석자료 계열 후보를 호출하세요. 지도/일기도/비구름/바람 흐름 "
-                "질의는 kma_apihub_url_analysis_weather_chart_image 를 우선 호출하고, "
-                "특정 지점 주변 값은 locate 뒤 "
-                "kma_apihub_url_high_resolution_grid_point 또는 "
-                "kma_apihub_url_aws_objective_analysis_grid 를 호출하세요. 공항/랜드마크 "
-                "주변 좌표는 kakao_keyword_search 를 kakao_address_search 보다 먼저 "
-                "사용하세요. locate 가 실패하면 다른 후보 위치 도구를 시도하고, 도구 "
-                "결과 없이 좌표를 추정하지 마세요. APIHub 승인 대기나 upstream 오류가 "
-                "나면 그 실패를 그대로 설명하고, 도구 결과 없이 지도 기반 내용을 "
-                "추정하지 마세요."
-            )
-        if has_amos_candidate and (
-            is_gimpo_runway_query or first_candidate_id == "kma_apihub_url_air_amos_minute"
-        ):
-            lines.append(
-                "AMOS 특수 규칙: kma_apihub_url_air_amos_minute 가 김포공항 "
-                "활주로/시정/RVR/매분 관측 후보이면 AMOS 공항기상관측 도구가 "
-                "있는 것입니다. 김포공항은 stn=110 을 사용하세요. 이 후보는 "
-                "좌표를 요구하지 않으므로 locate/kma_current_observation 을 먼저 "
-                '호출하지 말고 즉시 kma_apihub_url_air_amos_minute({"stn":"110",'
-                '"help":1}) 를 호출하세요. METAR 는 '
-                "보조 확인이 필요할 때만 추가로 사용하세요."
-            )
-        if has_metar_candidate and not (has_amos_candidate and is_gimpo_runway_query):
-            lines.append(
-                "METAR 특수 규칙: kma_apihub_url_air_metar_decoded 가 후보에 있으면 "
-                "공항 METAR 해독자료 조회 도구가 있는 것입니다. 김해공항/RKPK는 "
-                "decoded_records 의 station 153 Gimhae Airport / RKPK record를 "
-                "사용하고, 날씨 값은 decoded_records[].safe_weather 만 사용하세요. "
-                "raw_fields/raw_report에서 별도 값을 만들지 마세요. 이 후보는 좌표를 "
-                "요구하지 않으므로 locate/kma_current_observation 을 먼저 호출하지 "
-                '말고 즉시 kma_apihub_url_air_metar_decoded({"org":"K","help":1}) '
-                "를 호출하세요."
-            )
-        listed_primitives = {str(candidate.primitive or "find") for candidate in candidates}
-        if listed_primitives == {"find"}:
-            lines.append(
-                "공개자료 조회 규칙: 위 후보가 모두 primitive=find 이면 시민이 "
-                "인증/본인확인/동의/신청/제출/납부/신고를 명시하지 않은 한 "
-                "check/send 계열 adapter를 호출하지 마세요. 성공한 find 결과가 있으면 "
-                "다음 turn 은 최종 답변입니다."
-            )
-        lines.append(
-            "호출 전 검증: 시민 발화의 명시 조건(개수, 반경/거리, 날짜/시간, 종류, "
-            "카테고리, 진료과/분야, 키워드, 행정구역 등)이 아래 schema 의 선택 "
-            "필드와 대응하면 그 필드를 반드시 params 에 포함하세요. 더 좁은 요청을 "
-            "넓은 무필터 조회로 실행하지 마세요."
-        )
-        lines.append(
-            'params 는 위에 표시된 정확한 필드명만 사용하세요 — 일반적인 "location"/'
-            '"date" 같은 추측 키는 모든 어댑터에서 invalid_params 로 거부됩니다.'
-        )
-        lines.append(
-            "BM25 도구 발견은 백엔드 internal 기능입니다. 모델은 검색 함수를 호출하지 "
-            "않고, backend가 tools[]에 실어준 concrete adapter function을 우선 "
-            "호출합니다."
-        )
-        lines.append("</available_adapters>")
-        return "\n".join(lines)
 
     # Spec 1978 T053 — eager-import the Mock adapter tree so every adapter
     # self-registers with its primitive dispatcher before the first chat
@@ -7526,9 +7284,12 @@ async def run(  # noqa: C901
         # CC-style loop contract: the model can paint progress prose, then call
         # a primitive dispatcher with a concrete adapter in `tool_id`.
         registry = cast("Any", _ensure_tool_registry())
-        backend_tools_raw = [
-            t.to_openai_tool() for t in _select_concrete_adapter_tools_for_turn(latest_user_utt)
-        ]
+        turn_route_decision = _route_decision_for_turn(latest_user_utt)
+        turn_concrete_adapter_tools = _select_concrete_adapter_tools_for_turn(
+            latest_user_utt, route_decision=turn_route_decision
+        )
+        turn_concrete_adapter_tool_ids = tuple(t.id for t in turn_concrete_adapter_tools)
+        backend_tools_raw = [t.to_openai_tool() for t in turn_concrete_adapter_tools]
         backend_tool_names: set[object] = set()
         for raw_tool in backend_tools_raw:
             if not isinstance(raw_tool, dict):
@@ -7662,7 +7423,11 @@ async def run(  # noqa: C901
                         (latest_user_utt or "")[:256],
                     )
                 if latest_user_utt:
-                    suffix_block = _build_available_adapters_suffix(latest_user_utt)
+                    suffix_block = _build_available_adapters_suffix(
+                        latest_user_utt,
+                        route_decision=turn_route_decision,
+                        visible_tool_ids=turn_concrete_adapter_tool_ids,
+                    )
                     if suffix_block:
                         augmented_system = augmented_system + "\n\n" + suffix_block + "\n"
             except Exception:  # noqa: BLE001 — fail-open per FR-002

--- a/src/ummaya/tools/discovery_bridge.py
+++ b/src/ummaya/tools/discovery_bridge.py
@@ -34,7 +34,7 @@ from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, ConfigDict, Field, RootModel
 
-from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool
+from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool, MockFidelityGrade
 
 if TYPE_CHECKING:
     from ummaya.tools.registry import ToolRegistry
@@ -346,6 +346,7 @@ def _verify_to_govapitool(entry: dict[str, Any]) -> GovAPITool:
         rate_limit_per_minute=30,
         is_core=False,  # Discoverable via lookup search; NOT in primary LLM tool list
         primitive="check",
+        adapter_mode="mock",
     )
 
 
@@ -385,7 +386,22 @@ def _submit_to_govapitool(
         rate_limit_per_minute=registration.rate_limit_per_minute,
         is_core=False,  # Discoverable via lookup search; NOT in primary LLM tool list
         primitive="send",
+        adapter_mode="mock",
+        mock_fidelity_grade=_mock_fidelity_from_source_mode(registration.source_mode),
     )
+
+
+def _mock_fidelity_from_source_mode(source_mode: object) -> MockFidelityGrade:
+    raw = str(getattr(source_mode, "value", source_mode))
+    match raw:
+        case "OPENAPI":
+            return "OPENAPI"
+        case "OOS":
+            return "OOS"
+        case "harness-only" | "HARNESS_ONLY":
+            return "HARNESS_ONLY"
+        case _:
+            return "unknown"
 
 
 # ---------------------------------------------------------------------------

--- a/src/ummaya/tools/models.py
+++ b/src/ummaya/tools/models.py
@@ -31,6 +31,8 @@ _AUTH_TYPE_LEVEL_MAPPING: Final[dict[str, frozenset[str]]] = {
     "oauth": frozenset({"AAL1", "AAL2", "AAL3"}),
 }
 
+MockFidelityGrade = Literal["OPENAPI", "OOS", "HARNESS_ONLY", "unknown", "not_applicable"]
+
 # Spec 1634 (P3 Tool System Wiring) — closed ministry / institution enum.
 # Typed replacement for the former free-form ``provider: str`` field. New
 # institutions are added by enum extension (small dedicated PR, ADR not
@@ -214,6 +216,8 @@ class GovAPITool(BaseModel):
     """Runtime source. ``live`` = adapter calls the real public API.
     ``mock`` = adapter returns recorded fixture or shape-compatible synthetic.
     Distinct from ``AdapterRegistration.source_mode`` (mirror fidelity axis)."""
+
+    mock_fidelity_grade: MockFidelityGrade = "not_applicable"
 
     # Spec 031 T032 dual-axis fields — None during pre-v1.2 compatibility window FR-028
     primitive: Literal["find", "locate", "send", "check", "document"] | None = None

--- a/src/ummaya/tools/registry.py
+++ b/src/ummaya/tools/registry.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 
 import logging
 from enum import StrEnum
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, computed_field, model_validator
 
@@ -31,6 +31,9 @@ from ummaya.tools.retrieval.dense_backend import DenseBackendLoadError
 from ummaya.tools.search import search_tools
 
 logger = logging.getLogger(__name__)
+
+if TYPE_CHECKING:
+    from ummaya.tools.routing.cards import AdapterCard
 
 
 # ---------------------------------------------------------------------------
@@ -387,6 +390,11 @@ class ToolRegistry:
     def situational_tools(self) -> list[GovAPITool]:
         """Return non-core, active tools."""
         return [t for tid, t in self._tools.items() if not t.is_core and tid not in self._inactive]
+
+    def adapter_cards(self) -> list[AdapterCard]:
+        from ummaya.tools.routing.cards import build_adapter_cards
+
+        return list(build_adapter_cards(self.all_tools()))
 
     def export_core_tools_openai(self) -> list[dict[str, object]]:
         """Export core tools as OpenAI function-calling definitions.

--- a/src/ummaya/tools/routing/__init__.py
+++ b/src/ummaya/tools/routing/__init__.py
@@ -1,0 +1,23 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from ummaya.tools.routing.cards import (
+    AdapterCard,
+    AdapterCardError,
+    AdapterCardQualityViolation,
+    SchemaFieldSummary,
+    assert_adapter_card_quality,
+    build_adapter_card,
+    build_adapter_cards,
+    lint_adapter_card,
+)
+
+__all__ = [
+    "AdapterCard",
+    "AdapterCardError",
+    "AdapterCardQualityViolation",
+    "SchemaFieldSummary",
+    "assert_adapter_card_quality",
+    "build_adapter_card",
+    "build_adapter_cards",
+    "lint_adapter_card",
+]

--- a/src/ummaya/tools/routing/__init__.py
+++ b/src/ummaya/tools/routing/__init__.py
@@ -14,7 +14,10 @@ from ummaya.tools.routing.decision_service import RouteDecisionService
 from ummaya.tools.routing.decision_types import (
     FeasibilityStatus,
     RouteCandidate,
+    RouteClarificationDecision,
+    RouteClarificationReason,
     RouteDecision,
+    RouteStopReason,
     SchemaProjectionLevel,
 )
 from ummaya.tools.routing.intent import (
@@ -38,7 +41,10 @@ __all__ = [
     "FeasibilityStatus",
     "LEGACY_PRIMITIVE_ALIASES",
     "RouteCandidate",
+    "RouteClarificationDecision",
+    "RouteClarificationReason",
     "RouteDecision",
+    "RouteStopReason",
     "RouteDecisionService",
     "SchemaFieldSummary",
     "SchemaProjectionLevel",

--- a/src/ummaya/tools/routing/__init__.py
+++ b/src/ummaya/tools/routing/__init__.py
@@ -10,14 +10,24 @@ from ummaya.tools.routing.cards import (
     build_adapter_cards,
     lint_adapter_card,
 )
+from ummaya.tools.routing.intent import (
+    ACTIVE_PRIMITIVES,
+    LEGACY_PRIMITIVE_ALIASES,
+    ToolSelectionIntent,
+    extract_tool_selection_intent,
+)
 
 __all__ = [
+    "ACTIVE_PRIMITIVES",
     "AdapterCard",
     "AdapterCardError",
     "AdapterCardQualityViolation",
+    "LEGACY_PRIMITIVE_ALIASES",
     "SchemaFieldSummary",
+    "ToolSelectionIntent",
     "assert_adapter_card_quality",
     "build_adapter_card",
     "build_adapter_cards",
+    "extract_tool_selection_intent",
     "lint_adapter_card",
 ]

--- a/src/ummaya/tools/routing/__init__.py
+++ b/src/ummaya/tools/routing/__init__.py
@@ -10,6 +10,13 @@ from ummaya.tools.routing.cards import (
     build_adapter_cards,
     lint_adapter_card,
 )
+from ummaya.tools.routing.decision_service import RouteDecisionService
+from ummaya.tools.routing.decision_types import (
+    FeasibilityStatus,
+    RouteCandidate,
+    RouteDecision,
+    SchemaProjectionLevel,
+)
 from ummaya.tools.routing.intent import (
     ACTIVE_PRIMITIVES,
     LEGACY_PRIMITIVE_ALIASES,
@@ -22,8 +29,13 @@ __all__ = [
     "AdapterCard",
     "AdapterCardError",
     "AdapterCardQualityViolation",
+    "FeasibilityStatus",
     "LEGACY_PRIMITIVE_ALIASES",
+    "RouteCandidate",
+    "RouteDecision",
+    "RouteDecisionService",
     "SchemaFieldSummary",
+    "SchemaProjectionLevel",
     "ToolSelectionIntent",
     "assert_adapter_card_quality",
     "build_adapter_card",

--- a/src/ummaya/tools/routing/__init__.py
+++ b/src/ummaya/tools/routing/__init__.py
@@ -23,12 +23,18 @@ from ummaya.tools.routing.intent import (
     ToolSelectionIntent,
     extract_tool_selection_intent,
 )
+from ummaya.tools.routing.projection import (
+    AvailableAdaptersProjection,
+    build_available_adapters_projection,
+    selected_concrete_adapter_tools,
+)
 
 __all__ = [
     "ACTIVE_PRIMITIVES",
     "AdapterCard",
     "AdapterCardError",
     "AdapterCardQualityViolation",
+    "AvailableAdaptersProjection",
     "FeasibilityStatus",
     "LEGACY_PRIMITIVE_ALIASES",
     "RouteCandidate",
@@ -40,6 +46,8 @@ __all__ = [
     "assert_adapter_card_quality",
     "build_adapter_card",
     "build_adapter_cards",
+    "build_available_adapters_projection",
     "extract_tool_selection_intent",
     "lint_adapter_card",
+    "selected_concrete_adapter_tools",
 ]

--- a/src/ummaya/tools/routing/builder.py
+++ b/src/ummaya/tools/routing/builder.py
@@ -1,0 +1,105 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.routing.metadata import (
+    capabilities_for_tool,
+    credential_requirements_for_tool,
+    domain_for_tool,
+    entity_types_for_tool,
+    examples_en_for_tool,
+    examples_ko_for_tool,
+    limitations_for_tool,
+    mock_fidelity_grade_for_tool,
+    prerequisite_tools_for_tool,
+    primitive_family,
+    routing_text,
+    safety_annotations_for_tool,
+    side_effect_level_for_tool,
+    source_mode_for_tool,
+)
+from ummaya.tools.routing.schema import model_json_schema, schema_summary, sha256
+from ummaya.tools.routing.types import (
+    INTENT_VERBS,
+    LEGACY_ALIASES,
+    AdapterCard,
+)
+
+
+def build_adapter_cards(tools: Iterable[GovAPITool]) -> tuple[AdapterCard, ...]:
+    return tuple(build_adapter_card(tool) for tool in sorted(tools, key=lambda item: item.id))
+
+
+def build_adapter_card(tool: GovAPITool) -> AdapterCard:
+    primitive = primitive_family(tool.primitive)
+    input_schema = model_json_schema(tool.input_schema)
+    output_schema = model_json_schema(tool.output_schema)
+    input_summary = schema_summary(input_schema)
+    output_summary = schema_summary(output_schema)
+    required_slots = tuple(field.name for field in input_summary if field.required)
+    optional_slots = tuple(field.name for field in input_summary if not field.required)
+    source_mode = source_mode_for_tool(tool)
+    policy_authority_url = tool.policy.real_classification_url if tool.policy is not None else None
+    side_effect_level = side_effect_level_for_tool(tool, primitive)
+    credential_requirements = credential_requirements_for_tool(tool)
+    capabilities = capabilities_for_tool(tool, primitive)
+    entity_types = entity_types_for_tool(input_summary, tool.category)
+    prerequisite_tools = prerequisite_tools_for_tool(tool, primitive)
+    input_schema_hash = sha256(input_schema)
+    manifest_hash = sha256(
+        {
+            "tool_id": tool.id,
+            "primitive_family": primitive,
+            "agency": str(tool.ministry),
+            "source_mode": source_mode,
+            "policy_authority_url": policy_authority_url,
+            "input_schema_hash": input_schema_hash,
+            "output_schema_hash": sha256(output_schema),
+        }
+    )
+    examples_ko = examples_ko_for_tool(tool)
+    examples_en = examples_en_for_tool(tool, primitive)
+    negative_examples = (f"Do not use for requests outside primitive {primitive}.",)
+    limitations = limitations_for_tool(tool, source_mode, policy_authority_url)
+    safety_annotations = safety_annotations_for_tool(tool, side_effect_level)
+
+    return AdapterCard(
+        tool_id=tool.id,
+        primitive_family=primitive,
+        legacy_primitive_aliases=LEGACY_ALIASES[primitive],
+        domain=domain_for_tool(tool),
+        agency=str(tool.ministry),
+        source_mode=source_mode,
+        capabilities=capabilities,
+        intent_verbs=INTENT_VERBS[primitive],
+        entity_types=entity_types,
+        required_slots=required_slots,
+        optional_slots=optional_slots,
+        prerequisite_tools=prerequisite_tools,
+        input_schema_hash=input_schema_hash,
+        input_schema_summary=input_summary,
+        output_schema_summary=output_summary,
+        policy_authority_url=policy_authority_url,
+        safety_annotations=safety_annotations,
+        side_effect_level=side_effect_level,
+        credential_requirements=credential_requirements,
+        mock_fidelity_grade=mock_fidelity_grade_for_tool(tool),
+        examples_ko=examples_ko,
+        examples_en=examples_en,
+        negative_examples=negative_examples,
+        limitations=limitations,
+        manifest_hash=manifest_hash,
+        routing_text=routing_text(
+            tool_id=tool.id,
+            primitive=primitive,
+            agency=str(tool.ministry),
+            domain=domain_for_tool(tool),
+            capabilities=capabilities,
+            required_slots=required_slots,
+            examples_ko=examples_ko,
+            limitations=limitations,
+        ),
+    )

--- a/src/ummaya/tools/routing/cards.py
+++ b/src/ummaya/tools/routing/cards.py
@@ -1,0 +1,29 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from ummaya.tools.routing.builder import build_adapter_card, build_adapter_cards
+from ummaya.tools.routing.lint import assert_adapter_card_quality, lint_adapter_card
+from ummaya.tools.routing.types import (
+    AdapterCard,
+    AdapterCardError,
+    AdapterCardQualityViolation,
+    PrimitiveFamily,
+    SchemaFieldSummary,
+    SideEffectLevel,
+    SourceMode,
+)
+
+__all__ = [
+    "AdapterCard",
+    "AdapterCardError",
+    "AdapterCardQualityViolation",
+    "PrimitiveFamily",
+    "SchemaFieldSummary",
+    "SideEffectLevel",
+    "SourceMode",
+    "assert_adapter_card_quality",
+    "build_adapter_card",
+    "build_adapter_cards",
+    "lint_adapter_card",
+]

--- a/src/ummaya/tools/routing/decision_service.py
+++ b/src/ummaya/tools/routing/decision_service.py
@@ -10,7 +10,9 @@ from ummaya.tools.errors import ToolNotFoundError
 from ummaya.tools.routing.cards import build_adapter_card
 from ummaya.tools.routing.decision_types import (
     RouteCandidate,
+    RouteClarificationDecision,
     RouteDecision,
+    RouteStopReason,
     SchemaProjectionLevel,
 )
 from ummaya.tools.routing.feasibility import (
@@ -47,13 +49,17 @@ class RouteDecisionService:
         *,
         top_k: int = 15,
         max_selected: int = 5,
+        session_identity: object | None = None,
         initial_scores: Iterable[tuple[str, float]] | None = None,
+        validation_events: Sequence[str] = (),
     ) -> RouteDecision:
         return self.select_adapters(
             query,
             top_k=top_k,
             max_selected=max_selected,
+            session_identity=session_identity,
             initial_scores=initial_scores,
+            validation_events=validation_events,
             include_infeasible=True,
         )
 
@@ -69,12 +75,25 @@ class RouteDecisionService:
         allowed_credentials: Sequence[str] | None = None,
         include_infeasible: bool = False,
         initial_scores: Iterable[tuple[str, float]] | None = None,
+        validation_events: Sequence[str] = (),
     ) -> RouteDecision:
         registry_size = len(self._registry)
         effective_top_k = max(1, min(top_k, registry_size, 20)) if registry_size else 0
         route_intent = intent or extract_tool_selection_intent(
             query, known_tool_ids=self._registry._tools.keys()
         )
+        if _has_repeated_tool_mismatch(validation_events):
+            return self._terminal_decision(
+                query,
+                route_intent,
+                backend_label="validation",
+                stop_reason="repeated_tool_mismatch",
+                degradation_reason="repeated_tool_mismatch",
+                evidence_events=(
+                    "termination:repeated_tool_mismatch",
+                    *_route_validation_events(validation_events),
+                ),
+            )
         if registry_size == 0:
             return self._empty_decision(query, route_intent)
 
@@ -107,11 +126,31 @@ class RouteDecisionService:
             candidate for candidate in ranked_candidates if candidate.feasible
         )
         selection_limit = max_selected if max_selected is not None else effective_top_k
-        selected_route_candidates = selected_candidates[:selection_limit]
+        clarification = _clarification_decision(
+            ranked_candidates,
+            selected_candidates=selected_candidates,
+            selection_limit=selection_limit,
+            session_identity=session_identity,
+        )
+        selected_route_candidates = (
+            () if clarification is not None else selected_candidates[:selection_limit]
+        )
         selected_tools = tuple(candidate.tool_id for candidate in selected_route_candidates)
         visible_candidates = (ranked_candidates if include_infeasible else selected_candidates)[
             :effective_top_k
         ]
+        permission_gate = any(
+            requires_permission_gate(candidate.card, feasible=candidate.feasible)
+            for candidate in selected_route_candidates
+        )
+        stop_reason = _stop_reason(
+            selected_route_candidates=selected_route_candidates,
+            clarification=clarification,
+            permission_gate=permission_gate,
+            evidence_events=candidate_events,
+        )
+
+        clarification_events = () if clarification is None else clarification.evidence_events
 
         return RouteDecision(
             decision_id=sha256(
@@ -132,15 +171,13 @@ class RouteDecisionService:
             schema_projection_level=_schema_projection_level(selected_tools),
             backend_label=backend_label,
             effective_top_k=effective_top_k,
-            clarification_question=_clarification_question(ranked_candidates, selected_tools),
-            permission_gate=any(
-                requires_permission_gate(candidate.card, feasible=candidate.feasible)
-                for candidate in selected_route_candidates
-            ),
-            stop_reason=None if selected_tools else "no_feasible_candidate",
+            clarification=clarification,
+            clarification_question=None if clarification is None else clarification.question,
+            permission_gate=permission_gate,
+            stop_reason=stop_reason,
             degradation_reason=degradation_reason,
             score_breakdown=_aggregate_score_breakdown(ranked_candidates),
-            evidence_events=(*card_events, *candidate_events),
+            evidence_events=(*card_events, *candidate_events, *clarification_events),
         )
 
     def _empty_decision(
@@ -156,12 +193,49 @@ class RouteDecisionService:
             schema_projection_level="none",
             backend_label=backend_label,
             effective_top_k=0,
+            clarification=None,
             clarification_question=None,
             permission_gate=False,
-            stop_reason="no_feasible_candidate",
+            stop_reason="blocked_no_adapter",
             degradation_reason=None,
             score_breakdown={"candidate_count": 0.0, "feasible_count": 0.0},
             evidence_events=(),
+        )
+
+    def _terminal_decision(
+        self,
+        query: str,
+        intent: ToolSelectionIntent,
+        *,
+        backend_label: str,
+        stop_reason: RouteStopReason,
+        degradation_reason: str | None,
+        evidence_events: tuple[str, ...],
+    ) -> RouteDecision:
+        return RouteDecision(
+            decision_id=sha256(
+                {
+                    "query": query,
+                    "selected_tools": (),
+                    "stop_reason": stop_reason,
+                    "backend_label": backend_label,
+                }
+            )[:16],
+            query_hash=sha256(query),
+            manifest_hash=sha256([]),
+            intent=intent,
+            candidate_set=(),
+            selected_tools=(),
+            schema_projection_level="none",
+            backend_label=backend_label,
+            effective_top_k=0,
+            clarification=None,
+            clarification_question=None,
+            permission_gate=False,
+            stop_reason=stop_reason,
+            degradation_reason=degradation_reason,
+            score_breakdown={"candidate_count": 0.0, "feasible_count": 0.0},
+            evidence_events=evidence_events,
         )
 
     def _score(
@@ -274,9 +348,22 @@ class RouteDecisionService:
         return tuple(candidates), tuple(evidence_events)
 
 
-def _candidate_sort_key(candidate: RouteCandidate) -> tuple[int, float, str]:
+def _has_repeated_tool_mismatch(validation_events: Sequence[str]) -> bool:
+    mismatch_count = sum(1 for event in validation_events if "tool_mismatch" in event)
+    return mismatch_count >= 2
+
+
+def _route_validation_events(validation_events: Sequence[str]) -> tuple[str, ...]:
+    return tuple(f"validation_event:{event}" for event in validation_events)
+
+
+def _candidate_selection_score(candidate: RouteCandidate) -> float:
     penalty = len(candidate.filter_reasons) * 1000.0
-    score = candidate.retrieval_score + candidate.score_breakdown["feasibility"] * 100.0 - penalty
+    return candidate.retrieval_score + candidate.score_breakdown["feasibility"] * 100.0 - penalty
+
+
+def _candidate_sort_key(candidate: RouteCandidate) -> tuple[int, float, str]:
+    score = _candidate_selection_score(candidate)
     return (0 if candidate.feasible else 1, -score, candidate.tool_id)
 
 
@@ -284,11 +371,16 @@ def _schema_projection_level(selected_tools: tuple[str, ...]) -> SchemaProjectio
     return "summary" if selected_tools else "none"
 
 
-def _clarification_question(
-    candidates: tuple[RouteCandidate, ...], selected_tools: tuple[str, ...]
-) -> str | None:
-    if not candidates or selected_tools:
+def _clarification_decision(
+    candidates: tuple[RouteCandidate, ...],
+    *,
+    selected_candidates: tuple[RouteCandidate, ...],
+    selection_limit: int,
+    session_identity: object | None,
+) -> RouteClarificationDecision | None:
+    if not candidates:
         return None
+
     missing_slots = sorted(
         {
             reason.removeprefix("missing_slot:")
@@ -298,8 +390,96 @@ def _clarification_question(
         }
     )
     if missing_slots:
-        return f"Required slot missing: {', '.join(missing_slots)}."
+        joined_slots = _join_human_readable(tuple(missing_slots))
+        return RouteClarificationDecision(
+            reason="missing_slots",
+            question=f"Which values should I use for {joined_slots}?",
+            missing_slots=tuple(missing_slots),
+            evidence_events=("clarification:missing_slots",),
+        )
+
+    equal_candidates = _equal_top_candidates(selected_candidates, selection_limit)
+    if equal_candidates:
+        candidate_tool_ids = tuple(candidate.tool_id for candidate in equal_candidates)
+        joined_tools = _join_candidate_choices(candidate_tool_ids)
+        return RouteClarificationDecision(
+            reason="equal_candidates",
+            question=f"Which service should I use: {joined_tools}?",
+            candidate_tool_ids=candidate_tool_ids,
+            evidence_events=("clarification:equal_candidates",),
+        )
+
+    for candidate in candidates:
+        if "permission_context_missing" in candidate.filter_reasons:
+            return RouteClarificationDecision(
+                reason="side_effect_confirmation",
+                question=f"Should I proceed with {candidate.tool_id}?",
+                candidate_tool_ids=(candidate.tool_id,),
+                evidence_events=("clarification:side_effect_confirmation",),
+            )
+    if session_identity is None:
+        for candidate in selected_candidates:
+            if candidate.card.side_effect_level in {"action", "sign", "send", "verify"}:
+                return RouteClarificationDecision(
+                    reason="side_effect_confirmation",
+                    question=f"Should I proceed with {candidate.tool_id}?",
+                    candidate_tool_ids=(candidate.tool_id,),
+                    evidence_events=("clarification:side_effect_confirmation",),
+                )
+
     return None
+
+
+def _equal_top_candidates(
+    selected_candidates: tuple[RouteCandidate, ...], selection_limit: int
+) -> tuple[RouteCandidate, ...]:
+    if selection_limit != 1 or len(selected_candidates) < 2:
+        return ()
+    top_score = _candidate_selection_score(selected_candidates[0])
+    equal_candidates = tuple(
+        candidate
+        for candidate in selected_candidates
+        if abs(_candidate_selection_score(candidate) - top_score) <= 1e-9
+    )
+    return equal_candidates if len(equal_candidates) >= 2 else ()
+
+
+def _stop_reason(
+    *,
+    selected_route_candidates: tuple[RouteCandidate, ...],
+    clarification: RouteClarificationDecision | None,
+    permission_gate: bool,
+    evidence_events: tuple[str, ...],
+) -> RouteStopReason:
+    if clarification is not None:
+        return "needs_input"
+    if permission_gate:
+        return "permission_required"
+    if selected_route_candidates:
+        return "answerable"
+    if any("disallowed_credential" in event for event in evidence_events):
+        return "blocked_no_credential"
+    if any("disallowed_source_mode:internal" in event for event in evidence_events):
+        return "handoff_required"
+    return "blocked_no_adapter"
+
+
+def _join_human_readable(values: tuple[str, ...]) -> str:
+    if not values:
+        return ""
+    if len(values) == 1:
+        return values[0]
+    if len(values) == 2:
+        return f"{values[0]} and {values[1]}"
+    return f"{', '.join(values[:-1])}, and {values[-1]}"
+
+
+def _join_candidate_choices(values: tuple[str, ...]) -> str:
+    if len(values) <= 1:
+        return _join_human_readable(values)
+    if len(values) == 2:
+        return f"{values[0]} or {values[1]}"
+    return f"{', '.join(values[:-1])}, or {values[-1]}"
 
 
 def _aggregate_score_breakdown(candidates: tuple[RouteCandidate, ...]) -> dict[str, float]:

--- a/src/ummaya/tools/routing/decision_service.py
+++ b/src/ummaya/tools/routing/decision_service.py
@@ -76,6 +76,7 @@ class RouteDecisionService:
         include_infeasible: bool = False,
         initial_scores: Iterable[tuple[str, float]] | None = None,
         validation_events: Sequence[str] = (),
+        drop_zero_score_candidates: bool | None = None,
     ) -> RouteDecision:
         registry_size = len(self._registry)
         effective_top_k = max(1, min(top_k, registry_size, 20)) if registry_size else 0
@@ -107,6 +108,11 @@ class RouteDecisionService:
             backend_label = "injected"
             degradation_reason = None
 
+        should_drop_zero_score_candidates = (
+            _should_drop_zero_score_candidates(scored, route_intent=route_intent)
+            if drop_zero_score_candidates is None
+            else drop_zero_score_candidates
+        )
         active_cards, card_events = self._active_cards()
         active_tool_ids = frozenset(card.tool_id for card in active_cards)
         active_primitives = frozenset(card.primitive_family for card in active_cards)
@@ -120,21 +126,22 @@ class RouteDecisionService:
             allowed_credentials=(
                 None if allowed_credentials is None else frozenset(allowed_credentials)
             ),
+            drop_zero_score_candidates=should_drop_zero_score_candidates,
         )
         ranked_candidates = tuple(sorted(candidates, key=_candidate_sort_key))
         selected_candidates = tuple(
             candidate for candidate in ranked_candidates if candidate.feasible
         )
         selection_limit = max_selected if max_selected is not None else effective_top_k
+        selected_slice = selected_candidates[:selection_limit]
         clarification = _clarification_decision(
             ranked_candidates,
             selected_candidates=selected_candidates,
+            selected_slice=selected_slice,
             selection_limit=selection_limit,
             session_identity=session_identity,
         )
-        selected_route_candidates = (
-            () if clarification is not None else selected_candidates[:selection_limit]
-        )
+        selected_route_candidates = () if clarification is not None else selected_slice
         selected_tools = tuple(candidate.tool_id for candidate in selected_route_candidates)
         visible_candidates = (ranked_candidates if include_infeasible else selected_candidates)[
             :effective_top_k
@@ -300,10 +307,19 @@ class RouteDecisionService:
         active_primitives: frozenset[PrimitiveFamily],
         allowed_source_modes: frozenset[SourceMode],
         allowed_credentials: frozenset[str] | None,
+        drop_zero_score_candidates: bool,
     ) -> tuple[tuple[RouteCandidate, ...], tuple[str, ...]]:
         candidates: list[RouteCandidate] = []
         evidence_events: list[str] = []
         for tool_id, raw_score in scored:
+            retrieval_score = max(0.0, float(raw_score))
+            if (
+                drop_zero_score_candidates
+                and retrieval_score <= 0.0
+                and tool_id not in route_intent.explicit_tool_ids
+            ):
+                evidence_events.append(f"soft_excluded:zero_retrieval_score:{tool_id}")
+                continue
             try:
                 card = build_adapter_card(self._registry.find(tool_id))
             except ToolNotFoundError:
@@ -326,7 +342,6 @@ class RouteDecisionService:
                     evidence_events.append(f"hard_excluded:{reason}:{tool_id}")
                 continue
 
-            retrieval_score = max(0.0, float(raw_score))
             filter_reasons = soft_filter_reasons(
                 card,
                 route_intent=route_intent,
@@ -357,6 +372,16 @@ def _route_validation_events(validation_events: Sequence[str]) -> tuple[str, ...
     return tuple(f"validation_event:{event}" for event in validation_events)
 
 
+def _should_drop_zero_score_candidates(
+    scored: Sequence[tuple[str, float]], *, route_intent: ToolSelectionIntent
+) -> bool:
+    if route_intent.explicit_tool_ids:
+        return False
+    if any(float(score) > 0.0 for _tool_id, score in scored):
+        return True
+    return len(scored) > 1
+
+
 def _candidate_selection_score(candidate: RouteCandidate) -> float:
     penalty = len(candidate.filter_reasons) * 1000.0
     return candidate.retrieval_score + candidate.score_breakdown["feasibility"] * 100.0 - penalty
@@ -375,6 +400,7 @@ def _clarification_decision(
     candidates: tuple[RouteCandidate, ...],
     *,
     selected_candidates: tuple[RouteCandidate, ...],
+    selected_slice: tuple[RouteCandidate, ...],
     selection_limit: int,
     session_identity: object | None,
 ) -> RouteClarificationDecision | None:
@@ -409,17 +435,22 @@ def _clarification_decision(
             evidence_events=("clarification:equal_candidates",),
         )
 
-    for candidate in candidates:
-        if "permission_context_missing" in candidate.filter_reasons:
-            return RouteClarificationDecision(
-                reason="side_effect_confirmation",
-                question=f"Should I proceed with {candidate.tool_id}?",
-                candidate_tool_ids=(candidate.tool_id,),
-                evidence_events=("clarification:side_effect_confirmation",),
-            )
+    top_candidate = candidates[0]
+    if "permission_context_missing" in top_candidate.filter_reasons:
+        return RouteClarificationDecision(
+            reason="side_effect_confirmation",
+            question=f"Should I proceed with {top_candidate.tool_id}?",
+            candidate_tool_ids=(top_candidate.tool_id,),
+            evidence_events=("clarification:side_effect_confirmation",),
+        )
     if session_identity is None:
-        for candidate in selected_candidates:
-            if candidate.card.side_effect_level in {"action", "sign", "send", "verify"}:
+        for candidate in selected_slice:
+            if candidate.tool_id != "document" and candidate.card.side_effect_level in {
+                "action",
+                "sign",
+                "send",
+                "verify",
+            }:
                 return RouteClarificationDecision(
                     reason="side_effect_confirmation",
                     question=f"Should I proceed with {candidate.tool_id}?",

--- a/src/ummaya/tools/routing/decision_service.py
+++ b/src/ummaya/tools/routing/decision_service.py
@@ -1,0 +1,323 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable, Sequence
+from typing import TYPE_CHECKING
+
+from ummaya.tools.errors import ToolNotFoundError
+from ummaya.tools.routing.cards import build_adapter_card
+from ummaya.tools.routing.decision_types import (
+    RouteCandidate,
+    RouteDecision,
+    SchemaProjectionLevel,
+)
+from ummaya.tools.routing.feasibility import (
+    DEFAULT_SOURCE_MODES,
+    hard_exclusion_reasons,
+    requires_permission_gate,
+    score_breakdown,
+    soft_filter_reasons,
+)
+from ummaya.tools.routing.intent import (
+    ToolSelectionIntent,
+    extract_tool_selection_intent,
+)
+from ummaya.tools.routing.retrieval_policy import (
+    expand_query_for_intent,
+    filter_special_case_scores,
+)
+from ummaya.tools.routing.schema import sha256
+from ummaya.tools.routing.types import AdapterCard, PrimitiveFamily, SourceMode
+
+if TYPE_CHECKING:
+    from ummaya.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+
+class RouteDecisionService:
+    def __init__(self, registry: ToolRegistry) -> None:
+        self._registry = registry
+
+    def decide(
+        self,
+        query: str,
+        *,
+        top_k: int = 15,
+        max_selected: int = 5,
+        initial_scores: Iterable[tuple[str, float]] | None = None,
+    ) -> RouteDecision:
+        return self.select_adapters(
+            query,
+            top_k=top_k,
+            max_selected=max_selected,
+            initial_scores=initial_scores,
+            include_infeasible=True,
+        )
+
+    def select_adapters(
+        self,
+        query: str,
+        *,
+        top_k: int = 5,
+        max_selected: int | None = None,
+        intent: ToolSelectionIntent | None = None,
+        session_identity: object | None = None,
+        allowed_source_modes: Sequence[SourceMode] = DEFAULT_SOURCE_MODES,
+        allowed_credentials: Sequence[str] | None = None,
+        include_infeasible: bool = False,
+        initial_scores: Iterable[tuple[str, float]] | None = None,
+    ) -> RouteDecision:
+        registry_size = len(self._registry)
+        effective_top_k = max(1, min(top_k, registry_size, 20)) if registry_size else 0
+        route_intent = intent or extract_tool_selection_intent(
+            query, known_tool_ids=self._registry._tools.keys()
+        )
+        if registry_size == 0:
+            return self._empty_decision(query, route_intent)
+
+        if initial_scores is None:
+            scored, backend_label, degradation_reason = self._score(query, route_intent)
+        else:
+            scored = sorted(
+                filter_special_case_scores(route_intent, list(initial_scores)),
+                key=lambda pair: (-pair[1], pair[0]),
+            )
+            backend_label = "injected"
+            degradation_reason = None
+
+        active_cards, card_events = self._active_cards()
+        active_tool_ids = frozenset(card.tool_id for card in active_cards)
+        active_primitives = frozenset(card.primitive_family for card in active_cards)
+        candidates, candidate_events = self._candidate_set(
+            scored,
+            route_intent=route_intent,
+            session_identity=session_identity,
+            active_tool_ids=active_tool_ids,
+            active_primitives=active_primitives,
+            allowed_source_modes=frozenset(allowed_source_modes),
+            allowed_credentials=(
+                None if allowed_credentials is None else frozenset(allowed_credentials)
+            ),
+        )
+        ranked_candidates = tuple(sorted(candidates, key=_candidate_sort_key))
+        selected_candidates = tuple(
+            candidate for candidate in ranked_candidates if candidate.feasible
+        )
+        selection_limit = max_selected if max_selected is not None else effective_top_k
+        selected_route_candidates = selected_candidates[:selection_limit]
+        selected_tools = tuple(candidate.tool_id for candidate in selected_route_candidates)
+        visible_candidates = (ranked_candidates if include_infeasible else selected_candidates)[
+            :effective_top_k
+        ]
+
+        return RouteDecision(
+            decision_id=sha256(
+                {
+                    "query": query,
+                    "selected_tools": selected_tools,
+                    "backend_label": backend_label,
+                    "degradation_reason": degradation_reason,
+                }
+            )[:16],
+            query_hash=sha256(query),
+            manifest_hash=sha256(
+                [candidate.card.manifest_hash for candidate in visible_candidates]
+            ),
+            intent=route_intent,
+            candidate_set=visible_candidates,
+            selected_tools=selected_tools,
+            schema_projection_level=_schema_projection_level(selected_tools),
+            backend_label=backend_label,
+            effective_top_k=effective_top_k,
+            clarification_question=_clarification_question(ranked_candidates, selected_tools),
+            permission_gate=any(
+                requires_permission_gate(candidate.card, feasible=candidate.feasible)
+                for candidate in selected_route_candidates
+            ),
+            stop_reason=None if selected_tools else "no_feasible_candidate",
+            degradation_reason=degradation_reason,
+            score_breakdown=_aggregate_score_breakdown(ranked_candidates),
+            evidence_events=(*card_events, *candidate_events),
+        )
+
+    def _empty_decision(
+        self, query: str, intent: ToolSelectionIntent, *, backend_label: str = "retrieval"
+    ) -> RouteDecision:
+        return RouteDecision(
+            decision_id=sha256({"query": query, "selected_tools": ()})[:16],
+            query_hash=sha256(query),
+            manifest_hash=sha256([]),
+            intent=intent,
+            candidate_set=(),
+            selected_tools=(),
+            schema_projection_level="none",
+            backend_label=backend_label,
+            effective_top_k=0,
+            clarification_question=None,
+            permission_gate=False,
+            stop_reason="no_feasible_candidate",
+            degradation_reason=None,
+            score_breakdown={"candidate_count": 0.0, "feasible_count": 0.0},
+            evidence_events=(),
+        )
+
+    def _score(
+        self, query: str, intent: ToolSelectionIntent
+    ) -> tuple[list[tuple[str, float]], str, str | None]:
+        expanded_query = expand_query_for_intent(query, intent)
+        retriever = self._registry._retriever
+        backend_label = _backend_label(retriever)
+        try:
+            scored = retriever.score(expanded_query)
+            return (
+                sorted(
+                    filter_special_case_scores(intent, scored), key=lambda pair: (-pair[1], pair[0])
+                ),
+                backend_label,
+                None,
+            )
+        except Exception as exc:
+            logger.warning(
+                "route decision: retriever.score failed (%s: %s); "
+                "attempting BM25 companion fallback",
+                type(exc).__name__,
+                exc,
+            )
+            bm25_companion = getattr(retriever, "_bm25", None)
+            if bm25_companion is None:
+                return [], backend_label, f"{backend_label}_score_failed_no_bm25"
+            try:
+                scored = bm25_companion.score(expanded_query)
+            except Exception as bm25_exc:
+                logger.warning(
+                    "route decision: BM25 companion failed (%s: %s); returning empty ranking",
+                    type(bm25_exc).__name__,
+                    bm25_exc,
+                )
+                return [], backend_label, "bm25_companion_failed"
+            return (
+                sorted(
+                    filter_special_case_scores(intent, scored), key=lambda pair: (-pair[1], pair[0])
+                ),
+                "bm25",
+                f"{backend_label}_score_failed",
+            )
+
+    def _active_cards(self) -> tuple[tuple[AdapterCard, ...], tuple[str, ...]]:
+        cards: list[AdapterCard] = []
+        events: list[str] = []
+        for tool in self._registry.all_tools():
+            try:
+                cards.append(build_adapter_card(tool))
+            except Exception as exc:
+                events.append(f"active_card_build_failed:{tool.id}:{type(exc).__name__}")
+        return tuple(cards), tuple(events)
+
+    def _candidate_set(
+        self,
+        scored: Iterable[tuple[str, float]],
+        *,
+        route_intent: ToolSelectionIntent,
+        session_identity: object | None,
+        active_tool_ids: frozenset[str],
+        active_primitives: frozenset[PrimitiveFamily],
+        allowed_source_modes: frozenset[SourceMode],
+        allowed_credentials: frozenset[str] | None,
+    ) -> tuple[tuple[RouteCandidate, ...], tuple[str, ...]]:
+        candidates: list[RouteCandidate] = []
+        evidence_events: list[str] = []
+        for tool_id, raw_score in scored:
+            try:
+                card = build_adapter_card(self._registry.find(tool_id))
+            except ToolNotFoundError:
+                evidence_events.append(f"hard_excluded:missing_registered_tool:{tool_id}")
+                continue
+            except Exception as exc:
+                evidence_events.append(
+                    f"hard_excluded:card_build_failed:{tool_id}:{type(exc).__name__}"
+                )
+                continue
+
+            hard_reasons = hard_exclusion_reasons(
+                card,
+                active_tool_ids=active_tool_ids,
+                allowed_source_modes=allowed_source_modes,
+                allowed_credentials=allowed_credentials,
+            )
+            if hard_reasons:
+                for reason in hard_reasons:
+                    evidence_events.append(f"hard_excluded:{reason}:{tool_id}")
+                continue
+
+            retrieval_score = max(0.0, float(raw_score))
+            filter_reasons = soft_filter_reasons(
+                card,
+                route_intent=route_intent,
+                session_identity=session_identity,
+                active_tool_ids=active_tool_ids,
+                active_primitives=active_primitives,
+            )
+            candidates.append(
+                RouteCandidate(
+                    tool_id=tool_id,
+                    retrieval_score=retrieval_score,
+                    card=card,
+                    status="feasible" if not filter_reasons else "infeasible",
+                    feasible=not filter_reasons,
+                    filter_reasons=filter_reasons,
+                    score_breakdown=score_breakdown(card, retrieval_score, filter_reasons),
+                )
+            )
+        return tuple(candidates), tuple(evidence_events)
+
+
+def _candidate_sort_key(candidate: RouteCandidate) -> tuple[int, float, str]:
+    penalty = len(candidate.filter_reasons) * 1000.0
+    score = candidate.retrieval_score + candidate.score_breakdown["feasibility"] * 100.0 - penalty
+    return (0 if candidate.feasible else 1, -score, candidate.tool_id)
+
+
+def _schema_projection_level(selected_tools: tuple[str, ...]) -> SchemaProjectionLevel:
+    return "summary" if selected_tools else "none"
+
+
+def _clarification_question(
+    candidates: tuple[RouteCandidate, ...], selected_tools: tuple[str, ...]
+) -> str | None:
+    if not candidates or selected_tools:
+        return None
+    missing_slots = sorted(
+        {
+            reason.removeprefix("missing_slot:")
+            for candidate in candidates
+            for reason in candidate.filter_reasons
+            if reason.startswith("missing_slot:")
+        }
+    )
+    if missing_slots:
+        return f"Required slot missing: {', '.join(missing_slots)}."
+    return None
+
+
+def _aggregate_score_breakdown(candidates: tuple[RouteCandidate, ...]) -> dict[str, float]:
+    if not candidates:
+        return {"candidate_count": 0.0, "feasible_count": 0.0}
+    feasible_count = sum(1 for candidate in candidates if candidate.feasible)
+    return {
+        "candidate_count": float(len(candidates)),
+        "feasible_count": float(feasible_count),
+        "top_retrieval": max(candidate.retrieval_score for candidate in candidates),
+    }
+
+
+def _backend_label(retriever: object) -> str:
+    return str(
+        getattr(
+            retriever,
+            "_requested_backend_label",
+            type(retriever).__name__.removesuffix("Backend").lower() or "retrieval",
+        )
+    )

--- a/src/ummaya/tools/routing/decision_types.py
+++ b/src/ummaya/tools/routing/decision_types.py
@@ -11,6 +11,24 @@ from ummaya.tools.routing.types import AdapterCard
 
 SchemaProjectionLevel = Literal["none", "name_only", "summary", "full_schema"]
 FeasibilityStatus = Literal["feasible", "infeasible"]
+RouteStopReason = Literal[
+    "answerable",
+    "needs_input",
+    "permission_required",
+    "handoff_required",
+    "blocked_no_adapter",
+    "blocked_no_credential",
+    "max_turns",
+    "repeated_tool_mismatch",
+    "no_new_evidence",
+    "runtime_tool_failure_unrecovered",
+]
+RouteClarificationReason = Literal[
+    "missing_slots",
+    "equal_candidates",
+    "side_effect_confirmation",
+    "execution_risk_input_fault",
+]
 
 
 class RouteCandidate(BaseModel):
@@ -25,6 +43,16 @@ class RouteCandidate(BaseModel):
     score_breakdown: dict[str, float]
 
 
+class RouteClarificationDecision(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    reason: RouteClarificationReason
+    question: str = Field(min_length=1, max_length=240)
+    missing_slots: tuple[str, ...] = Field(default_factory=tuple)
+    candidate_tool_ids: tuple[str, ...] = Field(default_factory=tuple)
+    evidence_events: tuple[str, ...] = Field(default_factory=tuple)
+
+
 class RouteDecision(BaseModel):
     model_config = ConfigDict(frozen=True, extra="forbid")
 
@@ -37,9 +65,10 @@ class RouteDecision(BaseModel):
     schema_projection_level: SchemaProjectionLevel
     backend_label: str = Field(min_length=1)
     effective_top_k: int = Field(ge=0, le=20)
+    clarification: RouteClarificationDecision | None
     clarification_question: str | None
     permission_gate: bool
-    stop_reason: str | None
+    stop_reason: RouteStopReason
     degradation_reason: str | None
     score_breakdown: dict[str, float]
     evidence_events: tuple[str, ...]

--- a/src/ummaya/tools/routing/decision_types.py
+++ b/src/ummaya/tools/routing/decision_types.py
@@ -1,0 +1,45 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from ummaya.tools.routing.intent import ToolSelectionIntent
+from ummaya.tools.routing.types import AdapterCard
+
+SchemaProjectionLevel = Literal["none", "name_only", "summary", "full_schema"]
+FeasibilityStatus = Literal["feasible", "infeasible"]
+
+
+class RouteCandidate(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tool_id: str = Field(min_length=1)
+    retrieval_score: float = Field(ge=0)
+    card: AdapterCard
+    status: FeasibilityStatus
+    feasible: bool
+    filter_reasons: tuple[str, ...]
+    score_breakdown: dict[str, float]
+
+
+class RouteDecision(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    decision_id: str = Field(min_length=1)
+    query_hash: str = Field(min_length=64, max_length=64)
+    manifest_hash: str = Field(min_length=64, max_length=64)
+    intent: ToolSelectionIntent
+    candidate_set: tuple[RouteCandidate, ...]
+    selected_tools: tuple[str, ...]
+    schema_projection_level: SchemaProjectionLevel
+    backend_label: str = Field(min_length=1)
+    effective_top_k: int = Field(ge=0, le=20)
+    clarification_question: str | None
+    permission_gate: bool
+    stop_reason: str | None
+    degradation_reason: str | None
+    score_breakdown: dict[str, float]
+    evidence_events: tuple[str, ...]

--- a/src/ummaya/tools/routing/feasibility.py
+++ b/src/ummaya/tools/routing/feasibility.py
@@ -1,0 +1,122 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from ummaya.tools.routing.intent import ACTIVE_PRIMITIVES, ToolSelectionIntent
+from ummaya.tools.routing.lint import lint_adapter_card
+from ummaya.tools.routing.types import AdapterCard, PrimitiveFamily, SourceMode
+
+DEFAULT_SOURCE_MODES: tuple[SourceMode, ...] = ("live", "mock")
+SIDE_EFFECT_LEVELS = frozenset({"login", "action", "sign", "send", "verify"})
+PERMISSION_CONTEXT_LEVELS = frozenset({"action", "sign", "send", "verify"})
+
+
+def hard_exclusion_reasons(
+    card: AdapterCard,
+    *,
+    active_tool_ids: frozenset[str],
+    allowed_source_modes: frozenset[SourceMode],
+    allowed_credentials: frozenset[str] | None,
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    if card.tool_id not in active_tool_ids:
+        reasons.append("inactive_adapter")
+    if card.source_mode not in allowed_source_modes:
+        reasons.append(f"disallowed_source_mode:{card.source_mode}")
+    if allowed_credentials is not None:
+        missing_credentials = [
+            requirement
+            for requirement in card.credential_requirements
+            if requirement not in allowed_credentials
+        ]
+        reasons.extend(f"disallowed_credential:{credential}" for credential in missing_credentials)
+    return tuple(dict.fromkeys(reasons))
+
+
+def soft_filter_reasons(
+    card: AdapterCard,
+    *,
+    route_intent: ToolSelectionIntent,
+    session_identity: object | None,
+    active_tool_ids: frozenset[str],
+    active_primitives: frozenset[PrimitiveFamily],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    reasons.extend(
+        f"adapter_card_quality:{violation.code}" for violation in lint_adapter_card(card)
+    )
+    reasons.extend(_missing_slot_reasons(card.required_slots, route_intent.missing_slots))
+    reasons.extend(_permission_reasons(card, route_intent, session_identity))
+    reasons.extend(_prerequisite_reasons(card, active_tool_ids, active_primitives))
+    return tuple(dict.fromkeys(reasons))
+
+
+def score_breakdown(
+    card: AdapterCard,
+    retrieval_score: float,
+    filter_reasons: tuple[str, ...],
+) -> dict[str, float]:
+    return {
+        "retrieval": retrieval_score,
+        "feasibility": 1.0 if not filter_reasons else 0.0,
+        "source_mode": 1.0 if card.source_mode in {"live", "mock"} else 0.0,
+        "permission": 0.0 if any("permission" in reason for reason in filter_reasons) else 1.0,
+        "prerequisite": 0.0 if any("prerequisite" in reason for reason in filter_reasons) else 1.0,
+        "quality": 0.0
+        if any("adapter_card_quality" in reason for reason in filter_reasons)
+        else 1.0,
+    }
+
+
+def requires_permission_gate(card: AdapterCard, *, feasible: bool) -> bool:
+    return feasible and card.side_effect_level in SIDE_EFFECT_LEVELS
+
+
+def source_modes(value: Sequence[SourceMode]) -> frozenset[SourceMode]:
+    return frozenset(value)
+
+
+def _missing_slot_reasons(
+    required_slots: tuple[str, ...],
+    intent_missing_slots: tuple[str, ...],
+) -> tuple[str, ...]:
+    missing = frozenset(intent_missing_slots)
+    return tuple(f"missing_slot:{slot}" for slot in required_slots if slot in missing)
+
+
+def _permission_reasons(
+    card: AdapterCard,
+    intent: ToolSelectionIntent,
+    session_identity: object | None,
+) -> tuple[str, ...]:
+    if card.side_effect_level not in SIDE_EFFECT_LEVELS:
+        return ()
+    reasons: list[str] = []
+    if card.policy_authority_url is None:
+        reasons.append("missing_policy_citation")
+    if (
+        card.side_effect_level in PERMISSION_CONTEXT_LEVELS
+        and not intent.requires_permission
+        and session_identity is None
+    ):
+        reasons.append("permission_context_missing")
+    return tuple(reasons)
+
+
+def _prerequisite_reasons(
+    card: AdapterCard,
+    active_tool_ids: frozenset[str],
+    active_primitives: frozenset[PrimitiveFamily],
+) -> tuple[str, ...]:
+    reasons: list[str] = []
+    primitive_names = frozenset((*ACTIVE_PRIMITIVES, "document"))
+    for prerequisite in card.prerequisite_tools:
+        if prerequisite in primitive_names:
+            if prerequisite not in active_primitives:
+                reasons.append(f"missing_prerequisite_primitive:{prerequisite}")
+            continue
+        if prerequisite not in active_tool_ids:
+            reasons.append(f"missing_prerequisite_tool:{prerequisite}")
+    return tuple(reasons)

--- a/src/ummaya/tools/routing/intent.py
+++ b/src/ummaya/tools/routing/intent.py
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from ummaya.tools.routing.intent_extractor import extract_tool_selection_intent
+from ummaya.tools.routing.intent_types import (
+    ACTIVE_PRIMITIVES,
+    LEGACY_PRIMITIVE_ALIASES,
+    ActivePrimitive,
+    ToolSelectionIntent,
+)
+
+__all__ = [
+    "ACTIVE_PRIMITIVES",
+    "LEGACY_PRIMITIVE_ALIASES",
+    "ActivePrimitive",
+    "ToolSelectionIntent",
+    "extract_tool_selection_intent",
+]

--- a/src/ummaya/tools/routing/intent_extractor.py
+++ b/src/ummaya/tools/routing/intent_extractor.py
@@ -1,0 +1,207 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Collection, Iterable
+
+from ummaya.tools.routing.intent_patterns import (
+    _ADMIN_LOCATION_RE,
+    _ARTIFACT_ID_RE,
+    _COORDINATE_PAIR_RE,
+    _CREDENTIAL_RE,
+    _DOCUMENT_FORMAT_RE,
+    _DOCUMENT_INTENT_RE,
+    _DOCUMENT_LOCAL_HINT_RE,
+    _DOCUMENT_PATH_RE,
+    _DOCUMENT_WRITE_INTENT_RE,
+    _EXPLICIT_TOOL_ID_RE,
+    _PAYMENT_SIDE_EFFECT_RE,
+    _POI_LOCATION_RE,
+    _SIDE_EFFECT_RE,
+    _SUBMIT_SIDE_EFFECT_RE,
+    _WHITESPACE_RE,
+)
+from ummaya.tools.routing.intent_public_data import extract_public_data_refs
+from ummaya.tools.routing.intent_types import (
+    ACTIVE_PRIMITIVES,
+    ActivePrimitive,
+    ToolSelectionIntent,
+)
+
+
+def extract_tool_selection_intent(
+    query: str, *, known_tool_ids: Collection[str] = ()
+) -> ToolSelectionIntent:
+    normalized_query = _normalize_query(query)
+    document_refs = _extract_document_refs(query)
+    location_refs = _extract_location_refs(query)
+    public_data_refs = extract_public_data_refs(query)
+    credential_refs = _extract_credential_refs(query)
+    side_effect_markers = _extract_side_effect_markers(query, document_refs=document_refs)
+    explicit_tool_ids = _extract_explicit_tool_ids(query, known_tool_ids=known_tool_ids)
+    explicit_artifact_ids = _ordered_unique(_ARTIFACT_ID_RE.findall(query))
+    candidate_primitives = _candidate_primitives(
+        normalized_query=normalized_query,
+        document_refs=document_refs,
+        location_refs=location_refs,
+        public_data_refs=public_data_refs,
+        credential_refs=credential_refs,
+        side_effect_markers=side_effect_markers,
+        explicit_tool_ids=explicit_tool_ids,
+    )
+    return ToolSelectionIntent(
+        raw_query=query,
+        normalized_query=normalized_query,
+        intent_verbs=candidate_primitives,
+        entities=(),
+        document_refs=document_refs,
+        location_refs=location_refs,
+        time_refs=(),
+        public_data_refs=public_data_refs,
+        credential_refs=credential_refs,
+        side_effect_markers=side_effect_markers,
+        explicit_tool_ids=explicit_tool_ids,
+        explicit_artifact_ids=explicit_artifact_ids,
+        candidate_primitives=candidate_primitives,
+        missing_slots=_missing_slots(location_refs, public_data_refs),
+        unsafe_assumptions=_unsafe_assumptions(location_refs, public_data_refs),
+        requires_clarification=not normalized_query,
+        requires_permission=bool(credential_refs or side_effect_markers),
+    )
+
+
+def _normalize_query(query: str) -> str:
+    return _WHITESPACE_RE.sub(" ", query.strip()).lower()
+
+
+def _extract_explicit_tool_ids(query: str, *, known_tool_ids: Collection[str]) -> tuple[str, ...]:
+    matches: list[tuple[int, str]] = []
+    for match in _EXPLICIT_TOOL_ID_RE.finditer(query):
+        matches.append((match.start(1), match.group(1)))
+    query_lower = query.lower()
+    for tool_id in known_tool_ids:
+        index = query_lower.find(tool_id.lower())
+        if index >= 0:
+            matches.append((index, tool_id))
+    return _ordered_unique(value for _index, value in sorted(matches))
+
+
+def _extract_document_refs(query: str) -> tuple[str, ...]:
+    refs: list[str] = []
+    refs.extend(match.group(1).strip() for match in _DOCUMENT_PATH_RE.finditer(query))
+    refs.extend(f"format:{match.group(1).lower()}" for match in _DOCUMENT_FORMAT_RE.finditer(query))
+    if _is_document_harness_query(query):
+        refs.append("document_harness")
+    return _ordered_unique(refs)
+
+
+def _extract_location_refs(query: str) -> tuple[str, ...]:
+    refs: list[str] = []
+    for match in _COORDINATE_PAIR_RE.finditer(query):
+        lat = float(match.group("lat"))
+        lon = float(match.group("lon"))
+        if -90.0 <= lat <= 90.0 and -180.0 <= lon <= 180.0:
+            refs.append(f"coordinate:{_format_decimal(lat)},{_format_decimal(lon)}")
+    if _POI_LOCATION_RE.search(query):
+        refs.append("poi")
+    if _ADMIN_LOCATION_RE.search(query):
+        refs.append("admin")
+    return _ordered_unique(refs)
+
+
+def _extract_credential_refs(query: str) -> tuple[str, ...]:
+    if not _CREDENTIAL_RE.search(query):
+        return ()
+    refs: list[str] = []
+    lowered = query.lower()
+    if "간편인증" in query:
+        refs.append("simple_auth")
+    if "모바일" in query and "신분증" in query:
+        refs.append("mobile_id")
+    if "인증서" in query:
+        refs.append("certificate")
+    if "동의" in query or "consent" in lowered or "delegation" in lowered:
+        refs.append("delegation")
+    if not refs:
+        refs.append("credential")
+    return _ordered_unique(refs)
+
+
+def _extract_side_effect_markers(query: str, *, document_refs: tuple[str, ...]) -> tuple[str, ...]:
+    refs: list[str] = []
+    if _SIDE_EFFECT_RE.search(query):
+        refs.append("action")
+    if _SUBMIT_SIDE_EFFECT_RE.search(query):
+        refs.append("submit")
+    if _PAYMENT_SIDE_EFFECT_RE.search(query):
+        refs.append("payment")
+    if document_refs and _DOCUMENT_WRITE_INTENT_RE.search(query):
+        refs.append("document_write")
+    return _ordered_unique(refs)
+
+
+def _candidate_primitives(
+    *,
+    normalized_query: str,
+    document_refs: tuple[str, ...],
+    location_refs: tuple[str, ...],
+    public_data_refs: tuple[str, ...],
+    credential_refs: tuple[str, ...],
+    side_effect_markers: tuple[str, ...],
+    explicit_tool_ids: tuple[str, ...],
+) -> tuple[ActivePrimitive, ...]:
+    primitives: set[ActivePrimitive] = set()
+    if normalized_query or public_data_refs or document_refs or explicit_tool_ids:
+        primitives.add("find")
+    if location_refs:
+        primitives.add("locate")
+    if side_effect_markers:
+        primitives.add("send")
+    if credential_refs:
+        primitives.add("check")
+    return tuple(primitive for primitive in ACTIVE_PRIMITIVES if primitive in primitives)
+
+
+def _missing_slots(
+    location_refs: tuple[str, ...], public_data_refs: tuple[str, ...]
+) -> tuple[str, ...]:
+    has_coordinate = any(ref.startswith("coordinate:") for ref in location_refs)
+    coordinate_bound_refs = {"emergency_medical", "aed"}
+    if not has_coordinate and any(ref in coordinate_bound_refs for ref in public_data_refs):
+        return ("lat", "lon")
+    return ()
+
+
+def _unsafe_assumptions(
+    location_refs: tuple[str, ...], public_data_refs: tuple[str, ...]
+) -> tuple[str, ...]:
+    if "poi" in location_refs and not any(ref.startswith("coordinate:") for ref in location_refs):
+        return ("poi_requires_location_resolution",)
+    return ()
+
+
+def _is_document_harness_query(query: str) -> bool:
+    return bool(
+        _DOCUMENT_PATH_RE.search(query)
+        or (_DOCUMENT_FORMAT_RE.search(query) and _DOCUMENT_INTENT_RE.search(query))
+        or (
+            _DOCUMENT_INTENT_RE.search(query)
+            and _DOCUMENT_WRITE_INTENT_RE.search(query)
+            and _DOCUMENT_LOCAL_HINT_RE.search(query)
+        )
+    )
+
+
+def _format_decimal(value: float) -> str:
+    return f"{value:.6f}".rstrip("0").rstrip(".")
+
+
+def _ordered_unique(values: Iterable[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return tuple(ordered)

--- a/src/ummaya/tools/routing/intent_patterns.py
+++ b/src/ummaya/tools/routing/intent_patterns.py
@@ -112,6 +112,11 @@ _PPS_SHOPPING_RE = re.compile(
     r"(종합\s*쇼핑몰|쇼핑몰|계약\s*물품|물품\s*조회|shopping\s*mall)",
     re.IGNORECASE,
 )
+_AIRKOREA_AIR_QUALITY_RE = re.compile(
+    r"(미세먼지|초미세먼지|초미세|대기질|대기오염|공기질|마스크|"
+    r"pm\s*2\.?5|pm\s*10|air\s*korea|airkorea|air\s*quality|airquality)",
+    re.IGNORECASE,
+)
 _KCUE_REGIONAL_RE = re.compile(
     r"(대학알리미|대학정보공시|학교구분코드|schl[_\s-]?div[_\s-]?cd|KCUE|"
     r"지역별\s*(등록금|재정)|외국인\s*유학생|foreign\s+student|international\s+student)",

--- a/src/ummaya/tools/routing/intent_patterns.py
+++ b/src/ummaya/tools/routing/intent_patterns.py
@@ -1,0 +1,155 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import re
+
+_WHITESPACE_RE = re.compile(r"\s+")
+_EXPLICIT_TOOL_ID_RE = re.compile(
+    r"(?:tool_id|adapter|도구)\s*[:=]\s*`?([a-z][a-z0-9_]*(?:\.[a-z][a-z0-9_]*)?)`?",
+    re.IGNORECASE,
+)
+_ARTIFACT_ID_RE = re.compile(
+    r"\b(?:artifact|source|working|derivative|render|viewport)-[A-Za-z0-9_-]+\b"
+)
+_DOCUMENT_PATH_RE = re.compile(
+    r"(?:^|[\s:'\"(])((?:~|/|[A-Za-z]:\\|\.{1,2}/)?[^\s:'\"]*"
+    r"\.(?:hwpx|hwp|docx|pdf|xlsx|pptx))\b",
+    re.IGNORECASE,
+)
+_DOCUMENT_FORMAT_RE = re.compile(r"\b(hwpx|hwp|docx|pdf|xlsx|pptx)\b", re.IGNORECASE)
+_DOCUMENT_INTENT_RE = re.compile(
+    r"(문서|공문서|양식|서식|파일|작성|저장|렌더|미리보기|변경사항|"
+    r"\bdiff\b|\bcompact\b|\bdocument\b|\bfile\b|\bform\b|\brender\b|\bsave\b|\bwrite\b)",
+    re.IGNORECASE,
+)
+_DOCUMENT_WRITE_INTENT_RE = re.compile(
+    r"(작성|수정|편집|채우|채워|입력|변경|저장|write|edit|fill|apply|save)",
+    re.IGNORECASE,
+)
+_DOCUMENT_LOCAL_HINT_RE = re.compile(
+    r"(다운로드|downloads?|폴더|파일|양식|서식|활동일지|신청서|등본|증명서)",
+    re.IGNORECASE,
+)
+_COORDINATE_PAIR_RE = re.compile(
+    r"(?P<lat>[+-]?\d{1,2}(?:\.\d+)?)\s*,\s*(?P<lon>[+-]?\d{2,3}(?:\.\d+)?)"
+)
+_POI_LOCATION_RE = re.compile(
+    r"(근처|주변|인근|가까운|역|터미널|공항|캠퍼스|대학교|대학|해수욕장|시장|공원|랜드마크)"
+)
+_ADMIN_LOCATION_RE = re.compile(
+    r"(?:[가-힣]{2,}(?:시|군|구|동|읍|면)\b|[가-힣0-9]{2,}(?<!으)(?:로|길)\b)"
+)
+_PUBLIC_DATA_OPERATION_RE = re.compile(
+    r"\b(getSurfaceChart|getAuxillaryChart|SEA\d{4}|FinancesService|"
+    r"StudentService|WthrChartInfoService)\b",
+    re.IGNORECASE,
+)
+_KMA_GIMHAE_AIRPORT_RE = re.compile(r"(김해(?:공항)?|Gimhae|RKPK)", re.IGNORECASE)
+_KMA_GIMPO_AIRPORT_RE = re.compile(r"(김포(?:공항)?|Gimpo|RKSS)", re.IGNORECASE)
+_KMA_AIRPORT_AVIATION_RE = re.compile(
+    r"(AMOS|METAR|SPECI|RVR|항공기상|공항기상|활주로|runway|aviation|"
+    r"비행기|항공편|비행편|이륙|착륙|결항|지연|운항|뜰\s*만|뜨나|뜰\s*수|"
+    r"flight|take\s*off|landing|delay|cancel)",
+    re.IGNORECASE,
+)
+_KMA_EXPLICIT_METAR_RE = re.compile(r"(\bMETAR\b|\bSPECI\b|해독자료)", re.IGNORECASE)
+_KMA_RUNWAY_AREA_RE = re.compile(
+    r"(AMOS|활주로|RVR|runway|시정|visibility|공항기상관측|매분)",
+    re.IGNORECASE,
+)
+_KMA_ANALYSIS_CHART_RE = re.compile(
+    r"(분석일기도|지상일기도|보조일기도|WthrChartInfoService|getSurfaceChart|"
+    r"getAuxillaryChart|synoptic\s+chart)",
+    re.IGNORECASE,
+)
+_KMA_ANALYSIS_DATA_RE = re.compile(
+    r"(분석자료|이미\s*분석|고해상도\s*격자|객관분석|AWS\s*객관|지도\s*자료|"
+    r"일기도|분석일기도|비구름|바람\s*흐름|날씨\s*흐름|공식\s*기상자료|전국\s*날씨|"
+    r"synoptic|weather\s*chart|objective\s*analysis|high[-\s]?resolution|grid)",
+    re.IGNORECASE,
+)
+_KMA_ANALYSIS_MAP_RE = re.compile(
+    r"(일기도|분석일기도|지도\s*자료|비구름|바람\s*흐름|날씨\s*흐름|전국\s*날씨|"
+    r"synoptic|weather\s*chart)",
+    re.IGNORECASE,
+)
+_KMA_ANALYSIS_POINT_RE = re.compile(
+    r"(주변|근처|특정지점|좌표|위도|경도|\blat\b|\blon\b|공항\s*주변)",
+    re.IGNORECASE,
+)
+_KMA_LIFESTYLE_WEATHER_RE = re.compile(
+    r"(날씨|현재\s*기상|실황|관측|예보|기온|습도|풍속|지금\s*비|"
+    r"비\s*(?:와|오|올|내리)|우산|강수|소나기|산책|퇴근|"
+    r"current\s+weather|forecast|rain|umbrella|precipitation|temperature)",
+    re.IGNORECASE,
+)
+_EMERGENCY_RE = re.compile(r"(응급|응급실|응급의료|\bemergency\b|\ber\b)", re.IGNORECASE)
+_IMPLICIT_EMERGENCY_RE = re.compile(
+    r"(사람이\s*(?:쓰러|쓰러졌|쓰러져)|의식(?:을)?\s*(?:잃|없)|"
+    r"갑자기\s*쓰러|쓰러진\s*사람|위급|심정지|호흡(?:이)?\s*없|"
+    r"collapsed|unconscious|cardiac\s*arrest)",
+    re.IGNORECASE,
+)
+_AED_RE = re.compile(r"(\bAED\b|자동심장충격기|자동제세동기|제세동기)", re.IGNORECASE)
+_TRAFFIC_HAZARD_RE = re.compile(
+    r"(교통사고|사고\s*위험|사고다발|위험\s*(?:구간|도로|지점)|어린이보호구역|보호구역|"
+    r"도로\s*구간|accident|hazard|hotspot)",
+    re.IGNORECASE,
+)
+_TRAFFIC_HAZARD_SPECIFIC_RE = re.compile(
+    r"(사고\s*위험|위험\s*(?:구간|도로|지점)|어린이보호구역|보호구역|스쿨존|"
+    r"도로\s*구간|행정동코드|adm_cd|hazard|hotspot)",
+    re.IGNORECASE,
+)
+_MOF_OCEAN_WATER_QUALITY_RE = re.compile(
+    r"(해양\s*수질|해양수질|수질\s*자동\s*측정|용존산소|\bpH\b|"
+    r"water\s+quality|ocean\s+water)",
+    re.IGNORECASE,
+)
+_PPS_BID_RE = re.compile(r"(입찰|나라장터|조달청|\bbid\b|procurement|tender)", re.IGNORECASE)
+_PPS_SHOPPING_RE = re.compile(
+    r"(종합\s*쇼핑몰|쇼핑몰|계약\s*물품|물품\s*조회|shopping\s*mall)",
+    re.IGNORECASE,
+)
+_KCUE_REGIONAL_RE = re.compile(
+    r"(대학알리미|대학정보공시|학교구분코드|schl[_\s-]?div[_\s-]?cd|KCUE|"
+    r"지역별\s*(등록금|재정)|외국인\s*유학생|foreign\s+student|international\s+student)",
+    re.IGNORECASE,
+)
+_KCUE_REGIONAL_FINANCE_RE = re.compile(
+    r"(지역별\s*(등록금|재정)|등록금\s*(현황|지역별)?|tuition|finance)",
+    re.IGNORECASE,
+)
+_KCUE_REGIONAL_FOREIGN_STUDENT_RE = re.compile(
+    r"(외국인\s*유학생|유학생\s*현황|foreign\s+student|international\s+student)",
+    re.IGNORECASE,
+)
+_HIRA_MEDICAL_DETAIL_RE = re.compile(
+    r"((병원|의료기관|의원).*(상세|진료과|진료과목|진료시간|주차)|"
+    r"(상세|진료시간|주차|응급실).*(병원|의료기관|의원)|ykiho|detail)",
+    re.IGNORECASE,
+)
+_MOIS_EMERGENCY_CALL_BOX_RE = re.compile(
+    r"(안전\s*비상벨|비상벨|긴급\s*신고함|긴급신고함|방범벨|"
+    r"emergency\s+call\s+box)",
+    re.IGNORECASE,
+)
+_GYERYONG_ASSISTIVE_CHARGER_RE = re.compile(
+    r"((전동보장구|전동\s*휠체어|보장구|장애인).*(충전|충전소|충전장소)|"
+    r"(충전|충전소|충전장소).*(전동보장구|전동\s*휠체어|보장구|장애인)|"
+    r"계룡시?.*(충전소|충전\s*장소))",
+    re.IGNORECASE,
+)
+_CREDENTIAL_RE = re.compile(
+    r"(간편인증|본인인증|모바일\s*신분증|공동인증서|금융인증서|인증서|"
+    r"delegation|consent|verify|login|로그인|동의)",
+    re.IGNORECASE,
+)
+_SIDE_EFFECT_RE = re.compile(
+    r"(신청|제출|신고|송신|납부|결제|발급|저장|수정|편집|채우|"
+    r"submit|send|pay|issue|save|write|edit|fill|apply)",
+    re.IGNORECASE,
+)
+_SUBMIT_SIDE_EFFECT_RE = re.compile(r"(신청|제출|신고|submit|send|apply)", re.IGNORECASE)
+_PAYMENT_SIDE_EFFECT_RE = re.compile(r"(납부|결제|pay)", re.IGNORECASE)

--- a/src/ummaya/tools/routing/intent_public_data.py
+++ b/src/ummaya/tools/routing/intent_public_data.py
@@ -1,0 +1,140 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from ummaya.tools.routing.intent_patterns import (
+    _AED_RE,
+    _EMERGENCY_RE,
+    _GYERYONG_ASSISTIVE_CHARGER_RE,
+    _HIRA_MEDICAL_DETAIL_RE,
+    _IMPLICIT_EMERGENCY_RE,
+    _KCUE_REGIONAL_FINANCE_RE,
+    _KCUE_REGIONAL_FOREIGN_STUDENT_RE,
+    _KCUE_REGIONAL_RE,
+    _KMA_AIRPORT_AVIATION_RE,
+    _KMA_ANALYSIS_CHART_RE,
+    _KMA_ANALYSIS_DATA_RE,
+    _KMA_ANALYSIS_MAP_RE,
+    _KMA_ANALYSIS_POINT_RE,
+    _KMA_EXPLICIT_METAR_RE,
+    _KMA_GIMHAE_AIRPORT_RE,
+    _KMA_GIMPO_AIRPORT_RE,
+    _KMA_LIFESTYLE_WEATHER_RE,
+    _KMA_RUNWAY_AREA_RE,
+    _MOF_OCEAN_WATER_QUALITY_RE,
+    _MOIS_EMERGENCY_CALL_BOX_RE,
+    _PPS_BID_RE,
+    _PPS_SHOPPING_RE,
+    _PUBLIC_DATA_OPERATION_RE,
+    _TRAFFIC_HAZARD_RE,
+    _TRAFFIC_HAZARD_SPECIFIC_RE,
+)
+
+
+def extract_public_data_refs(query: str) -> tuple[str, ...]:
+    refs = [f"operation:{match.group(1)}" for match in _PUBLIC_DATA_OPERATION_RE.finditer(query)]
+    refs.extend(_extract_kma_public_data_refs(query))
+    refs.extend(_extract_emergency_public_data_refs(query))
+    refs.extend(_extract_domain_public_data_refs(query))
+    return _ordered_unique(refs)
+
+
+def _extract_kma_public_data_refs(query: str) -> list[str]:
+    has_airport_aviation = bool(_KMA_AIRPORT_AVIATION_RE.search(query))
+    has_emergency = bool(_EMERGENCY_RE.search(query) or _IMPLICIT_EMERGENCY_RE.search(query))
+    refs: list[str] = []
+    refs.extend(_extract_kma_aviation_refs(query, has_airport_aviation=has_airport_aviation))
+    refs.extend(_extract_kma_analysis_refs(query))
+    if _is_lifestyle_weather_ref(query, has_airport_aviation, has_emergency):
+        refs.append("kma_lifestyle_weather")
+    return refs
+
+
+def _extract_kma_aviation_refs(query: str, *, has_airport_aviation: bool) -> list[str]:
+    refs: list[str] = []
+    if has_airport_aviation:
+        refs.append("kma_airport_aviation")
+    if _KMA_GIMHAE_AIRPORT_RE.search(query):
+        refs.append("kma_gimhae_airport")
+    if _KMA_GIMPO_AIRPORT_RE.search(query):
+        refs.append("kma_gimpo_airport")
+    if _KMA_EXPLICIT_METAR_RE.search(query):
+        refs.append("kma_explicit_metar")
+    if _KMA_RUNWAY_AREA_RE.search(query):
+        refs.append("kma_runway_area")
+    return refs
+
+
+def _extract_kma_analysis_refs(query: str) -> list[str]:
+    refs: list[str] = []
+    if _KMA_ANALYSIS_CHART_RE.search(query):
+        refs.append("kma_analysis_chart")
+    if _KMA_ANALYSIS_DATA_RE.search(query):
+        refs.append("kma_analysis_data")
+    if _KMA_ANALYSIS_MAP_RE.search(query):
+        refs.append("kma_analysis_map")
+    if _KMA_ANALYSIS_POINT_RE.search(query):
+        refs.append("kma_analysis_point")
+    return refs
+
+
+def _is_lifestyle_weather_ref(query: str, has_airport_aviation: bool, has_emergency: bool) -> bool:
+    return bool(
+        _KMA_LIFESTYLE_WEATHER_RE.search(query)
+        and not has_airport_aviation
+        and not has_emergency
+        and not _KMA_ANALYSIS_DATA_RE.search(query)
+        and not _TRAFFIC_HAZARD_RE.search(query)
+        and not _MOF_OCEAN_WATER_QUALITY_RE.search(query)
+    )
+
+
+def _extract_emergency_public_data_refs(query: str) -> list[str]:
+    refs: list[str] = []
+    has_call_box = bool(_MOIS_EMERGENCY_CALL_BOX_RE.search(query))
+    has_emergency = bool(_EMERGENCY_RE.search(query) or _IMPLICIT_EMERGENCY_RE.search(query))
+    if has_emergency and not has_call_box:
+        refs.append("emergency_medical")
+    if _IMPLICIT_EMERGENCY_RE.search(query) and not has_call_box:
+        refs.append("implicit_emergency")
+    if _AED_RE.search(query):
+        refs.append("aed")
+    if has_call_box:
+        refs.append("mois_emergency_call_box")
+    return refs
+
+
+def _extract_domain_public_data_refs(query: str) -> list[str]:
+    refs: list[str] = []
+    if _TRAFFIC_HAZARD_RE.search(query):
+        refs.append("traffic_hazard")
+    if _TRAFFIC_HAZARD_SPECIFIC_RE.search(query):
+        refs.append("traffic_hazard_specific")
+    if _MOF_OCEAN_WATER_QUALITY_RE.search(query):
+        refs.append("mof_ocean_water_quality")
+    if _PPS_BID_RE.search(query) and not _PPS_SHOPPING_RE.search(query):
+        refs.append("pps_bid")
+    has_kcue_finance = bool(_KCUE_REGIONAL_FINANCE_RE.search(query))
+    has_kcue_foreign_student = bool(_KCUE_REGIONAL_FOREIGN_STUDENT_RE.search(query))
+    if _KCUE_REGIONAL_RE.search(query) or has_kcue_finance or has_kcue_foreign_student:
+        refs.append("kcue_regional")
+    if has_kcue_finance:
+        refs.append("kcue_regional_finance")
+    if has_kcue_foreign_student:
+        refs.append("kcue_regional_foreign_student")
+    if _HIRA_MEDICAL_DETAIL_RE.search(query):
+        refs.append("hira_medical_detail")
+    if _GYERYONG_ASSISTIVE_CHARGER_RE.search(query):
+        refs.append("gyeryong_assistive_charger")
+    return refs
+
+
+def _ordered_unique(values: list[str]) -> tuple[str, ...]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return tuple(ordered)

--- a/src/ummaya/tools/routing/intent_public_data.py
+++ b/src/ummaya/tools/routing/intent_public_data.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from ummaya.tools.routing.intent_patterns import (
     _AED_RE,
+    _AIRKOREA_AIR_QUALITY_RE,
     _EMERGENCY_RE,
     _GYERYONG_ASSISTIVE_CHARGER_RE,
     _HIRA_MEDICAL_DETAIL_RE,
@@ -83,6 +84,7 @@ def _is_lifestyle_weather_ref(query: str, has_airport_aviation: bool, has_emerge
         _KMA_LIFESTYLE_WEATHER_RE.search(query)
         and not has_airport_aviation
         and not has_emergency
+        and not _AIRKOREA_AIR_QUALITY_RE.search(query)
         and not _KMA_ANALYSIS_DATA_RE.search(query)
         and not _TRAFFIC_HAZARD_RE.search(query)
         and not _MOF_OCEAN_WATER_QUALITY_RE.search(query)
@@ -110,8 +112,7 @@ def _extract_domain_public_data_refs(query: str) -> list[str]:
         refs.append("traffic_hazard")
     if _TRAFFIC_HAZARD_SPECIFIC_RE.search(query):
         refs.append("traffic_hazard_specific")
-    if _MOF_OCEAN_WATER_QUALITY_RE.search(query):
-        refs.append("mof_ocean_water_quality")
+    refs.extend(_extract_environment_public_data_refs(query))
     if _PPS_BID_RE.search(query) and not _PPS_SHOPPING_RE.search(query):
         refs.append("pps_bid")
     has_kcue_finance = bool(_KCUE_REGIONAL_FINANCE_RE.search(query))
@@ -126,6 +127,15 @@ def _extract_domain_public_data_refs(query: str) -> list[str]:
         refs.append("hira_medical_detail")
     if _GYERYONG_ASSISTIVE_CHARGER_RE.search(query):
         refs.append("gyeryong_assistive_charger")
+    return refs
+
+
+def _extract_environment_public_data_refs(query: str) -> list[str]:
+    refs: list[str] = []
+    if _MOF_OCEAN_WATER_QUALITY_RE.search(query):
+        refs.append("mof_ocean_water_quality")
+    if _AIRKOREA_AIR_QUALITY_RE.search(query):
+        refs.append("airkorea_air_quality")
     return refs
 
 

--- a/src/ummaya/tools/routing/intent_types.py
+++ b/src/ummaya/tools/routing/intent_types.py
@@ -1,0 +1,48 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict
+
+ActivePrimitive = Literal["find", "locate", "send", "check"]
+
+ACTIVE_PRIMITIVES: Final[tuple[ActivePrimitive, ...]] = ("find", "locate", "send", "check")
+LEGACY_PRIMITIVE_ALIASES: Final[dict[str, ActivePrimitive]] = {
+    "lookup": "find",
+    "resolve_location": "locate",
+    "submit": "send",
+    "verify": "check",
+}
+
+
+class ToolSelectionIntent(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    raw_query: str
+    normalized_query: str
+    intent_verbs: tuple[ActivePrimitive, ...]
+    entities: tuple[str, ...]
+    document_refs: tuple[str, ...]
+    location_refs: tuple[str, ...]
+    time_refs: tuple[str, ...]
+    public_data_refs: tuple[str, ...]
+    credential_refs: tuple[str, ...]
+    side_effect_markers: tuple[str, ...]
+    explicit_tool_ids: tuple[str, ...]
+    explicit_artifact_ids: tuple[str, ...]
+    candidate_primitives: tuple[ActivePrimitive, ...]
+    missing_slots: tuple[str, ...]
+    unsafe_assumptions: tuple[str, ...]
+    requires_clarification: bool
+    requires_permission: bool
+
+    def has_location_ref(self, value: str) -> bool:
+        return value in self.location_refs
+
+    def has_public_data_ref(self, value: str) -> bool:
+        return value in self.public_data_refs
+
+    def has_document_ref(self, value: str) -> bool:
+        return value in self.document_refs

--- a/src/ummaya/tools/routing/lint.py
+++ b/src/ummaya/tools/routing/lint.py
@@ -1,0 +1,78 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from ummaya.tools.routing.types import (
+    RAW_SCHEMA_MARKERS,
+    AdapterCard,
+    AdapterCardQualityViolation,
+)
+
+
+def lint_adapter_card(card: AdapterCard) -> tuple[AdapterCardQualityViolation, ...]:
+    violations: list[AdapterCardQualityViolation] = []
+    if card.source_mode in ("live", "mock") and not card.policy_authority_url:
+        violations.append(
+            AdapterCardQualityViolation(
+                code="missing_policy_citation",
+                message="live/mock adapter cards must cite an agency policy URL",
+            )
+        )
+    if not card.input_schema_summary:
+        violations.append(
+            AdapterCardQualityViolation(
+                code="missing_required_slot_metadata",
+                message="adapter cards must summarize input slots",
+            )
+        )
+    if not card.safety_annotations:
+        violations.append(
+            AdapterCardQualityViolation(
+                code="missing_safety_annotations",
+                message="adapter cards must expose safety annotations",
+            )
+        )
+    if not card.credential_requirements:
+        violations.append(
+            AdapterCardQualityViolation(
+                code="missing_credential_requirements",
+                message="adapter cards must expose credential requirements",
+            )
+        )
+    if not card.examples_ko or not card.examples_en:
+        violations.append(
+            AdapterCardQualityViolation(
+                code="missing_examples",
+                message="adapter cards must include Korean and English examples",
+            )
+        )
+    if not card.negative_examples:
+        violations.append(
+            AdapterCardQualityViolation(
+                code="missing_negative_examples",
+                message="adapter cards must include negative examples",
+            )
+        )
+    if not card.limitations:
+        violations.append(
+            AdapterCardQualityViolation(
+                code="missing_limitations",
+                message="adapter cards must state routing limitations",
+            )
+        )
+    if any(marker in card.routing_text for marker in RAW_SCHEMA_MARKERS):
+        violations.append(
+            AdapterCardQualityViolation(
+                code="raw_schema_leakage",
+                message="routing_text must not embed raw JSON schema",
+            )
+        )
+    return tuple(violations)
+
+
+def assert_adapter_card_quality(card: AdapterCard) -> None:
+    violations = lint_adapter_card(card)
+    if not violations:
+        return
+    detail = ", ".join(f"{violation.code}: {violation.message}" for violation in violations)
+    raise ValueError(f"AdapterCard quality violations: {detail}")

--- a/src/ummaya/tools/routing/metadata.py
+++ b/src/ummaya/tools/routing/metadata.py
@@ -1,0 +1,174 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import assert_never
+
+from ummaya.tools.models import GovAPITool, MockFidelityGrade
+from ummaya.tools.routing.schema import unique
+from ummaya.tools.routing.types import (
+    AdapterCardError,
+    PrimitiveFamily,
+    SchemaFieldSummary,
+    SideEffectLevel,
+    SourceMode,
+)
+
+
+def primitive_family(value: str | None) -> PrimitiveFamily:
+    match value:
+        case "find":
+            return "find"
+        case "locate":
+            return "locate"
+        case "send":
+            return "send"
+        case "check":
+            return "check"
+        case "document":
+            return "document"
+        case None:
+            raise AdapterCardError("AdapterCard requires GovAPITool.primitive to be declared")
+        case _:
+            raise AdapterCardError(f"Unsupported adapter primitive for AdapterCard: {value!r}")
+
+
+def source_mode_for_tool(tool: GovAPITool) -> SourceMode:
+    return "mock" if tool.adapter_mode == "mock" else "live"
+
+
+def side_effect_level_for_tool(
+    tool: GovAPITool,
+    primitive: PrimitiveFamily,
+) -> SideEffectLevel:
+    if tool.policy is not None:
+        match tool.policy.citizen_facing_gate:
+            case "read-only":
+                return "read_only"
+            case "login":
+                return "login"
+            case "action":
+                return "action"
+            case "sign":
+                return "sign"
+            case "send":
+                return "send"
+            case unreachable_gate:
+                assert_never(unreachable_gate)
+    match primitive:
+        case "send":
+            return "send"
+        case "check":
+            return "verify"
+        case "find" | "locate" | "document":
+            return "read_only"
+        case unreachable_primitive:
+            assert_never(unreachable_primitive)
+
+
+def mock_fidelity_grade_for_tool(tool: GovAPITool) -> MockFidelityGrade:
+    if tool.adapter_mode != "mock":
+        return "not_applicable"
+    if tool.mock_fidelity_grade == "not_applicable":
+        return "unknown"
+    return tool.mock_fidelity_grade
+
+
+def credential_requirements_for_tool(tool: GovAPITool) -> tuple[str, ...]:
+    requirements: list[str] = [tool.auth_type]
+    if tool.published_tier_minimum is not None:
+        requirements.append(tool.published_tier_minimum)
+    if tool.nist_aal_hint is not None:
+        requirements.append(tool.nist_aal_hint)
+    return tuple(unique(requirements))
+
+
+def capabilities_for_tool(tool: GovAPITool, primitive: PrimitiveFamily) -> tuple[str, ...]:
+    return tuple(unique([primitive, *tool.category, tool.name_ko]))
+
+
+def entity_types_for_tool(
+    input_summary: Sequence[SchemaFieldSummary],
+    categories: Sequence[str],
+) -> tuple[str, ...]:
+    names = [field.name for field in input_summary]
+    if names:
+        return tuple(names)
+    return tuple(unique(categories))
+
+
+def prerequisite_tools_for_tool(tool: GovAPITool, primitive: PrimitiveFamily) -> tuple[str, ...]:
+    description = (tool.llm_description or "").lower()
+    if primitive == "send" or "prior check" in description or "delegation" in description:
+        return ("check",)
+    return ()
+
+
+def examples_ko_for_tool(tool: GovAPITool) -> tuple[str, ...]:
+    if tool.trigger_examples:
+        return tuple(tool.trigger_examples)
+    return (tool.name_ko,)
+
+
+def examples_en_for_tool(tool: GovAPITool, primitive: PrimitiveFamily) -> tuple[str, ...]:
+    domain = tool.category[0] if tool.category else tool.id
+    return (f"Use {tool.id} to {primitive} {domain} information.",)
+
+
+def limitations_for_tool(
+    tool: GovAPITool,
+    source_mode: SourceMode,
+    policy_authority_url: str | None,
+) -> tuple[str, ...]:
+    limitations = [f"Requires registry source_mode {source_mode} and auth_type {tool.auth_type}."]
+    if source_mode == "mock":
+        limitations.append("Mock output may mirror shape without live upstream freshness.")
+    if policy_authority_url is None:
+        limitations.append("No agency policy citation is registered for this adapter.")
+    return tuple(limitations)
+
+
+def safety_annotations_for_tool(
+    tool: GovAPITool,
+    side_effect_level: SideEffectLevel,
+) -> tuple[str, ...]:
+    values = [
+        f"side_effect_level:{side_effect_level}",
+        f"auth_type:{tool.auth_type}",
+        f"concurrency_safe:{str(tool.is_concurrency_safe).lower()}",
+    ]
+    if tool.policy is not None:
+        values.append(f"citizen_gate:{tool.policy.citizen_facing_gate}")
+    return tuple(values)
+
+
+def domain_for_tool(tool: GovAPITool) -> str:
+    if tool.category:
+        return tool.category[0]
+    return tool.id
+
+
+def routing_text(
+    *,
+    tool_id: str,
+    primitive: PrimitiveFamily,
+    agency: str,
+    domain: str,
+    capabilities: Sequence[str],
+    required_slots: Sequence[str],
+    examples_ko: Sequence[str],
+    limitations: Sequence[str],
+) -> str:
+    return " | ".join(
+        (
+            f"tool_id={tool_id}",
+            f"primitive={primitive}",
+            f"agency={agency}",
+            f"domain={domain}",
+            f"capabilities={', '.join(capabilities)}",
+            f"required_slots={', '.join(required_slots) or 'none'}",
+            f"examples_ko={'; '.join(examples_ko)}",
+            f"limitations={'; '.join(limitations)}",
+        )
+    )

--- a/src/ummaya/tools/routing/projection.py
+++ b/src/ummaya/tools/routing/projection.py
@@ -1,0 +1,329 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterable, Mapping
+from typing import TYPE_CHECKING
+
+from pydantic import BaseModel, ConfigDict
+
+from ummaya.tools.errors import ToolNotFoundError
+from ummaya.tools.models import GovAPITool
+from ummaya.tools.routing.decision_types import RouteCandidate, RouteDecision, SchemaProjectionLevel
+from ummaya.tools.routing.schema import model_json_schema
+
+if TYPE_CHECKING:
+    from ummaya.tools.registry import ToolRegistry
+
+
+class AvailableAdaptersProjection(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    content: str | None
+    tool_ids: tuple[str, ...]
+    schema_projection_level: SchemaProjectionLevel
+
+
+def build_available_adapters_projection(
+    decision: RouteDecision,
+    registry: ToolRegistry,
+    *,
+    query: str,
+    projection_level: SchemaProjectionLevel | None = None,
+    max_visible: int = 5,
+    visible_tool_ids: Iterable[str] | None = None,
+    exclude_tool_ids: Iterable[str] = (),
+) -> AvailableAdaptersProjection:
+    level = projection_level or decision.schema_projection_level
+    if level == "none":
+        return AvailableAdaptersProjection(
+            content=None,
+            tool_ids=(),
+            schema_projection_level=level,
+        )
+
+    visible = _selected_candidates(
+        decision,
+        max_visible=max_visible,
+        visible_tool_ids=visible_tool_ids,
+        exclude_tool_ids=exclude_tool_ids,
+    )
+    if not visible:
+        return AvailableAdaptersProjection(
+            content=None,
+            tool_ids=(),
+            schema_projection_level="none",
+        )
+
+    tool_ids = tuple(candidate.tool_id for candidate in visible)
+    lines: list[str] = [
+        (
+            f'<available_adapters query="{_xml_attr(query[:120])}" '
+            f'decision_id="{decision.decision_id}" '
+            f'backend="{_xml_attr(decision.backend_label)}" '
+            f'schema_projection="{level}">'
+        ),
+        (
+            f"RouteDecision candidates (top {len(visible)}, backend={decision.backend_label}, "
+            f"manifest_hash={decision.manifest_hash[:12]})."
+        ),
+        "Use concrete adapter function names when they are present in tools[].",
+    ]
+    if decision.degradation_reason:
+        lines.append(f"degradation_reason: {decision.degradation_reason}")
+    if decision.permission_gate:
+        lines.append("permission_gate: true")
+    if level == "name_only":
+        lines.extend(f"- {candidate.tool_id}" for candidate in visible)
+        lines.append("</available_adapters>")
+        return AvailableAdaptersProjection(
+            content="\n".join(lines),
+            tool_ids=tool_ids,
+            schema_projection_level=level,
+        )
+
+    for candidate in visible:
+        lines.extend(_candidate_lines(candidate, registry, projection_level=level))
+    lines.extend(_route_rules(visible))
+    lines.append("</available_adapters>")
+    return AvailableAdaptersProjection(
+        content="\n".join(lines),
+        tool_ids=tool_ids,
+        schema_projection_level=level,
+    )
+
+
+def selected_concrete_adapter_tools(
+    decision: RouteDecision,
+    registry: ToolRegistry,
+    *,
+    exclude_tool_ids: Iterable[str] = (),
+    max_tools: int = 5,
+) -> tuple[GovAPITool, ...]:
+    excluded = frozenset(exclude_tool_ids)
+    tools: list[GovAPITool] = []
+    for tool_id in decision.selected_tools:
+        if tool_id in excluded:
+            continue
+        try:
+            tools.append(registry.find(tool_id))
+        except ToolNotFoundError:
+            continue
+        if len(tools) >= max_tools:
+            break
+    return tuple(tools)
+
+
+def _selected_candidates(
+    decision: RouteDecision,
+    *,
+    max_visible: int,
+    visible_tool_ids: Iterable[str] | None = None,
+    exclude_tool_ids: Iterable[str] = (),
+) -> tuple[RouteCandidate, ...]:
+    excluded = frozenset(exclude_tool_ids)
+    selected = (
+        tuple(tool_id for tool_id in visible_tool_ids if tool_id not in excluded)
+        if visible_tool_ids is not None
+        else tuple(tool_id for tool_id in decision.selected_tools if tool_id not in excluded)
+    )
+    selected_rank = {tool_id: index for index, tool_id in enumerate(selected)}
+    candidates_by_id = {
+        candidate.tool_id: candidate
+        for candidate in decision.candidate_set
+        if candidate.tool_id in selected_rank and candidate.feasible
+    }
+    ordered = tuple(
+        candidates_by_id[tool_id] for tool_id in selected if tool_id in candidates_by_id
+    )
+    return ordered[: max(0, max_visible)]
+
+
+def _candidate_lines(
+    candidate: RouteCandidate,
+    registry: ToolRegistry,
+    *,
+    projection_level: SchemaProjectionLevel,
+) -> list[str]:
+    card = candidate.card
+    lines = [
+        f"- tool_id: {card.tool_id}",
+        f"  primitive: {card.primitive_family}",
+        f"  source_mode: {card.source_mode}",
+        f"  agency: {card.agency}",
+        f"  domain: {card.domain}",
+        f"  score: {candidate.retrieval_score:.4f}",
+        f"  description: {_one_line(card.routing_text)}",
+        f"  required_params: {list(card.required_slots)}",
+        f"  optional_params: {list(card.optional_slots)}",
+        f"  call_hint: {card.tool_id}({{...schema fields...}})",
+        f"  policy_url: {card.policy_authority_url or ''}",
+    ]
+    llm_description = _tool_llm_description(card.tool_id, registry)
+    if llm_description:
+        lines.append(f"  usage: {_one_line(llm_description)}")
+    if projection_level in {"summary", "full_schema"}:
+        lines.append("  input_schema_summary:")
+        lines.extend(_schema_summary_lines(candidate, registry))
+    if projection_level == "full_schema":
+        try:
+            tool = registry.find(card.tool_id)
+            schema_json = json.dumps(
+                model_json_schema(tool.input_schema),
+                ensure_ascii=False,
+                sort_keys=True,
+            )
+        except ToolNotFoundError:
+            schema_json = "{}"
+        lines.append(f"  input_schema_json: {schema_json}")
+    return lines
+
+
+def _tool_llm_description(tool_id: str, registry: ToolRegistry) -> str | None:
+    try:
+        value = registry.find(tool_id).llm_description
+    except ToolNotFoundError:
+        return None
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _schema_summary_lines(candidate: RouteCandidate, registry: ToolRegistry) -> list[str]:
+    card = candidate.card
+    try:
+        schema = model_json_schema(registry.find(card.tool_id).input_schema)
+    except ToolNotFoundError:
+        schema = {}
+    properties = _mapping(schema.get("properties"))
+    defs = _mapping(schema.get("$defs"))
+    required = frozenset(card.required_slots)
+    lines: list[str] = []
+    for field in card.input_schema_summary:
+        flag = "required" if field.required else "optional"
+        description = f" - {_one_line(field.description)}" if field.description else ""
+        lines.append(f"    - {field.name} ({field.type}, {flag}){description}")
+        field_schema = _mapping(properties.get(field.name))
+        for nested_name, nested_schema in _nested_properties(field.name, field_schema, defs):
+            nested_description = _description(nested_schema)
+            nested_suffix = f" - {_one_line(nested_description)}" if nested_description else ""
+            nested_required = _nested_required(field.name, nested_name, field_schema, defs)
+            nested_flag = "required" if field.name in required and nested_required else "optional"
+            lines.append(
+                f"      - {nested_name} ({_schema_type(nested_schema)}, {nested_flag})"
+                f"{nested_suffix}"
+            )
+    return lines
+
+
+def _route_rules(candidates: tuple[RouteCandidate, ...]) -> tuple[str, ...]:
+    primitives = frozenset(candidate.card.primitive_family for candidate in candidates)
+    lines = [
+        "Rules:",
+        (
+            "  - Concrete adapter functions accept only their own schema fields; "
+            "do not wrap tool_id/params inside concrete adapter calls."
+        ),
+        (
+            "  - Use root primitives find/locate/check/send only when the concrete "
+            "adapter function is not loaded."
+        ),
+        (
+            "  - Preserve explicit citizen constraints such as count, radius, date, "
+            "time, category, institution type, and administrative region when a "
+            "selected schema exposes the matching field."
+        ),
+    ]
+    if primitives == {"find"}:
+        lines.append(
+            "  - All selected adapters are read/fetch candidates; do not switch to "
+            "check/send unless the citizen explicitly asks for authentication, "
+            "consent, submission, payment, report, or filing."
+        )
+    return tuple(lines)
+
+
+def _one_line(value: str | None, *, limit: int = 900) -> str:
+    compact = " ".join((value or "").split())
+    if len(compact) <= limit:
+        return compact
+    return compact[: limit - 3] + "..."
+
+
+def _xml_attr(value: str) -> str:
+    return (
+        value.replace("&", "&amp;").replace('"', "&quot;").replace("<", "&lt;").replace(">", "&gt;")
+    )
+
+
+def _nested_properties(
+    parent_name: str,
+    field_schema: Mapping[str, object],
+    defs: Mapping[str, object],
+) -> tuple[tuple[str, Mapping[str, object]], ...]:
+    target = _resolve_ref(field_schema, defs)
+    if target:
+        return _properties_with_prefix(parent_name, target)
+    raw_items = field_schema.get("items")
+    item_schema = _mapping(raw_items)
+    item_target = _resolve_ref(item_schema, defs)
+    if item_target:
+        return _properties_with_prefix(f"{parent_name}[]", item_target)
+    return ()
+
+
+def _properties_with_prefix(
+    prefix: str, schema: Mapping[str, object]
+) -> tuple[tuple[str, Mapping[str, object]], ...]:
+    properties = _mapping(schema.get("properties"))
+    return tuple(
+        (f"{prefix}.{name}", _mapping(spec)) for name, spec in properties.items() if str(name)
+    )
+
+
+def _nested_required(
+    parent_name: str,
+    nested_name: str,
+    field_schema: Mapping[str, object],
+    defs: Mapping[str, object],
+) -> bool:
+    target = _resolve_ref(field_schema, defs)
+    nested_key = nested_name.removeprefix(f"{parent_name}.")
+    if not target:
+        item_schema = _mapping(field_schema.get("items"))
+        target = _resolve_ref(item_schema, defs)
+        nested_key = nested_name.removeprefix(f"{parent_name}[].")
+    raw_required = target.get("required") if target else None
+    if not isinstance(raw_required, list):
+        return False
+    return nested_key in {str(item) for item in raw_required if isinstance(item, str)}
+
+
+def _resolve_ref(schema: Mapping[str, object], defs: Mapping[str, object]) -> Mapping[str, object]:
+    ref = schema.get("$ref")
+    if not isinstance(ref, str) or not ref.startswith("#/$defs/"):
+        return {}
+    return _mapping(defs.get(ref.removeprefix("#/$defs/")))
+
+
+def _mapping(value: object) -> Mapping[str, object]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _description(schema: Mapping[str, object]) -> str | None:
+    value = schema.get("description")
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def _schema_type(schema: Mapping[str, object]) -> str:
+    raw_type = schema.get("type")
+    if isinstance(raw_type, str):
+        return raw_type
+    if isinstance(raw_type, list):
+        return "|".join(str(item) for item in raw_type)
+    if "$ref" in schema:
+        return "ref"
+    if "anyOf" in schema:
+        return "anyOf"
+    if "oneOf" in schema:
+        return "oneOf"
+    return "unknown"

--- a/src/ummaya/tools/routing/projection.py
+++ b/src/ummaya/tools/routing/projection.py
@@ -103,7 +103,7 @@ def selected_concrete_adapter_tools(
 ) -> tuple[GovAPITool, ...]:
     excluded = frozenset(exclude_tool_ids)
     tools: list[GovAPITool] = []
-    for tool_id in decision.selected_tools:
+    for tool_id in _decision_tool_ids(decision):
         if tool_id in excluded:
             continue
         try:
@@ -126,18 +126,29 @@ def _selected_candidates(
     selected = (
         tuple(tool_id for tool_id in visible_tool_ids if tool_id not in excluded)
         if visible_tool_ids is not None
-        else tuple(tool_id for tool_id in decision.selected_tools if tool_id not in excluded)
+        else tuple(tool_id for tool_id in _decision_tool_ids(decision) if tool_id not in excluded)
     )
     selected_rank = {tool_id: index for index, tool_id in enumerate(selected)}
     candidates_by_id = {
         candidate.tool_id: candidate
         for candidate in decision.candidate_set
-        if candidate.tool_id in selected_rank and candidate.feasible
+        if candidate.tool_id in selected_rank
     }
     ordered = tuple(
         candidates_by_id[tool_id] for tool_id in selected if tool_id in candidates_by_id
     )
     return ordered[: max(0, max_visible)]
+
+
+def _decision_tool_ids(decision: RouteDecision) -> tuple[str, ...]:
+    if decision.selected_tools:
+        return decision.selected_tools
+    if (
+        decision.clarification is not None
+        and decision.clarification.reason == "side_effect_confirmation"
+    ):
+        return ()
+    return tuple(candidate.tool_id for candidate in decision.candidate_set)
 
 
 def _candidate_lines(

--- a/src/ummaya/tools/routing/retrieval_policy.py
+++ b/src/ummaya/tools/routing/retrieval_policy.py
@@ -41,6 +41,7 @@ _LOCATION_TOOL_IDS = frozenset(
         "sgis_adm_cd_lookup",
     }
 )
+_AIRKOREA_TOOL_IDS = frozenset({"airkorea_ctprvn_air_quality"})
 
 
 def expand_query_for_adapter_retrieval(query: str) -> str:
@@ -67,6 +68,7 @@ def expand_query_for_intent(query: str, intent: ToolSelectionIntent) -> str:
         additions.extend(["AED", "자동심장충격기", "자동제세동기", "국립중앙의료원"])
     additions.extend(_emergency_chain_additions(intent))
     additions.extend(_pps_bid_additions(intent))
+    additions.extend(_airkorea_air_quality_additions(intent))
     additions.extend(_kcue_regional_additions(intent))
     additions.extend(_ocean_water_quality_additions(intent))
     additions.extend(_health_detail_additions(intent))
@@ -103,6 +105,7 @@ def filter_special_case_scores(
     scored = _filter_document_harness_scores(intent, scored)
     scored = _filter_emergency_chain_scores(intent, scored)
     scored = _filter_pps_bid_scores(intent, scored)
+    scored = _filter_airkorea_air_quality_scores(intent, scored)
     scored = _filter_kcue_regional_scores(intent, scored)
     scored = _filter_health_detail_scores(intent, scored)
     scored = _filter_public_safety_location_scores(intent, scored)
@@ -314,6 +317,24 @@ def _pps_bid_additions(intent: ToolSelectionIntent) -> list[str]:
     ]
 
 
+def _airkorea_air_quality_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("airkorea_air_quality"):
+        return []
+    return [
+        "에어코리아",
+        "AirKorea",
+        "미세먼지",
+        "초미세먼지",
+        "대기질",
+        "대기오염",
+        "공기질",
+        "PM10",
+        "PM2.5",
+        "sido_name",
+        "city province air quality",
+    ]
+
+
 def _kcue_regional_additions(intent: ToolSelectionIntent) -> list[str]:
     if not intent.has_public_data_ref("kcue_regional"):
         return []
@@ -456,6 +477,17 @@ def _filter_pps_bid_scores(
     return [
         (tool_id, score + 1000.0) for tool_id, score in scored if tool_id == "pps_bid_public_info"
     ]
+
+
+def _filter_airkorea_air_quality_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("airkorea_air_quality"):
+        return scored
+    has_airkorea = any(tool_id in _AIRKOREA_TOOL_IDS for tool_id, _ in scored)
+    if not has_airkorea:
+        return scored
+    return [(tool_id, score + 1200.0) for tool_id, score in scored if tool_id in _AIRKOREA_TOOL_IDS]
 
 
 def _filter_kcue_regional_scores(

--- a/src/ummaya/tools/routing/retrieval_policy.py
+++ b/src/ummaya/tools/routing/retrieval_policy.py
@@ -1,0 +1,597 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from ummaya.tools.routing.intent import ToolSelectionIntent, extract_tool_selection_intent
+
+_KCUE_TOOL_IDS = frozenset(
+    {
+        "kcue_finance_regional_tuition",
+        "kcue_student_regional_foreign",
+    }
+)
+_DOCUMENT_TOOL_IDS = frozenset({"document"})
+_KMA_URL_AIR_TOOL_IDS = frozenset(
+    {
+        "kma_apihub_url_air_amos_minute",
+        "kma_apihub_url_air_metar_decoded",
+    }
+)
+_KMA_ANALYSIS_TOOL_IDS = frozenset(
+    {
+        "kma_apihub_url_high_resolution_grid_point",
+        "kma_apihub_url_aws_objective_analysis_grid",
+        "kma_apihub_url_analysis_weather_chart_image",
+    }
+)
+_KMA_LIFESTYLE_WEATHER_TOOL_IDS = frozenset(
+    {
+        "kma_current_observation",
+        "kma_ultra_short_term_forecast",
+        "kma_short_term_forecast",
+    }
+)
+_LOCATION_TOOL_IDS = frozenset(
+    {
+        "locate",
+        "kakao_address_search",
+        "kakao_keyword_search",
+        "kakao_coord_to_region",
+        "juso_adm_cd_lookup",
+        "sgis_adm_cd_lookup",
+    }
+)
+
+
+def expand_query_for_adapter_retrieval(query: str) -> str:
+    intent = extract_tool_selection_intent(query)
+    return expand_query_for_intent(query, intent)
+
+
+def expand_query_for_intent(query: str, intent: ToolSelectionIntent) -> str:
+    additions: list[str] = []
+    is_airport_aviation_query = intent.has_public_data_ref("kma_airport_aviation")
+    if is_airport_aviation_query:
+        additions.extend(_airport_aviation_additions(intent))
+    if intent.has_public_data_ref("kma_analysis_data"):
+        additions.extend(_kma_analysis_data_additions())
+    if intent.has_public_data_ref("kma_lifestyle_weather"):
+        additions.extend(_kma_lifestyle_weather_additions())
+    if intent.has_location_ref("poi") and not is_airport_aviation_query:
+        additions.extend(["장소", "키워드", "POI", "랜드마크", "역", "keyword"])
+    if intent.has_location_ref("admin"):
+        additions.extend(["주소", "행정동", "법정동", "도로명", "지번", "address"])
+    if intent.has_public_data_ref("emergency_medical"):
+        additions.extend(["응급실", "응급의료", "NMC", "emergency"])
+    if intent.has_public_data_ref("aed"):
+        additions.extend(["AED", "자동심장충격기", "자동제세동기", "국립중앙의료원"])
+    additions.extend(_emergency_chain_additions(intent))
+    additions.extend(_pps_bid_additions(intent))
+    additions.extend(_kcue_regional_additions(intent))
+    additions.extend(_ocean_water_quality_additions(intent))
+    additions.extend(_health_detail_additions(intent))
+    additions.extend(_document_harness_additions(intent))
+    additions.extend(_public_safety_location_additions(intent))
+    if intent.has_public_data_ref("traffic_hazard"):
+        additions.extend(_traffic_hazard_additions())
+    if not additions:
+        return query
+    return f"{query} {' '.join(additions)}"
+
+
+def filter_special_case_scores(
+    intent: ToolSelectionIntent,
+    scored: list[tuple[str, float]],
+) -> list[tuple[str, float]]:
+    is_airport_aviation_query = intent.has_public_data_ref("kma_airport_aviation")
+    is_analysis_query = intent.has_public_data_ref("kma_analysis_data")
+    is_analysis_map_query = intent.has_public_data_ref("kma_analysis_map")
+    is_analysis_point_query = (
+        intent.has_public_data_ref("kma_analysis_point") and not is_analysis_map_query
+    )
+    is_lifestyle_weather_query = intent.has_public_data_ref("kma_lifestyle_weather")
+    scored = _filter_initial_special_scores(intent, scored)
+    if is_analysis_query:
+        scored = _filter_kma_analysis_scores(
+            scored,
+            is_analysis_map_query=is_analysis_map_query,
+            is_analysis_point_query=is_analysis_point_query,
+            prefer_poi_location=intent.has_location_ref("poi"),
+        )
+    if is_lifestyle_weather_query:
+        scored = _filter_kma_lifestyle_weather_scores(scored)
+    scored = _filter_document_harness_scores(intent, scored)
+    scored = _filter_emergency_chain_scores(intent, scored)
+    scored = _filter_pps_bid_scores(intent, scored)
+    scored = _filter_kcue_regional_scores(intent, scored)
+    scored = _filter_health_detail_scores(intent, scored)
+    scored = _filter_public_safety_location_scores(intent, scored)
+    scored = _filter_ocean_water_quality_scores(intent, scored)
+    scored = _filter_kma_aviation_scores(
+        intent, scored, is_airport_aviation_query=is_airport_aviation_query
+    )
+    scored = _boost_aed_scores(intent, scored)
+
+    return [
+        (tool_id, score + 1000.0 if tool_id in intent.explicit_tool_ids else score)
+        for tool_id, score in scored
+    ]
+
+
+def is_document_harness_query(query: str) -> bool:
+    return extract_tool_selection_intent(query).has_document_ref("document_harness")
+
+
+def _filter_kma_analysis_scores(
+    scored: list[tuple[str, float]],
+    *,
+    is_analysis_map_query: bool,
+    is_analysis_point_query: bool,
+    prefer_poi_location: bool,
+) -> list[tuple[str, float]]:
+    chart_boost = 900.0 if is_analysis_map_query else 150.0
+    if is_analysis_point_query and not is_analysis_map_query:
+        chart_boost = -20.0
+    analysis_boosts = {
+        "kma_apihub_url_analysis_weather_chart_image": chart_boost,
+        "kma_apihub_url_high_resolution_grid_point": (900.0 if is_analysis_point_query else 450.0),
+        "kma_apihub_url_aws_objective_analysis_grid": (800.0 if is_analysis_point_query else 400.0),
+    }
+    allowed_location_ids = _LOCATION_TOOL_IDS if is_analysis_point_query else frozenset()
+    adjusted: list[tuple[str, float]] = []
+    for tool_id, score in scored:
+        if tool_id in _KMA_ANALYSIS_TOOL_IDS:
+            adjusted.append((tool_id, score + analysis_boosts.get(tool_id, 0.0)))
+            continue
+        if tool_id in allowed_location_ids:
+            location_score = max(1.0, score - 10.0)
+            if prefer_poi_location and tool_id == "kakao_keyword_search":
+                location_score += 30.0
+            elif prefer_poi_location and tool_id == "kakao_address_search":
+                location_score = max(1.0, location_score - 15.0)
+            adjusted.append((tool_id, location_score))
+    return adjusted
+
+
+def _kma_lifestyle_weather_additions() -> list[str]:
+    return [
+        "기상청",
+        "KMA",
+        "현재날씨",
+        "초단기실황",
+        "초단기예보",
+        "단기예보",
+        "강수",
+        "우산",
+        "nx",
+        "ny",
+        "base_date",
+        "base_time",
+        "current",
+        "observation",
+        "forecast",
+        "precipitation",
+    ]
+
+
+def _airport_aviation_additions(intent: ToolSelectionIntent) -> list[str]:
+    additions = [
+        "METAR",
+        "SPECI",
+        "AMOS",
+        "항공기상",
+        "공항기상",
+        "항공",
+        "비행기",
+        "항공편",
+        "운항",
+        "이륙",
+        "시정",
+        "RVR",
+        "wind",
+        "visibility",
+    ]
+    if intent.has_public_data_ref("kma_gimpo_airport") and intent.has_public_data_ref(
+        "kma_runway_area"
+    ):
+        additions.extend(["AMOS", "공항기상관측", "매분자료", "활주로", "김포공항", "stn110"])
+    return additions
+
+
+def _kma_analysis_data_additions() -> list[str]:
+    return [
+        "분석자료",
+        "고해상도",
+        "격자자료",
+        "객관분석",
+        "AWS",
+        "분석일기도",
+        "지도",
+        "비구름",
+        "바람흐름",
+        "objective",
+        "analysis",
+        "grid",
+        "chart",
+    ]
+
+
+def _traffic_hazard_additions() -> list[str]:
+    return [
+        "교통사고",
+        "사고다발구역",
+        "위험지점",
+        "도로위험구역",
+        "어린이보호구역",
+        "행정동코드",
+        "KOROAD",
+        "accident",
+        "hazard",
+    ]
+
+
+def _emergency_chain_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("emergency_medical"):
+        return []
+    additions = [
+        "응급실",
+        "응급의료",
+        "자동심장충격기",
+        "AED",
+        "국립중앙의료원",
+        "NMC",
+        "nearby",
+        "emergency",
+        "hospital",
+    ]
+    if intent.has_location_ref("poi"):
+        additions.extend(["장소", "키워드", "POI", "랜드마크", "역", "keyword"])
+    return additions
+
+
+def _public_safety_location_additions(intent: ToolSelectionIntent) -> list[str]:
+    additions: list[str] = []
+    if intent.has_public_data_ref("mois_emergency_call_box"):
+        additions.extend(
+            [
+                "안전비상벨",
+                "비상벨",
+                "긴급신고함",
+                "방범",
+                "행정안전부",
+                "MOIS",
+                "emergency",
+                "call",
+                "box",
+            ]
+        )
+    if intent.has_public_data_ref("gyeryong_assistive_charger"):
+        additions.extend(
+            [
+                "계룡시",
+                "전동보장구",
+                "전동휠체어",
+                "장애인",
+                "충전소",
+                "충전장소",
+                "accessibility",
+                "charger",
+            ]
+        )
+    return additions
+
+
+def _ocean_water_quality_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("mof_ocean_water_quality"):
+        return []
+    return [
+        "해양수산부",
+        "해양수질",
+        "수질자동측정망",
+        "관측소",
+        "SEA3003",
+        "용존산소",
+        "water",
+        "quality",
+        "ocean",
+    ]
+
+
+def _pps_bid_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("pps_bid"):
+        return []
+    return [
+        "조달청",
+        "나라장터",
+        "입찰공고",
+        "공사입찰",
+        "bidNtceNm",
+        "inqryBgnDt",
+        "inqryEndDt",
+        "PPS",
+        "bid",
+        "procurement",
+    ]
+
+
+def _kcue_regional_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("kcue_regional"):
+        return []
+    additions = [
+        "한국대학교육협의회",
+        "대학알리미",
+        "대학정보공시",
+        "학교구분코드",
+        "schlDivCd",
+        "지역별통계",
+        "KCUE",
+    ]
+    if intent.has_public_data_ref("kcue_regional_finance"):
+        additions.extend(["재정현황", "등록금", "FinancesService", "regional tuition"])
+    if intent.has_public_data_ref("kcue_regional_foreign_student"):
+        additions.extend(["학생현황", "외국인유학생", "regional foreign student"])
+    return additions
+
+
+def _health_detail_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("hira_medical_detail"):
+        return []
+    return [
+        "의료기관",
+        "상세정보",
+        "진료과목",
+        "진료시간",
+        "주차",
+        "요양기호",
+        "ykiho",
+        "HIRA",
+        "hospital",
+        "detail",
+    ]
+
+
+def _document_harness_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_document_ref("document_harness"):
+        return []
+    return [
+        "document",
+        "document.path",
+        "local",
+        "file",
+        "path",
+        "artifact_refs",
+        "public",
+        "document",
+        "harness",
+        "form",
+        "render",
+        "diff",
+        "save",
+    ]
+
+
+def _filter_kma_lifestyle_weather_scores(
+    scored: list[tuple[str, float]],
+) -> list[tuple[str, float]]:
+    allowed_tool_ids = _KMA_LIFESTYLE_WEATHER_TOOL_IDS | _LOCATION_TOOL_IDS
+    if any(tool_id in allowed_tool_ids for tool_id, _ in scored):
+        scored = [(tool_id, score) for tool_id, score in scored if tool_id in allowed_tool_ids]
+    boosts = {
+        "kakao_keyword_search": 1100.0,
+        "kakao_address_search": 1000.0,
+        "kma_current_observation": 900.0,
+        "kma_ultra_short_term_forecast": 800.0,
+        "kma_short_term_forecast": 650.0,
+        "kakao_coord_to_region": 260.0,
+        "juso_adm_cd_lookup": 260.0,
+        "sgis_adm_cd_lookup": 260.0,
+    }
+    return [(tool_id, score + boosts.get(tool_id, 0.0)) for tool_id, score in scored]
+
+
+def _filter_public_safety_location_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    boosts = {}
+    if intent.has_public_data_ref("mois_emergency_call_box"):
+        boosts["mois_emergency_call_box_lookup"] = 1000.0
+    if intent.has_public_data_ref("gyeryong_assistive_charger"):
+        boosts["gyeryong_assistive_device_charging_place_locate"] = 1000.0
+    if not boosts:
+        return scored
+    return [(tool_id, score + boosts.get(tool_id, 0.0)) for tool_id, score in scored]
+
+
+def _filter_emergency_chain_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("emergency_medical"):
+        return scored
+    emergency_tool_ids = {
+        "nmc_emergency_search",
+        "nmc_aed_site_locate",
+        "hira_hospital_search",
+        "hira_medical_institution_detail",
+    }
+    allowed_tool_ids = emergency_tool_ids | _LOCATION_TOOL_IDS
+    if any(tool_id in emergency_tool_ids for tool_id, _ in scored):
+        scored = [(tool_id, score) for tool_id, score in scored if tool_id in allowed_tool_ids]
+    implicit_collapse = intent.has_public_data_ref("implicit_emergency")
+    boosts = {
+        "nmc_emergency_search": 1200.0,
+        "nmc_aed_site_locate": 1150.0 if implicit_collapse else 950.0,
+        "kakao_keyword_search": 1100.0 if implicit_collapse else 900.0,
+        "kakao_address_search": 800.0,
+        "kakao_coord_to_region": 500.0,
+        "juso_adm_cd_lookup": 300.0,
+        "sgis_adm_cd_lookup": 300.0,
+        "hira_hospital_search": 250.0,
+        "hira_medical_institution_detail": 200.0,
+    }
+    return [(tool_id, score + boosts.get(tool_id, 0.0)) for tool_id, score in scored]
+
+
+def _filter_ocean_water_quality_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("mof_ocean_water_quality"):
+        return scored
+    return [
+        (
+            tool_id,
+            score + (1000.0 if tool_id == "mof_ocean_water_quality_check" else 0.0),
+        )
+        for tool_id, score in scored
+    ]
+
+
+def _filter_pps_bid_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("pps_bid"):
+        return scored
+    has_pps_bid = any(tool_id == "pps_bid_public_info" for tool_id, _ in scored)
+    if not has_pps_bid:
+        return scored
+    return [
+        (tool_id, score + 1000.0) for tool_id, score in scored if tool_id == "pps_bid_public_info"
+    ]
+
+
+def _filter_kcue_regional_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("kcue_regional"):
+        return scored
+    has_kcue = any(tool_id in _KCUE_TOOL_IDS for tool_id, _ in scored)
+    if not has_kcue:
+        return scored
+
+    prefer_finance = intent.has_public_data_ref("kcue_regional_finance")
+    prefer_foreign_student = intent.has_public_data_ref("kcue_regional_foreign_student")
+    boosts = {
+        "kcue_finance_regional_tuition": 1000.0 if prefer_finance else 700.0,
+        "kcue_student_regional_foreign": 1000.0 if prefer_foreign_student else 700.0,
+    }
+    return [
+        (tool_id, score + boosts[tool_id]) for tool_id, score in scored if tool_id in _KCUE_TOOL_IDS
+    ]
+
+
+def _filter_health_detail_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("hira_medical_detail"):
+        return scored
+    return [
+        (
+            tool_id,
+            score + (650.0 if tool_id == "hira_medical_institution_detail" else 0.0),
+        )
+        for tool_id, score in scored
+    ]
+
+
+def _filter_document_harness_scores(
+    intent: ToolSelectionIntent,
+    scored: list[tuple[str, float]],
+) -> list[tuple[str, float]]:
+    if not intent.has_document_ref("document_harness"):
+        return scored
+    if not any(tool_id in _DOCUMENT_TOOL_IDS for tool_id, _score in scored):
+        return scored
+    boosts = {"document": 1600.0}
+    return [
+        (tool_id, score + boosts[tool_id])
+        for tool_id, score in scored
+        if tool_id in _DOCUMENT_TOOL_IDS
+    ]
+
+
+def _filter_initial_special_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if intent.has_public_data_ref("traffic_hazard_specific"):
+        scored = [
+            (tool_id, score) for tool_id, score in scored if tool_id != "koroad_accident_search"
+        ]
+    if intent.has_public_data_ref("kma_analysis_chart"):
+        return [
+            (tool_id, score)
+            for tool_id, score in scored
+            if tool_id == "kma_apihub_url_analysis_weather_chart_image"
+        ]
+    return scored
+
+
+def _filter_kma_aviation_scores(
+    intent: ToolSelectionIntent,
+    scored: list[tuple[str, float]],
+    *,
+    is_airport_aviation_query: bool,
+) -> list[tuple[str, float]]:
+    if intent.has_public_data_ref("kma_gimhae_airport") and is_airport_aviation_query:
+        scored = [
+            (tool_id, score)
+            for tool_id, score in scored
+            if tool_id != "kma_apihub_url_air_amos_minute"
+        ]
+    if (
+        intent.has_public_data_ref("kma_gimpo_airport")
+        and intent.has_public_data_ref("kma_runway_area")
+        and is_airport_aviation_query
+    ):
+        scored = [
+            (tool_id, score + 500.0 if tool_id == "kma_apihub_url_air_amos_minute" else score)
+            for tool_id, score in scored
+        ]
+    if not is_airport_aviation_query:
+        return scored
+
+    has_air_url_candidate = any(tool_id in _KMA_URL_AIR_TOOL_IDS for tool_id, _ in scored)
+    if not has_air_url_candidate:
+        return scored
+    if intent.has_public_data_ref("kma_explicit_metar"):
+        blocked_tool_ids = (
+            _LOCATION_TOOL_IDS | _KMA_LIFESTYLE_WEATHER_TOOL_IDS | {"kma_forecast_fetch"}
+        )
+        scored = [(tool_id, score) for tool_id, score in scored if tool_id not in blocked_tool_ids]
+    else:
+        scored = [(tool_id, score) for tool_id, score in scored if tool_id in _KMA_URL_AIR_TOOL_IDS]
+    prefer_amos = bool(
+        intent.has_public_data_ref("kma_gimpo_airport")
+        and intent.has_public_data_ref("kma_runway_area")
+        and not intent.has_public_data_ref("kma_gimhae_airport")
+    )
+    return [
+        (
+            tool_id,
+            score
+            + (
+                800.0
+                if tool_id == "kma_apihub_url_air_amos_minute" and prefer_amos
+                else 700.0
+                if tool_id == "kma_apihub_url_air_metar_decoded"
+                else 0.0
+            ),
+        )
+        for tool_id, score in scored
+    ]
+
+
+def _boost_aed_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("aed"):
+        return scored
+    return [
+        (
+            tool_id,
+            score + 900.0
+            if tool_id == "nmc_aed_site_locate"
+            else score + 700.0
+            if tool_id == "nmc_emergency_search" and intent.has_public_data_ref("emergency_medical")
+            else score,
+        )
+        for tool_id, score in scored
+    ]

--- a/src/ummaya/tools/routing/schema.py
+++ b/src/ummaya/tools/routing/schema.py
@@ -1,0 +1,81 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Iterable, Mapping
+
+from pydantic import BaseModel
+
+from ummaya.tools.routing.types import SchemaFieldSummary
+
+
+def model_json_schema(model: type[BaseModel]) -> dict[str, object]:
+    return {str(key): value for key, value in model.model_json_schema().items()}
+
+
+def schema_summary(schema: Mapping[str, object]) -> tuple[SchemaFieldSummary, ...]:
+    raw_properties = schema.get("properties")
+    if not isinstance(raw_properties, Mapping):
+        return ()
+    required = required_names(schema)
+    summaries: list[SchemaFieldSummary] = []
+    for raw_name, raw_spec in raw_properties.items():
+        name = str(raw_name)
+        spec = raw_spec if isinstance(raw_spec, Mapping) else {}
+        summaries.append(
+            SchemaFieldSummary(
+                name=name,
+                type=schema_type(spec),
+                required=name in required,
+                description=schema_description(spec),
+            )
+        )
+    return tuple(summaries)
+
+
+def required_names(schema: Mapping[str, object]) -> frozenset[str]:
+    raw_required = schema.get("required")
+    if not isinstance(raw_required, list):
+        return frozenset()
+    return frozenset(str(item) for item in raw_required if isinstance(item, str))
+
+
+def schema_type(spec: Mapping[str, object]) -> str:
+    raw_type = spec.get("type")
+    if isinstance(raw_type, str):
+        return raw_type
+    if isinstance(raw_type, list):
+        return "|".join(str(item) for item in raw_type)
+    if "$ref" in spec:
+        return "ref"
+    if "anyOf" in spec:
+        return "anyOf"
+    if "oneOf" in spec:
+        return "oneOf"
+    return "unknown"
+
+
+def schema_description(spec: Mapping[str, object]) -> str | None:
+    value = spec.get("description")
+    return value if isinstance(value, str) and value.strip() else None
+
+
+def sha256(value: object) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def canonical_json(value: object) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def unique(values: Iterable[str]) -> list[str]:
+    seen: set[str] = set()
+    result: list[str] = []
+    for value in values:
+        item = str(value).strip()
+        if item and item not in seen:
+            result.append(item)
+            seen.add(item)
+    return result

--- a/src/ummaya/tools/routing/types.py
+++ b/src/ummaya/tools/routing/types.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from typing import Final, Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from ummaya.tools.models import MockFidelityGrade
+
+PrimitiveFamily = Literal["find", "locate", "send", "check", "document"]
+SourceMode = Literal["live", "mock", "internal"]
+SideEffectLevel = Literal["read_only", "login", "action", "sign", "send", "verify"]
+
+LEGACY_ALIASES: Final[dict[PrimitiveFamily, tuple[str, ...]]] = {
+    "find": ("lookup",),
+    "locate": ("resolve_location",),
+    "send": ("submit",),
+    "check": ("verify",),
+    "document": (),
+}
+
+INTENT_VERBS: Final[dict[PrimitiveFamily, tuple[str, ...]]] = {
+    "find": ("find", "search", "lookup"),
+    "locate": ("locate", "geocode", "resolve_location"),
+    "send": ("send", "submit"),
+    "check": ("check", "verify"),
+    "document": ("inspect", "fill", "validate"),
+}
+
+RAW_SCHEMA_MARKERS: Final[tuple[str, ...]] = (
+    "{",
+    "$defs",
+    '"properties"',
+    "'properties'",
+    "input_schema_json",
+    "output_schema_json",
+)
+
+
+class AdapterCardError(ValueError):
+    pass
+
+
+class SchemaFieldSummary(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    name: str = Field(min_length=1)
+    type: str = Field(min_length=1)
+    required: bool
+    description: str | None = None
+
+
+class AdapterCard(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tool_id: str = Field(min_length=1)
+    primitive_family: PrimitiveFamily
+    legacy_primitive_aliases: tuple[str, ...]
+    domain: str = Field(min_length=1)
+    agency: str = Field(min_length=1)
+    source_mode: SourceMode
+    capabilities: tuple[str, ...]
+    intent_verbs: tuple[str, ...]
+    entity_types: tuple[str, ...]
+    required_slots: tuple[str, ...]
+    optional_slots: tuple[str, ...]
+    prerequisite_tools: tuple[str, ...]
+    input_schema_hash: str
+    input_schema_summary: tuple[SchemaFieldSummary, ...]
+    output_schema_summary: tuple[SchemaFieldSummary, ...]
+    policy_authority_url: str | None
+    safety_annotations: tuple[str, ...]
+    side_effect_level: SideEffectLevel
+    credential_requirements: tuple[str, ...]
+    mock_fidelity_grade: MockFidelityGrade
+    examples_ko: tuple[str, ...]
+    examples_en: tuple[str, ...]
+    negative_examples: tuple[str, ...]
+    limitations: tuple[str, ...]
+    manifest_hash: str
+    routing_text: str = Field(min_length=1, max_length=4096)
+
+    @field_validator("input_schema_hash", "manifest_hash")
+    @classmethod
+    def _validate_sha256(cls, value: str) -> str:
+        if len(value) != 64 or any(ch not in "0123456789abcdef" for ch in value):
+            raise ValueError("hash fields must be lowercase SHA-256 hex")
+        return value
+
+
+class AdapterCardQualityViolation(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1)

--- a/src/ummaya/tools/search.py
+++ b/src/ummaya/tools/search.py
@@ -110,6 +110,7 @@ def search(
         top_k=effective_top_k,
         max_selected=effective_top_k,
         intent=intent,
+        drop_zero_score_candidates=False,
     )
 
     results: list[AdapterCandidate] = []

--- a/src/ummaya/tools/search.py
+++ b/src/ummaya/tools/search.py
@@ -15,7 +15,6 @@ Public API (for external callers):
 from __future__ import annotations
 
 import logging
-import re
 from typing import TYPE_CHECKING
 
 from ummaya.tools.bm25_index import BM25Index
@@ -26,6 +25,7 @@ from ummaya.tools.models import (
     SearchToolsOutput,
     ToolSearchResult,
 )
+from ummaya.tools.routing.intent import ToolSelectionIntent, extract_tool_selection_intent
 
 if TYPE_CHECKING:
     from ummaya.tools.registry import ToolRegistry
@@ -33,141 +33,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_POI_LOCATION_RE = re.compile(
-    r"(근처|주변|인근|가까운|역|터미널|공항|캠퍼스|대학교|대학|해수욕장|시장|공원|랜드마크)"
-)
-_ADMIN_LOCATION_RE = re.compile(
-    r"(?:[가-힣]{2,}(?:시|군|구|동|읍|면)\b|[가-힣0-9]{2,}(?<!으)(?:로|길)\b)"
-)
-_EMERGENCY_RE = re.compile(r"(응급|응급실|응급의료|\bemergency\b|\ber\b)", re.IGNORECASE)
-_IMPLICIT_EMERGENCY_RE = re.compile(
-    r"(사람이\s*(?:쓰러|쓰러졌|쓰러져)|의식(?:을)?\s*(?:잃|없)|"
-    r"갑자기\s*쓰러|쓰러진\s*사람|위급|심정지|호흡(?:이)?\s*없|"
-    r"collapsed|unconscious|cardiac\s*arrest)",
-    re.IGNORECASE,
-)
-_AED_RE = re.compile(r"(\bAED\b|자동심장충격기|자동제세동기|제세동기)", re.IGNORECASE)
-_TRAFFIC_HAZARD_RE = re.compile(
-    r"(교통사고|사고\s*위험|사고다발|위험\s*(?:구간|도로|지점)|어린이보호구역|보호구역|"
-    r"도로\s*구간|accident|hazard|hotspot)",
-    re.IGNORECASE,
-)
-_TRAFFIC_HAZARD_SPECIFIC_RE = re.compile(
-    r"(사고\s*위험|위험\s*(?:구간|도로|지점)|어린이보호구역|보호구역|스쿨존|"
-    r"도로\s*구간|행정동코드|adm_cd|hazard|hotspot)",
-    re.IGNORECASE,
-)
-_KMA_ANALYSIS_CHART_RE = re.compile(
-    r"(분석일기도|지상일기도|보조일기도|WthrChartInfoService|getSurfaceChart|"
-    r"getAuxillaryChart|synoptic\s+chart)",
-    re.IGNORECASE,
-)
-_KMA_GIMHAE_AIRPORT_RE = re.compile(r"(김해(?:공항)?|Gimhae|RKPK)", re.IGNORECASE)
-_KMA_GIMPO_AIRPORT_RE = re.compile(r"(김포(?:공항)?|Gimpo|RKSS)", re.IGNORECASE)
-_KMA_AIRPORT_NAME_RE = re.compile(
-    r"(공항|\bairport\b|\bRK[A-Z]{2}\b|station\s*\d{2,3})",
-    re.IGNORECASE,
-)
-_KMA_AIRPORT_AVIATION_RE = re.compile(
-    r"(AMOS|METAR|SPECI|RVR|항공기상|공항기상|활주로|runway|aviation|"
-    r"비행기|항공편|비행편|이륙|착륙|결항|지연|운항|뜰\s*만|뜨나|뜰\s*수|"
-    r"flight|take\s*off|landing|delay|cancel)",
-    re.IGNORECASE,
-)
-_KMA_EXPLICIT_METAR_RE = re.compile(r"(\bMETAR\b|\bSPECI\b|해독자료)", re.IGNORECASE)
-_KMA_RUNWAY_AREA_RE = re.compile(
-    r"(AMOS|활주로|RVR|runway|시정|visibility|공항기상관측|매분)",
-    re.IGNORECASE,
-)
-_KMA_ANALYSIS_DATA_RE = re.compile(
-    r"(분석자료|이미\s*분석|고해상도\s*격자|객관분석|AWS\s*객관|지도\s*자료|"
-    r"일기도|분석일기도|비구름|바람\s*흐름|날씨\s*흐름|공식\s*기상자료|전국\s*날씨|"
-    r"synoptic|weather\s*chart|"
-    r"objective\s*analysis|high[-\s]?resolution|grid)",
-    re.IGNORECASE,
-)
-_KMA_LIFESTYLE_WEATHER_RE = re.compile(
-    r"(날씨|현재\s*기상|실황|관측|예보|기온|습도|풍속|지금\s*비|"
-    r"비\s*(?:와|오|올|내리)|우산|강수|소나기|산책|퇴근|"
-    r"current\s+weather|forecast|rain|umbrella|precipitation|temperature)",
-    re.IGNORECASE,
-)
-_HIRA_MEDICAL_DETAIL_RE = re.compile(
-    r"((병원|의료기관|의원).*(상세|진료과|진료과목|진료시간|주차)|"
-    r"(상세|진료시간|주차|응급실).*(병원|의료기관|의원)|ykiho|detail)",
-    re.IGNORECASE,
-)
-_MOIS_EMERGENCY_CALL_BOX_RE = re.compile(
-    r"(안전\s*비상벨|비상벨|긴급\s*신고함|긴급신고함|방범벨|"
-    r"emergency\s+call\s+box)",
-    re.IGNORECASE,
-)
-_GYERYONG_ASSISTIVE_CHARGER_RE = re.compile(
-    r"((전동보장구|전동\s*휠체어|보장구|장애인).*(충전|충전소|충전장소)|"
-    r"(충전|충전소|충전장소).*(전동보장구|전동\s*휠체어|보장구|장애인)|"
-    r"계룡시?.*(충전소|충전\s*장소))",
-    re.IGNORECASE,
-)
-_MOF_OCEAN_WATER_QUALITY_RE = re.compile(
-    r"(해양\s*수질|해양수질|수질\s*자동\s*측정|용존산소|\bpH\b|"
-    r"water\s+quality|ocean\s+water)",
-    re.IGNORECASE,
-)
-_PPS_SHOPPING_RE = re.compile(
-    r"(종합\s*쇼핑몰|쇼핑몰|계약\s*물품|물품\s*조회|shopping\s*mall)",
-    re.IGNORECASE,
-)
-_PPS_BID_RE = re.compile(
-    r"(입찰|나라장터|조달청|\bbid\b|procurement|tender)",
-    re.IGNORECASE,
-)
-_KCUE_ACADEMY_INFO_RE = re.compile(
-    r"(대학알리미|대학정보공시|학교구분코드|schl[_\s-]?div[_\s-]?cd|KCUE)",
-    re.IGNORECASE,
-)
-_KCUE_REGIONAL_FINANCE_RE = re.compile(
-    r"(지역별\s*(등록금|재정)|등록금\s*(현황|지역별)?|tuition|finance)",
-    re.IGNORECASE,
-)
-_KCUE_REGIONAL_FOREIGN_STUDENT_RE = re.compile(
-    r"(외국인\s*유학생|유학생\s*현황|foreign\s+student|international\s+student)",
-    re.IGNORECASE,
-)
 _KCUE_TOOL_IDS = frozenset(
     {
         "kcue_finance_regional_tuition",
         "kcue_student_regional_foreign",
     }
 )
-_DOCUMENT_PATH_RE = re.compile(
-    r"(?:^|[\s:'\"(])(?:~|/|[A-Za-z]:\\|\.{1,2}/)?[^\s:'\"]*"
-    r"\.(?:hwpx|hwp|docx|pdf|xlsx|pptx)\b",
-    re.IGNORECASE,
-)
-_DOCUMENT_FORMAT_RE = re.compile(r"\b(?:hwpx|hwp|docx|pdf|xlsx|pptx)\b", re.IGNORECASE)
-_DOCUMENT_INTENT_RE = re.compile(
-    r"(문서|공문서|양식|서식|파일|작성|저장|렌더|미리보기|변경사항|"
-    r"\bdiff\b|\bcompact\b|\bdocument\b|\bfile\b|\bform\b|\brender\b|\bsave\b|\bwrite\b)",
-    re.IGNORECASE,
-)
-_DOCUMENT_WRITE_INTENT_RE = re.compile(
-    r"(작성|수정|편집|채우|채워|입력|변경|저장|write|edit|fill|apply|save)",
-    re.IGNORECASE,
-)
-_DOCUMENT_LOCAL_HINT_RE = re.compile(
-    r"(다운로드|downloads?|폴더|파일|양식|서식|활동일지|신청서|등본|증명서)",
-    re.IGNORECASE,
-)
 _DOCUMENT_TOOL_IDS = frozenset({"document"})
-_KMA_ANALYSIS_MAP_RE = re.compile(
-    r"(일기도|분석일기도|지도\s*자료|비구름|바람\s*흐름|날씨\s*흐름|전국\s*날씨|"
-    r"synoptic|weather\s*chart)",
-    re.IGNORECASE,
-)
-_KMA_ANALYSIS_POINT_RE = re.compile(
-    r"(주변|근처|특정지점|좌표|위도|경도|\blat\b|\blon\b|공항\s*주변)",
-    re.IGNORECASE,
-)
 _KMA_URL_AIR_TOOL_IDS = frozenset(
     {
         "kma_apihub_url_air_amos_minute",
@@ -201,56 +73,31 @@ _LOCATION_TOOL_IDS = frozenset(
 
 
 def _is_kma_analysis_point_query(query: str, *, is_analysis_map_query: bool) -> bool:
-    return bool(_KMA_ANALYSIS_POINT_RE.search(query)) and not is_analysis_map_query
+    return (
+        extract_tool_selection_intent(query).has_public_data_ref("kma_analysis_point")
+        and not is_analysis_map_query
+    )
 
 
 def _is_airport_aviation_query(query: str) -> bool:
-    return bool(
-        (
-            _KMA_AIRPORT_NAME_RE.search(query)
-            or _KMA_GIMHAE_AIRPORT_RE.search(query)
-            or _KMA_GIMPO_AIRPORT_RE.search(query)
-        )
-        and _KMA_AIRPORT_AVIATION_RE.search(query)
-    )
+    return extract_tool_selection_intent(query).has_public_data_ref("kma_airport_aviation")
 
 
 def _is_lifestyle_weather_query(query: str, *, is_airport_aviation_query: bool) -> bool:
-    return bool(
-        _KMA_LIFESTYLE_WEATHER_RE.search(query)
-        and not is_airport_aviation_query
-        and not _is_emergency_chain_query(query)
-        and not _KMA_ANALYSIS_DATA_RE.search(query)
-        and not _TRAFFIC_HAZARD_RE.search(query)
-        and not _MOF_OCEAN_WATER_QUALITY_RE.search(query)
-    )
+    del is_airport_aviation_query
+    return extract_tool_selection_intent(query).has_public_data_ref("kma_lifestyle_weather")
 
 
 def _is_pps_bid_query(query: str) -> bool:
-    return bool(_PPS_BID_RE.search(query) and not _PPS_SHOPPING_RE.search(query))
+    return extract_tool_selection_intent(query).has_public_data_ref("pps_bid")
 
 
 def _is_kcue_regional_query(query: str) -> bool:
-    has_kcue_anchor = bool(_KCUE_ACADEMY_INFO_RE.search(query)) or (
-        bool(re.search(r"대학(?!병원)", query)) and "공식" in query
-    )
-    if not has_kcue_anchor:
-        return False
-    return bool(
-        _KCUE_REGIONAL_FINANCE_RE.search(query) or _KCUE_REGIONAL_FOREIGN_STUDENT_RE.search(query)
-    )
+    return extract_tool_selection_intent(query).has_public_data_ref("kcue_regional")
 
 
 def _is_document_harness_query(query: str) -> bool:
-    return bool(
-        _DOCUMENT_PATH_RE.search(query)
-        or (_DOCUMENT_FORMAT_RE.search(query) and _DOCUMENT_INTENT_RE.search(query))
-        or (
-            _DOCUMENT_INTENT_RE.search(query)
-            and _DOCUMENT_WRITE_INTENT_RE.search(query)
-            and _DOCUMENT_LOCAL_HINT_RE.search(query)
-        )
-    )
+    return extract_tool_selection_intent(query).has_document_ref("document_harness")
 
 
 def is_document_harness_query(query: str) -> bool:
@@ -259,9 +106,7 @@ def is_document_harness_query(query: str) -> bool:
 
 
 def _is_emergency_chain_query(query: str) -> bool:
-    if _MOIS_EMERGENCY_CALL_BOX_RE.search(query):
-        return False
-    return bool(_IMPLICIT_EMERGENCY_RE.search(query) or _EMERGENCY_RE.search(query))
+    return extract_tool_selection_intent(query).has_public_data_ref("emergency_medical")
 
 
 def _filter_kma_analysis_scores(
@@ -316,7 +161,7 @@ def _kma_lifestyle_weather_additions() -> list[str]:
     ]
 
 
-def _airport_aviation_additions(query: str) -> list[str]:
+def _airport_aviation_additions(intent: ToolSelectionIntent) -> list[str]:
     additions = [
         "METAR",
         "SPECI",
@@ -333,7 +178,9 @@ def _airport_aviation_additions(query: str) -> list[str]:
         "wind",
         "visibility",
     ]
-    if _KMA_GIMPO_AIRPORT_RE.search(query) and _KMA_RUNWAY_AREA_RE.search(query):
+    if intent.has_public_data_ref("kma_gimpo_airport") and intent.has_public_data_ref(
+        "kma_runway_area"
+    ):
         additions.extend(["AMOS", "공항기상관측", "매분자료", "활주로", "김포공항", "stn110"])
     return additions
 
@@ -370,8 +217,8 @@ def _traffic_hazard_additions() -> list[str]:
     ]
 
 
-def _emergency_chain_additions(query: str) -> list[str]:
-    if not _is_emergency_chain_query(query):
+def _emergency_chain_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("emergency_medical"):
         return []
     additions = [
         "응급실",
@@ -384,14 +231,14 @@ def _emergency_chain_additions(query: str) -> list[str]:
         "emergency",
         "hospital",
     ]
-    if _POI_LOCATION_RE.search(query):
+    if intent.has_location_ref("poi"):
         additions.extend(["장소", "키워드", "POI", "랜드마크", "역", "keyword"])
     return additions
 
 
-def _public_safety_location_additions(query: str) -> list[str]:
+def _public_safety_location_additions(intent: ToolSelectionIntent) -> list[str]:
     additions: list[str] = []
-    if _MOIS_EMERGENCY_CALL_BOX_RE.search(query):
+    if intent.has_public_data_ref("mois_emergency_call_box"):
         additions.extend(
             [
                 "안전비상벨",
@@ -405,7 +252,7 @@ def _public_safety_location_additions(query: str) -> list[str]:
                 "box",
             ]
         )
-    if _GYERYONG_ASSISTIVE_CHARGER_RE.search(query):
+    if intent.has_public_data_ref("gyeryong_assistive_charger"):
         additions.extend(
             [
                 "계룡시",
@@ -421,8 +268,8 @@ def _public_safety_location_additions(query: str) -> list[str]:
     return additions
 
 
-def _ocean_water_quality_additions(query: str) -> list[str]:
-    if not _MOF_OCEAN_WATER_QUALITY_RE.search(query):
+def _ocean_water_quality_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("mof_ocean_water_quality"):
         return []
     return [
         "해양수산부",
@@ -437,8 +284,8 @@ def _ocean_water_quality_additions(query: str) -> list[str]:
     ]
 
 
-def _pps_bid_additions(query: str) -> list[str]:
-    if not _is_pps_bid_query(query):
+def _pps_bid_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("pps_bid"):
         return []
     return [
         "조달청",
@@ -454,8 +301,8 @@ def _pps_bid_additions(query: str) -> list[str]:
     ]
 
 
-def _kcue_regional_additions(query: str) -> list[str]:
-    if not _is_kcue_regional_query(query):
+def _kcue_regional_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("kcue_regional"):
         return []
     additions = [
         "한국대학교육협의회",
@@ -466,15 +313,15 @@ def _kcue_regional_additions(query: str) -> list[str]:
         "지역별통계",
         "KCUE",
     ]
-    if _KCUE_REGIONAL_FINANCE_RE.search(query):
+    if intent.has_public_data_ref("kcue_regional_finance"):
         additions.extend(["재정현황", "등록금", "FinancesService", "regional tuition"])
-    if _KCUE_REGIONAL_FOREIGN_STUDENT_RE.search(query):
+    if intent.has_public_data_ref("kcue_regional_foreign_student"):
         additions.extend(["학생현황", "외국인유학생", "regional foreign student"])
     return additions
 
 
-def _health_detail_additions(query: str) -> list[str]:
-    if not _HIRA_MEDICAL_DETAIL_RE.search(query):
+def _health_detail_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_public_data_ref("hira_medical_detail"):
         return []
     return [
         "의료기관",
@@ -490,8 +337,8 @@ def _health_detail_additions(query: str) -> list[str]:
     ]
 
 
-def _document_harness_additions(query: str) -> list[str]:
-    if not _is_document_harness_query(query):
+def _document_harness_additions(intent: ToolSelectionIntent) -> list[str]:
+    if not intent.has_document_ref("document_harness"):
         return []
     return [
         "document",
@@ -530,12 +377,12 @@ def _filter_kma_lifestyle_weather_scores(
 
 
 def _filter_public_safety_location_scores(
-    query: str, scored: list[tuple[str, float]]
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
     boosts = {}
-    if _MOIS_EMERGENCY_CALL_BOX_RE.search(query):
+    if intent.has_public_data_ref("mois_emergency_call_box"):
         boosts["mois_emergency_call_box_lookup"] = 1000.0
-    if _GYERYONG_ASSISTIVE_CHARGER_RE.search(query):
+    if intent.has_public_data_ref("gyeryong_assistive_charger"):
         boosts["gyeryong_assistive_device_charging_place_locate"] = 1000.0
     if not boosts:
         return scored
@@ -543,9 +390,9 @@ def _filter_public_safety_location_scores(
 
 
 def _filter_emergency_chain_scores(
-    query: str, scored: list[tuple[str, float]]
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
-    if not _is_emergency_chain_query(query):
+    if not intent.has_public_data_ref("emergency_medical"):
         return scored
     emergency_tool_ids = {
         "nmc_emergency_search",
@@ -556,7 +403,7 @@ def _filter_emergency_chain_scores(
     allowed_tool_ids = emergency_tool_ids | _LOCATION_TOOL_IDS
     if any(tool_id in emergency_tool_ids for tool_id, _ in scored):
         scored = [(tool_id, score) for tool_id, score in scored if tool_id in allowed_tool_ids]
-    implicit_collapse = bool(_IMPLICIT_EMERGENCY_RE.search(query))
+    implicit_collapse = intent.has_public_data_ref("implicit_emergency")
     boosts = {
         "nmc_emergency_search": 1200.0,
         "nmc_aed_site_locate": 1150.0 if implicit_collapse else 950.0,
@@ -572,9 +419,9 @@ def _filter_emergency_chain_scores(
 
 
 def _filter_ocean_water_quality_scores(
-    query: str, scored: list[tuple[str, float]]
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
-    if not _MOF_OCEAN_WATER_QUALITY_RE.search(query):
+    if not intent.has_public_data_ref("mof_ocean_water_quality"):
         return scored
     return [
         (
@@ -585,8 +432,10 @@ def _filter_ocean_water_quality_scores(
     ]
 
 
-def _filter_pps_bid_scores(query: str, scored: list[tuple[str, float]]) -> list[tuple[str, float]]:
-    if not _is_pps_bid_query(query):
+def _filter_pps_bid_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("pps_bid"):
         return scored
     has_pps_bid = any(tool_id == "pps_bid_public_info" for tool_id, _ in scored)
     if not has_pps_bid:
@@ -597,16 +446,16 @@ def _filter_pps_bid_scores(query: str, scored: list[tuple[str, float]]) -> list[
 
 
 def _filter_kcue_regional_scores(
-    query: str, scored: list[tuple[str, float]]
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
-    if not _is_kcue_regional_query(query):
+    if not intent.has_public_data_ref("kcue_regional"):
         return scored
     has_kcue = any(tool_id in _KCUE_TOOL_IDS for tool_id, _ in scored)
     if not has_kcue:
         return scored
 
-    prefer_finance = bool(_KCUE_REGIONAL_FINANCE_RE.search(query))
-    prefer_foreign_student = bool(_KCUE_REGIONAL_FOREIGN_STUDENT_RE.search(query))
+    prefer_finance = intent.has_public_data_ref("kcue_regional_finance")
+    prefer_foreign_student = intent.has_public_data_ref("kcue_regional_foreign_student")
     boosts = {
         "kcue_finance_regional_tuition": 1000.0 if prefer_finance else 700.0,
         "kcue_student_regional_foreign": 1000.0 if prefer_foreign_student else 700.0,
@@ -617,9 +466,9 @@ def _filter_kcue_regional_scores(
 
 
 def _filter_health_detail_scores(
-    query: str, scored: list[tuple[str, float]]
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
-    if not _HIRA_MEDICAL_DETAIL_RE.search(query):
+    if not intent.has_public_data_ref("hira_medical_detail"):
         return scored
     return [
         (
@@ -631,10 +480,10 @@ def _filter_health_detail_scores(
 
 
 def _filter_document_harness_scores(
-    query: str,
+    intent: ToolSelectionIntent,
     scored: list[tuple[str, float]],
 ) -> list[tuple[str, float]]:
-    if not _is_document_harness_query(query):
+    if not intent.has_document_ref("document_harness"):
         return scored
     if not any(tool_id in _DOCUMENT_TOOL_IDS for tool_id, _score in scored):
         return scored
@@ -647,13 +496,13 @@ def _filter_document_harness_scores(
 
 
 def _filter_initial_special_scores(
-    query: str, scored: list[tuple[str, float]]
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
-    if _TRAFFIC_HAZARD_SPECIFIC_RE.search(query):
+    if intent.has_public_data_ref("traffic_hazard_specific"):
         scored = [
             (tool_id, score) for tool_id, score in scored if tool_id != "koroad_accident_search"
         ]
-    if _KMA_ANALYSIS_CHART_RE.search(query):
+    if intent.has_public_data_ref("kma_analysis_chart"):
         return [
             (tool_id, score)
             for tool_id, score in scored
@@ -663,18 +512,18 @@ def _filter_initial_special_scores(
 
 
 def _filter_kma_aviation_scores(
-    query: str, scored: list[tuple[str, float]], *, is_airport_aviation_query: bool
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]], *, is_airport_aviation_query: bool
 ) -> list[tuple[str, float]]:
-    if _KMA_GIMHAE_AIRPORT_RE.search(query) and _KMA_AIRPORT_AVIATION_RE.search(query):
+    if intent.has_public_data_ref("kma_gimhae_airport") and is_airport_aviation_query:
         scored = [
             (tool_id, score)
             for tool_id, score in scored
             if tool_id != "kma_apihub_url_air_amos_minute"
         ]
     if (
-        _KMA_GIMPO_AIRPORT_RE.search(query)
-        and _KMA_RUNWAY_AREA_RE.search(query)
-        and _KMA_AIRPORT_AVIATION_RE.search(query)
+        intent.has_public_data_ref("kma_gimpo_airport")
+        and intent.has_public_data_ref("kma_runway_area")
+        and is_airport_aviation_query
     ):
         scored = [
             (tool_id, score + 500.0 if tool_id == "kma_apihub_url_air_amos_minute" else score)
@@ -686,7 +535,7 @@ def _filter_kma_aviation_scores(
     has_air_url_candidate = any(tool_id in _KMA_URL_AIR_TOOL_IDS for tool_id, _ in scored)
     if not has_air_url_candidate:
         return scored
-    if _KMA_EXPLICIT_METAR_RE.search(query):
+    if intent.has_public_data_ref("kma_explicit_metar"):
         blocked_tool_ids = (
             _LOCATION_TOOL_IDS | _KMA_LIFESTYLE_WEATHER_TOOL_IDS | {"kma_forecast_fetch"}
         )
@@ -694,9 +543,9 @@ def _filter_kma_aviation_scores(
     else:
         scored = [(tool_id, score) for tool_id, score in scored if tool_id in _KMA_URL_AIR_TOOL_IDS]
     prefer_amos = bool(
-        _KMA_GIMPO_AIRPORT_RE.search(query)
-        and _KMA_RUNWAY_AREA_RE.search(query)
-        and not _KMA_GIMHAE_AIRPORT_RE.search(query)
+        intent.has_public_data_ref("kma_gimpo_airport")
+        and intent.has_public_data_ref("kma_runway_area")
+        and not intent.has_public_data_ref("kma_gimhae_airport")
     )
     return [
         (
@@ -714,8 +563,10 @@ def _filter_kma_aviation_scores(
     ]
 
 
-def _boost_aed_scores(query: str, scored: list[tuple[str, float]]) -> list[tuple[str, float]]:
-    if not _AED_RE.search(query):
+def _boost_aed_scores(
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
+) -> list[tuple[str, float]]:
+    if not intent.has_public_data_ref("aed"):
         return scored
     return [
         (
@@ -723,7 +574,7 @@ def _boost_aed_scores(query: str, scored: list[tuple[str, float]]) -> list[tuple
             score + 900.0
             if tool_id == "nmc_aed_site_locate"
             else score + 700.0
-            if tool_id == "nmc_emergency_search" and _EMERGENCY_RE.search(query)
+            if tool_id == "nmc_emergency_search" and intent.has_public_data_ref("emergency_medical")
             else score,
         )
         for tool_id, score in scored
@@ -740,30 +591,35 @@ def _expand_query_for_adapter_retrieval(query: str) -> str:
     adapter contract unchanged while letting the concrete locate adapter stay
     visible to the model.
     """
+    intent: ToolSelectionIntent = extract_tool_selection_intent(query)
+    return _expand_query_for_intent(query, intent)
+
+
+def _expand_query_for_intent(query: str, intent: ToolSelectionIntent) -> str:
     additions: list[str] = []
-    is_airport_aviation_query = _is_airport_aviation_query(query)
+    is_airport_aviation_query = intent.has_public_data_ref("kma_airport_aviation")
     if is_airport_aviation_query:
-        additions.extend(_airport_aviation_additions(query))
-    if _KMA_ANALYSIS_DATA_RE.search(query):
+        additions.extend(_airport_aviation_additions(intent))
+    if intent.has_public_data_ref("kma_analysis_data"):
         additions.extend(_kma_analysis_data_additions())
-    if _is_lifestyle_weather_query(query, is_airport_aviation_query=is_airport_aviation_query):
+    if intent.has_public_data_ref("kma_lifestyle_weather"):
         additions.extend(_kma_lifestyle_weather_additions())
-    if _POI_LOCATION_RE.search(query) and not is_airport_aviation_query:
+    if intent.has_location_ref("poi") and not is_airport_aviation_query:
         additions.extend(["장소", "키워드", "POI", "랜드마크", "역", "keyword"])
-    if _ADMIN_LOCATION_RE.search(query):
+    if intent.has_location_ref("admin"):
         additions.extend(["주소", "행정동", "법정동", "도로명", "지번", "address"])
-    if _EMERGENCY_RE.search(query):
+    if intent.has_public_data_ref("emergency_medical"):
         additions.extend(["응급실", "응급의료", "NMC", "emergency"])
-    if _AED_RE.search(query):
+    if intent.has_public_data_ref("aed"):
         additions.extend(["AED", "자동심장충격기", "자동제세동기", "국립중앙의료원"])
-    additions.extend(_emergency_chain_additions(query))
-    additions.extend(_pps_bid_additions(query))
-    additions.extend(_kcue_regional_additions(query))
-    additions.extend(_ocean_water_quality_additions(query))
-    additions.extend(_health_detail_additions(query))
-    additions.extend(_document_harness_additions(query))
-    additions.extend(_public_safety_location_additions(query))
-    if _TRAFFIC_HAZARD_RE.search(query):
+    additions.extend(_emergency_chain_additions(intent))
+    additions.extend(_pps_bid_additions(intent))
+    additions.extend(_kcue_regional_additions(intent))
+    additions.extend(_ocean_water_quality_additions(intent))
+    additions.extend(_health_detail_additions(intent))
+    additions.extend(_document_harness_additions(intent))
+    additions.extend(_public_safety_location_additions(intent))
+    if intent.has_public_data_ref("traffic_hazard"):
         additions.extend(_traffic_hazard_additions())
     if not additions:
         return query
@@ -771,43 +627,40 @@ def _expand_query_for_adapter_retrieval(query: str) -> str:
 
 
 def _filter_special_case_scores(
-    query: str, scored: list[tuple[str, float]]
+    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
     """Apply deterministic domain disambiguation after backend scoring."""
-    is_airport_aviation_query = _is_airport_aviation_query(query)
-    is_analysis_query = bool(_KMA_ANALYSIS_DATA_RE.search(query))
-    is_analysis_map_query = bool(_KMA_ANALYSIS_MAP_RE.search(query))
-    is_analysis_point_query = _is_kma_analysis_point_query(
-        query, is_analysis_map_query=is_analysis_map_query
+    is_airport_aviation_query = intent.has_public_data_ref("kma_airport_aviation")
+    is_analysis_query = intent.has_public_data_ref("kma_analysis_data")
+    is_analysis_map_query = intent.has_public_data_ref("kma_analysis_map")
+    is_analysis_point_query = (
+        intent.has_public_data_ref("kma_analysis_point") and not is_analysis_map_query
     )
-    is_lifestyle_weather_query = _is_lifestyle_weather_query(
-        query, is_airport_aviation_query=is_airport_aviation_query
-    )
-    scored = _filter_initial_special_scores(query, scored)
+    is_lifestyle_weather_query = intent.has_public_data_ref("kma_lifestyle_weather")
+    scored = _filter_initial_special_scores(intent, scored)
     if is_analysis_query:
         scored = _filter_kma_analysis_scores(
             scored,
             is_analysis_map_query=is_analysis_map_query,
             is_analysis_point_query=is_analysis_point_query,
-            prefer_poi_location=bool(_POI_LOCATION_RE.search(query)),
+            prefer_poi_location=intent.has_location_ref("poi"),
         )
     if is_lifestyle_weather_query:
         scored = _filter_kma_lifestyle_weather_scores(scored)
-    scored = _filter_document_harness_scores(query, scored)
-    scored = _filter_emergency_chain_scores(query, scored)
-    scored = _filter_pps_bid_scores(query, scored)
-    scored = _filter_kcue_regional_scores(query, scored)
-    scored = _filter_health_detail_scores(query, scored)
-    scored = _filter_public_safety_location_scores(query, scored)
-    scored = _filter_ocean_water_quality_scores(query, scored)
+    scored = _filter_document_harness_scores(intent, scored)
+    scored = _filter_emergency_chain_scores(intent, scored)
+    scored = _filter_pps_bid_scores(intent, scored)
+    scored = _filter_kcue_regional_scores(intent, scored)
+    scored = _filter_health_detail_scores(intent, scored)
+    scored = _filter_public_safety_location_scores(intent, scored)
+    scored = _filter_ocean_water_quality_scores(intent, scored)
     scored = _filter_kma_aviation_scores(
-        query, scored, is_airport_aviation_query=is_airport_aviation_query
+        intent, scored, is_airport_aviation_query=is_airport_aviation_query
     )
-    scored = _boost_aed_scores(query, scored)
+    scored = _boost_aed_scores(intent, scored)
 
-    query_lower = query.lower()
     return [
-        (tool_id, score + 1000.0 if tool_id.lower() in query_lower else score)
+        (tool_id, score + 1000.0 if tool_id in intent.explicit_tool_ids else score)
         for tool_id, score in scored
     ]
 
@@ -850,9 +703,11 @@ def search(
     if registry_size == 0:
         return []
 
+    intent = extract_tool_selection_intent(query, known_tool_ids=registry._tools.keys())
+    expanded_query = _expand_query_for_intent(query, intent)
     retriever = registry._retriever
     try:
-        scored = retriever.score(_expand_query_for_adapter_retrieval(query))
+        scored = retriever.score(expanded_query)
     except Exception as exc:
         # FR-002 fail-open: a mid-session retriever failure (dense OOM,
         # tokenizer crash, encoder corruption) must not surface as a 5xx
@@ -876,7 +731,7 @@ def search(
             )
             return []
         try:
-            scored = bm25_companion.score(_expand_query_for_adapter_retrieval(query))
+            scored = bm25_companion.score(expanded_query)
         except Exception as bm25_exc:
             logger.warning(
                 "search: BM25 companion also failed (%s: %s) — returning empty ranking",
@@ -885,7 +740,7 @@ def search(
             )
             return []
 
-    scored = _filter_special_case_scores(query, scored)
+    scored = _filter_special_case_scores(intent, scored)
 
     # Enforce the deterministic tie-break once, here. Backend-internal
     # orderings are not trusted (HybridBackend returns unordered union).

--- a/src/ummaya/tools/search.py
+++ b/src/ummaya/tools/search.py
@@ -26,6 +26,18 @@ from ummaya.tools.models import (
     ToolSearchResult,
 )
 from ummaya.tools.routing.intent import ToolSelectionIntent, extract_tool_selection_intent
+from ummaya.tools.routing.retrieval_policy import (
+    expand_query_for_adapter_retrieval as _policy_expand_query_for_adapter_retrieval,
+)
+from ummaya.tools.routing.retrieval_policy import (
+    expand_query_for_intent as _policy_expand_query_for_intent,
+)
+from ummaya.tools.routing.retrieval_policy import (
+    filter_special_case_scores as _policy_filter_special_case_scores,
+)
+from ummaya.tools.routing.retrieval_policy import (
+    is_document_harness_query as _policy_is_document_harness_query,
+)
 
 if TYPE_CHECKING:
     from ummaya.tools.registry import ToolRegistry
@@ -33,636 +45,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-_KCUE_TOOL_IDS = frozenset(
-    {
-        "kcue_finance_regional_tuition",
-        "kcue_student_regional_foreign",
-    }
-)
-_DOCUMENT_TOOL_IDS = frozenset({"document"})
-_KMA_URL_AIR_TOOL_IDS = frozenset(
-    {
-        "kma_apihub_url_air_amos_minute",
-        "kma_apihub_url_air_metar_decoded",
-    }
-)
-_KMA_ANALYSIS_TOOL_IDS = frozenset(
-    {
-        "kma_apihub_url_high_resolution_grid_point",
-        "kma_apihub_url_aws_objective_analysis_grid",
-        "kma_apihub_url_analysis_weather_chart_image",
-    }
-)
-_KMA_LIFESTYLE_WEATHER_TOOL_IDS = frozenset(
-    {
-        "kma_current_observation",
-        "kma_ultra_short_term_forecast",
-        "kma_short_term_forecast",
-    }
-)
-_LOCATION_TOOL_IDS = frozenset(
-    {
-        "locate",
-        "kakao_address_search",
-        "kakao_keyword_search",
-        "kakao_coord_to_region",
-        "juso_adm_cd_lookup",
-        "sgis_adm_cd_lookup",
-    }
-)
-
-
-def _is_kma_analysis_point_query(query: str, *, is_analysis_map_query: bool) -> bool:
-    return (
-        extract_tool_selection_intent(query).has_public_data_ref("kma_analysis_point")
-        and not is_analysis_map_query
-    )
-
-
-def _is_airport_aviation_query(query: str) -> bool:
-    return extract_tool_selection_intent(query).has_public_data_ref("kma_airport_aviation")
-
-
-def _is_lifestyle_weather_query(query: str, *, is_airport_aviation_query: bool) -> bool:
-    del is_airport_aviation_query
-    return extract_tool_selection_intent(query).has_public_data_ref("kma_lifestyle_weather")
-
-
-def _is_pps_bid_query(query: str) -> bool:
-    return extract_tool_selection_intent(query).has_public_data_ref("pps_bid")
-
-
-def _is_kcue_regional_query(query: str) -> bool:
-    return extract_tool_selection_intent(query).has_public_data_ref("kcue_regional")
-
-
-def _is_document_harness_query(query: str) -> bool:
-    return extract_tool_selection_intent(query).has_document_ref("document_harness")
-
-
 def is_document_harness_query(query: str) -> bool:
-    """Return whether a query is a local document-harness request."""
-    return _is_document_harness_query(query)
-
-
-def _is_emergency_chain_query(query: str) -> bool:
-    return extract_tool_selection_intent(query).has_public_data_ref("emergency_medical")
-
-
-def _filter_kma_analysis_scores(
-    scored: list[tuple[str, float]],
-    *,
-    is_analysis_map_query: bool,
-    is_analysis_point_query: bool,
-    prefer_poi_location: bool,
-) -> list[tuple[str, float]]:
-    chart_boost = 900.0 if is_analysis_map_query else 150.0
-    if is_analysis_point_query and not is_analysis_map_query:
-        chart_boost = -20.0
-    analysis_boosts = {
-        "kma_apihub_url_analysis_weather_chart_image": chart_boost,
-        "kma_apihub_url_high_resolution_grid_point": (900.0 if is_analysis_point_query else 450.0),
-        "kma_apihub_url_aws_objective_analysis_grid": (800.0 if is_analysis_point_query else 400.0),
-    }
-    allowed_location_ids = _LOCATION_TOOL_IDS if is_analysis_point_query else frozenset()
-    adjusted: list[tuple[str, float]] = []
-    for tool_id, score in scored:
-        if tool_id in _KMA_ANALYSIS_TOOL_IDS:
-            adjusted.append((tool_id, score + analysis_boosts.get(tool_id, 0.0)))
-            continue
-        if tool_id in allowed_location_ids:
-            location_score = max(1.0, score - 10.0)
-            if prefer_poi_location and tool_id == "kakao_keyword_search":
-                location_score += 30.0
-            elif prefer_poi_location and tool_id == "kakao_address_search":
-                location_score = max(1.0, location_score - 15.0)
-            adjusted.append((tool_id, location_score))
-    return adjusted
-
-
-def _kma_lifestyle_weather_additions() -> list[str]:
-    return [
-        "기상청",
-        "KMA",
-        "현재날씨",
-        "초단기실황",
-        "초단기예보",
-        "단기예보",
-        "강수",
-        "우산",
-        "nx",
-        "ny",
-        "base_date",
-        "base_time",
-        "current",
-        "observation",
-        "forecast",
-        "precipitation",
-    ]
-
-
-def _airport_aviation_additions(intent: ToolSelectionIntent) -> list[str]:
-    additions = [
-        "METAR",
-        "SPECI",
-        "AMOS",
-        "항공기상",
-        "공항기상",
-        "항공",
-        "비행기",
-        "항공편",
-        "운항",
-        "이륙",
-        "시정",
-        "RVR",
-        "wind",
-        "visibility",
-    ]
-    if intent.has_public_data_ref("kma_gimpo_airport") and intent.has_public_data_ref(
-        "kma_runway_area"
-    ):
-        additions.extend(["AMOS", "공항기상관측", "매분자료", "활주로", "김포공항", "stn110"])
-    return additions
-
-
-def _kma_analysis_data_additions() -> list[str]:
-    return [
-        "분석자료",
-        "고해상도",
-        "격자자료",
-        "객관분석",
-        "AWS",
-        "분석일기도",
-        "지도",
-        "비구름",
-        "바람흐름",
-        "objective",
-        "analysis",
-        "grid",
-        "chart",
-    ]
-
-
-def _traffic_hazard_additions() -> list[str]:
-    return [
-        "교통사고",
-        "사고다발구역",
-        "위험지점",
-        "도로위험구역",
-        "어린이보호구역",
-        "행정동코드",
-        "KOROAD",
-        "accident",
-        "hazard",
-    ]
-
-
-def _emergency_chain_additions(intent: ToolSelectionIntent) -> list[str]:
-    if not intent.has_public_data_ref("emergency_medical"):
-        return []
-    additions = [
-        "응급실",
-        "응급의료",
-        "자동심장충격기",
-        "AED",
-        "국립중앙의료원",
-        "NMC",
-        "nearby",
-        "emergency",
-        "hospital",
-    ]
-    if intent.has_location_ref("poi"):
-        additions.extend(["장소", "키워드", "POI", "랜드마크", "역", "keyword"])
-    return additions
-
-
-def _public_safety_location_additions(intent: ToolSelectionIntent) -> list[str]:
-    additions: list[str] = []
-    if intent.has_public_data_ref("mois_emergency_call_box"):
-        additions.extend(
-            [
-                "안전비상벨",
-                "비상벨",
-                "긴급신고함",
-                "방범",
-                "행정안전부",
-                "MOIS",
-                "emergency",
-                "call",
-                "box",
-            ]
-        )
-    if intent.has_public_data_ref("gyeryong_assistive_charger"):
-        additions.extend(
-            [
-                "계룡시",
-                "전동보장구",
-                "전동휠체어",
-                "장애인",
-                "충전소",
-                "충전장소",
-                "accessibility",
-                "charger",
-            ]
-        )
-    return additions
-
-
-def _ocean_water_quality_additions(intent: ToolSelectionIntent) -> list[str]:
-    if not intent.has_public_data_ref("mof_ocean_water_quality"):
-        return []
-    return [
-        "해양수산부",
-        "해양수질",
-        "수질자동측정망",
-        "관측소",
-        "SEA3003",
-        "용존산소",
-        "water",
-        "quality",
-        "ocean",
-    ]
-
-
-def _pps_bid_additions(intent: ToolSelectionIntent) -> list[str]:
-    if not intent.has_public_data_ref("pps_bid"):
-        return []
-    return [
-        "조달청",
-        "나라장터",
-        "입찰공고",
-        "공사입찰",
-        "bidNtceNm",
-        "inqryBgnDt",
-        "inqryEndDt",
-        "PPS",
-        "bid",
-        "procurement",
-    ]
-
-
-def _kcue_regional_additions(intent: ToolSelectionIntent) -> list[str]:
-    if not intent.has_public_data_ref("kcue_regional"):
-        return []
-    additions = [
-        "한국대학교육협의회",
-        "대학알리미",
-        "대학정보공시",
-        "학교구분코드",
-        "schlDivCd",
-        "지역별통계",
-        "KCUE",
-    ]
-    if intent.has_public_data_ref("kcue_regional_finance"):
-        additions.extend(["재정현황", "등록금", "FinancesService", "regional tuition"])
-    if intent.has_public_data_ref("kcue_regional_foreign_student"):
-        additions.extend(["학생현황", "외국인유학생", "regional foreign student"])
-    return additions
-
-
-def _health_detail_additions(intent: ToolSelectionIntent) -> list[str]:
-    if not intent.has_public_data_ref("hira_medical_detail"):
-        return []
-    return [
-        "의료기관",
-        "상세정보",
-        "진료과목",
-        "진료시간",
-        "주차",
-        "요양기호",
-        "ykiho",
-        "HIRA",
-        "hospital",
-        "detail",
-    ]
-
-
-def _document_harness_additions(intent: ToolSelectionIntent) -> list[str]:
-    if not intent.has_document_ref("document_harness"):
-        return []
-    return [
-        "document",
-        "document.path",
-        "local",
-        "file",
-        "path",
-        "artifact_refs",
-        "public",
-        "document",
-        "harness",
-        "form",
-        "render",
-        "diff",
-        "save",
-    ]
-
-
-def _filter_kma_lifestyle_weather_scores(
-    scored: list[tuple[str, float]],
-) -> list[tuple[str, float]]:
-    allowed_tool_ids = _KMA_LIFESTYLE_WEATHER_TOOL_IDS | _LOCATION_TOOL_IDS
-    if any(tool_id in allowed_tool_ids for tool_id, _ in scored):
-        scored = [(tool_id, score) for tool_id, score in scored if tool_id in allowed_tool_ids]
-    boosts = {
-        "kakao_keyword_search": 1100.0,
-        "kakao_address_search": 1000.0,
-        "kma_current_observation": 900.0,
-        "kma_ultra_short_term_forecast": 800.0,
-        "kma_short_term_forecast": 650.0,
-        "kakao_coord_to_region": 260.0,
-        "juso_adm_cd_lookup": 260.0,
-        "sgis_adm_cd_lookup": 260.0,
-    }
-    return [(tool_id, score + boosts.get(tool_id, 0.0)) for tool_id, score in scored]
-
-
-def _filter_public_safety_location_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    boosts = {}
-    if intent.has_public_data_ref("mois_emergency_call_box"):
-        boosts["mois_emergency_call_box_lookup"] = 1000.0
-    if intent.has_public_data_ref("gyeryong_assistive_charger"):
-        boosts["gyeryong_assistive_device_charging_place_locate"] = 1000.0
-    if not boosts:
-        return scored
-    return [(tool_id, score + boosts.get(tool_id, 0.0)) for tool_id, score in scored]
-
-
-def _filter_emergency_chain_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    if not intent.has_public_data_ref("emergency_medical"):
-        return scored
-    emergency_tool_ids = {
-        "nmc_emergency_search",
-        "nmc_aed_site_locate",
-        "hira_hospital_search",
-        "hira_medical_institution_detail",
-    }
-    allowed_tool_ids = emergency_tool_ids | _LOCATION_TOOL_IDS
-    if any(tool_id in emergency_tool_ids for tool_id, _ in scored):
-        scored = [(tool_id, score) for tool_id, score in scored if tool_id in allowed_tool_ids]
-    implicit_collapse = intent.has_public_data_ref("implicit_emergency")
-    boosts = {
-        "nmc_emergency_search": 1200.0,
-        "nmc_aed_site_locate": 1150.0 if implicit_collapse else 950.0,
-        "kakao_keyword_search": 1100.0 if implicit_collapse else 900.0,
-        "kakao_address_search": 800.0,
-        "kakao_coord_to_region": 500.0,
-        "juso_adm_cd_lookup": 300.0,
-        "sgis_adm_cd_lookup": 300.0,
-        "hira_hospital_search": 250.0,
-        "hira_medical_institution_detail": 200.0,
-    }
-    return [(tool_id, score + boosts.get(tool_id, 0.0)) for tool_id, score in scored]
-
-
-def _filter_ocean_water_quality_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    if not intent.has_public_data_ref("mof_ocean_water_quality"):
-        return scored
-    return [
-        (
-            tool_id,
-            score + (1000.0 if tool_id == "mof_ocean_water_quality_check" else 0.0),
-        )
-        for tool_id, score in scored
-    ]
-
-
-def _filter_pps_bid_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    if not intent.has_public_data_ref("pps_bid"):
-        return scored
-    has_pps_bid = any(tool_id == "pps_bid_public_info" for tool_id, _ in scored)
-    if not has_pps_bid:
-        return scored
-    return [
-        (tool_id, score + 1000.0) for tool_id, score in scored if tool_id == "pps_bid_public_info"
-    ]
-
-
-def _filter_kcue_regional_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    if not intent.has_public_data_ref("kcue_regional"):
-        return scored
-    has_kcue = any(tool_id in _KCUE_TOOL_IDS for tool_id, _ in scored)
-    if not has_kcue:
-        return scored
-
-    prefer_finance = intent.has_public_data_ref("kcue_regional_finance")
-    prefer_foreign_student = intent.has_public_data_ref("kcue_regional_foreign_student")
-    boosts = {
-        "kcue_finance_regional_tuition": 1000.0 if prefer_finance else 700.0,
-        "kcue_student_regional_foreign": 1000.0 if prefer_foreign_student else 700.0,
-    }
-    return [
-        (tool_id, score + boosts[tool_id]) for tool_id, score in scored if tool_id in _KCUE_TOOL_IDS
-    ]
-
-
-def _filter_health_detail_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    if not intent.has_public_data_ref("hira_medical_detail"):
-        return scored
-    return [
-        (
-            tool_id,
-            score + (650.0 if tool_id == "hira_medical_institution_detail" else 0.0),
-        )
-        for tool_id, score in scored
-    ]
-
-
-def _filter_document_harness_scores(
-    intent: ToolSelectionIntent,
-    scored: list[tuple[str, float]],
-) -> list[tuple[str, float]]:
-    if not intent.has_document_ref("document_harness"):
-        return scored
-    if not any(tool_id in _DOCUMENT_TOOL_IDS for tool_id, _score in scored):
-        return scored
-    boosts = {"document": 1600.0}
-    return [
-        (tool_id, score + boosts[tool_id])
-        for tool_id, score in scored
-        if tool_id in _DOCUMENT_TOOL_IDS
-    ]
-
-
-def _filter_initial_special_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    if intent.has_public_data_ref("traffic_hazard_specific"):
-        scored = [
-            (tool_id, score) for tool_id, score in scored if tool_id != "koroad_accident_search"
-        ]
-    if intent.has_public_data_ref("kma_analysis_chart"):
-        return [
-            (tool_id, score)
-            for tool_id, score in scored
-            if tool_id == "kma_apihub_url_analysis_weather_chart_image"
-        ]
-    return scored
-
-
-def _filter_kma_aviation_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]], *, is_airport_aviation_query: bool
-) -> list[tuple[str, float]]:
-    if intent.has_public_data_ref("kma_gimhae_airport") and is_airport_aviation_query:
-        scored = [
-            (tool_id, score)
-            for tool_id, score in scored
-            if tool_id != "kma_apihub_url_air_amos_minute"
-        ]
-    if (
-        intent.has_public_data_ref("kma_gimpo_airport")
-        and intent.has_public_data_ref("kma_runway_area")
-        and is_airport_aviation_query
-    ):
-        scored = [
-            (tool_id, score + 500.0 if tool_id == "kma_apihub_url_air_amos_minute" else score)
-            for tool_id, score in scored
-        ]
-    if not is_airport_aviation_query:
-        return scored
-
-    has_air_url_candidate = any(tool_id in _KMA_URL_AIR_TOOL_IDS for tool_id, _ in scored)
-    if not has_air_url_candidate:
-        return scored
-    if intent.has_public_data_ref("kma_explicit_metar"):
-        blocked_tool_ids = (
-            _LOCATION_TOOL_IDS | _KMA_LIFESTYLE_WEATHER_TOOL_IDS | {"kma_forecast_fetch"}
-        )
-        scored = [(tool_id, score) for tool_id, score in scored if tool_id not in blocked_tool_ids]
-    else:
-        scored = [(tool_id, score) for tool_id, score in scored if tool_id in _KMA_URL_AIR_TOOL_IDS]
-    prefer_amos = bool(
-        intent.has_public_data_ref("kma_gimpo_airport")
-        and intent.has_public_data_ref("kma_runway_area")
-        and not intent.has_public_data_ref("kma_gimhae_airport")
-    )
-    return [
-        (
-            tool_id,
-            score
-            + (
-                800.0
-                if tool_id == "kma_apihub_url_air_amos_minute" and prefer_amos
-                else 700.0
-                if tool_id == "kma_apihub_url_air_metar_decoded"
-                else 0.0
-            ),
-        )
-        for tool_id, score in scored
-    ]
-
-
-def _boost_aed_scores(
-    intent: ToolSelectionIntent, scored: list[tuple[str, float]]
-) -> list[tuple[str, float]]:
-    if not intent.has_public_data_ref("aed"):
-        return scored
-    return [
-        (
-            tool_id,
-            score + 900.0
-            if tool_id == "nmc_aed_site_locate"
-            else score + 700.0
-            if tool_id == "nmc_emergency_search" and intent.has_public_data_ref("emergency_medical")
-            else score,
-        )
-        for tool_id, score in scored
-    ]
+    return _policy_is_document_harness_query(query)
 
 
 def _expand_query_for_adapter_retrieval(query: str) -> str:
-    """Add domain-neutral retrieval hints that Korean spacing can hide.
-
-    The retriever indexes adapter search hints, not a Korean morphological
-    parse.  A station query such as "하단역 근처 응급실" contains a POI suffix,
-    but does not literally contain the "키워드/POI/랜드마크" terms in
-    ``kakao_keyword_search``.  Expanding only the retrieval query keeps the
-    adapter contract unchanged while letting the concrete locate adapter stay
-    visible to the model.
-    """
-    intent: ToolSelectionIntent = extract_tool_selection_intent(query)
-    return _expand_query_for_intent(query, intent)
+    return _policy_expand_query_for_adapter_retrieval(query)
 
 
 def _expand_query_for_intent(query: str, intent: ToolSelectionIntent) -> str:
-    additions: list[str] = []
-    is_airport_aviation_query = intent.has_public_data_ref("kma_airport_aviation")
-    if is_airport_aviation_query:
-        additions.extend(_airport_aviation_additions(intent))
-    if intent.has_public_data_ref("kma_analysis_data"):
-        additions.extend(_kma_analysis_data_additions())
-    if intent.has_public_data_ref("kma_lifestyle_weather"):
-        additions.extend(_kma_lifestyle_weather_additions())
-    if intent.has_location_ref("poi") and not is_airport_aviation_query:
-        additions.extend(["장소", "키워드", "POI", "랜드마크", "역", "keyword"])
-    if intent.has_location_ref("admin"):
-        additions.extend(["주소", "행정동", "법정동", "도로명", "지번", "address"])
-    if intent.has_public_data_ref("emergency_medical"):
-        additions.extend(["응급실", "응급의료", "NMC", "emergency"])
-    if intent.has_public_data_ref("aed"):
-        additions.extend(["AED", "자동심장충격기", "자동제세동기", "국립중앙의료원"])
-    additions.extend(_emergency_chain_additions(intent))
-    additions.extend(_pps_bid_additions(intent))
-    additions.extend(_kcue_regional_additions(intent))
-    additions.extend(_ocean_water_quality_additions(intent))
-    additions.extend(_health_detail_additions(intent))
-    additions.extend(_document_harness_additions(intent))
-    additions.extend(_public_safety_location_additions(intent))
-    if intent.has_public_data_ref("traffic_hazard"):
-        additions.extend(_traffic_hazard_additions())
-    if not additions:
-        return query
-    return f"{query} {' '.join(additions)}"
+    return _policy_expand_query_for_intent(query, intent)
 
 
 def _filter_special_case_scores(
     intent: ToolSelectionIntent, scored: list[tuple[str, float]]
 ) -> list[tuple[str, float]]:
-    """Apply deterministic domain disambiguation after backend scoring."""
-    is_airport_aviation_query = intent.has_public_data_ref("kma_airport_aviation")
-    is_analysis_query = intent.has_public_data_ref("kma_analysis_data")
-    is_analysis_map_query = intent.has_public_data_ref("kma_analysis_map")
-    is_analysis_point_query = (
-        intent.has_public_data_ref("kma_analysis_point") and not is_analysis_map_query
-    )
-    is_lifestyle_weather_query = intent.has_public_data_ref("kma_lifestyle_weather")
-    scored = _filter_initial_special_scores(intent, scored)
-    if is_analysis_query:
-        scored = _filter_kma_analysis_scores(
-            scored,
-            is_analysis_map_query=is_analysis_map_query,
-            is_analysis_point_query=is_analysis_point_query,
-            prefer_poi_location=intent.has_location_ref("poi"),
-        )
-    if is_lifestyle_weather_query:
-        scored = _filter_kma_lifestyle_weather_scores(scored)
-    scored = _filter_document_harness_scores(intent, scored)
-    scored = _filter_emergency_chain_scores(intent, scored)
-    scored = _filter_pps_bid_scores(intent, scored)
-    scored = _filter_kcue_regional_scores(intent, scored)
-    scored = _filter_health_detail_scores(intent, scored)
-    scored = _filter_public_safety_location_scores(intent, scored)
-    scored = _filter_ocean_water_quality_scores(intent, scored)
-    scored = _filter_kma_aviation_scores(
-        intent, scored, is_airport_aviation_query=is_airport_aviation_query
-    )
-    scored = _boost_aed_scores(intent, scored)
-
-    return [
-        (tool_id, score + 1000.0 if tool_id in intent.explicit_tool_ids else score)
-        for tool_id, score in scored
-    ]
+    return _policy_filter_special_case_scores(intent, scored)
 
 
 def search(
@@ -704,67 +102,26 @@ def search(
         return []
 
     intent = extract_tool_selection_intent(query, known_tool_ids=registry._tools.keys())
-    expanded_query = _expand_query_for_intent(query, intent)
-    retriever = registry._retriever
-    try:
-        scored = retriever.score(expanded_query)
-    except Exception as exc:
-        # FR-002 fail-open: a mid-session retriever failure (dense OOM,
-        # tokenizer crash, encoder corruption) must not surface as a 5xx
-        # on the citizen path. The Retriever protocol does not forbid
-        # score() from raising, so this is the last defensive boundary
-        # before the public ``lookup`` contract. Try the retriever's BM25
-        # companion (present on ``_DenseFailOpenWrapper`` and
-        # ``HybridBackend``) before falling back to an empty ranking so
-        # citizens still see lexical matches when the dense path crashes
-        # outside its own catch-blocks.
-        logger.warning(
-            "search: retriever.score failed (%s: %s) — attempting BM25 companion fallback",
-            type(exc).__name__,
-            exc,
-        )
-        bm25_companion = getattr(retriever, "_bm25", None)
-        if bm25_companion is None:
-            logger.warning(
-                "search: no BM25 companion on retriever %s — returning empty ranking",
-                type(retriever).__name__,
-            )
-            return []
-        try:
-            scored = bm25_companion.score(expanded_query)
-        except Exception as bm25_exc:
-            logger.warning(
-                "search: BM25 companion also failed (%s: %s) — returning empty ranking",
-                type(bm25_exc).__name__,
-                bm25_exc,
-            )
-            return []
 
-    scored = _filter_special_case_scores(intent, scored)
+    from ummaya.tools.routing.decision_service import RouteDecisionService
 
-    # Enforce the deterministic tie-break once, here. Backend-internal
-    # orderings are not trusted (HybridBackend returns unordered union).
-    scored = sorted(scored, key=lambda pair: (-pair[1], pair[0]))
-
-    # Derive the backend label from the active retriever. Prefer the
-    # explicit ``_requested_backend_label`` attribute (set on wrappers
-    # like ``_DenseFailOpenWrapper`` that report a logical backend name
-    # distinct from their Python class name) so ``why_matched`` reflects
-    # the operator's configured backend, not an internal wrapper type.
-    backend_label = getattr(
-        retriever,
-        "_requested_backend_label",
-        type(retriever).__name__.removesuffix("Backend").lower() or "retrieval",
+    decision = RouteDecisionService(registry).select_adapters(
+        query,
+        top_k=effective_top_k,
+        max_selected=effective_top_k,
+        intent=intent,
     )
 
     results: list[AdapterCandidate] = []
-    for tool_id, score in scored[:effective_top_k]:
+    for route_candidate in decision.candidate_set:
+        tool_id = route_candidate.tool_id
         try:
             tool = registry.find(tool_id)
         except Exception:  # pragma: no cover
             logger.warning("search: tool %r in retriever but not in registry", tool_id)
             continue
 
+        score = route_candidate.retrieval_score
         input_schema_json, required_params = _input_schema_export(tool)
         output_schema_json = _output_schema_export(tool)
         candidate = AdapterCandidate(
@@ -772,7 +129,7 @@ def search(
             score=max(0.0, float(score)),
             required_params=required_params,
             search_hint=tool.search_hint,
-            why_matched=f"{backend_label} score {score:.4f} on search_hint",
+            why_matched=f"{decision.backend_label} score {score:.4f} on search_hint",
             input_schema_json=input_schema_json,
             output_schema_json=output_schema_json,
             llm_description=tool.llm_description,

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -629,6 +629,29 @@ def test_available_adapters_context_pps_bid_search_exposes_search_contract() -> 
     assert "bid_ntce_no" not in content
 
 
+def test_available_adapters_context_air_quality_exposes_airkorea() -> None:
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry)
+    register_all_tools(registry, executor)
+    engine = QueryEngine(
+        llm_client=_FailingMockClient(),
+        tool_registry=registry,
+        tool_executor=executor,
+    )
+
+    message, turn_tool_ids = engine._build_available_adapters_context(  # noqa: SLF001
+        "부산 공기질과 미세먼지 지금 어때? air quality 확인해줘"
+    )
+
+    assert message is not None
+    content = message.content or ""
+    assert turn_tool_ids[0] == "airkorea_ctprvn_air_quality"
+    assert "airkorea_ctprvn_air_quality" in turn_tool_ids
+    assert "kma_current_observation" not in turn_tool_ids
+    assert "kakao_keyword_search" not in turn_tool_ids
+    assert "sido_name" in content
+
+
 def test_available_adapters_context_natural_kcue_finance_excludes_locate() -> None:
     """Natural official university tuition wording should expose KCUE finance first."""
 

--- a/tests/engine/test_engine.py
+++ b/tests/engine/test_engine.py
@@ -181,6 +181,14 @@ def _adapter_context_tool() -> GovAPITool:
     )
 
 
+def _projected_tool_ids(content: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip().removeprefix("- tool_id:").strip()
+        for line in content.splitlines()
+        if line.strip().startswith("- tool_id:")
+    )
+
+
 def test_available_adapters_context_includes_retrieved_adapter() -> None:
     """Rich REPL QueryEngine must inject BM25 adapter candidates for the turn."""
     registry = ToolRegistry()
@@ -199,13 +207,38 @@ def test_available_adapters_context_includes_retrieved_adapter() -> None:
 
     assert message is not None
     assert message.role == "system"
-    assert "<available_adapters>" in (message.content or "")
+    assert "<available_adapters" in (message.content or "")
     assert "bfc_funeral_area_fee" in (message.content or "")
-    assert "The model-facing function name is the concrete tool_id" in (message.content or "")
-    assert "Do not call locate just because" in (message.content or "")
-    assert "call_hint: bfc_funeral_area_fee({...})" in (message.content or "")
+    assert 'backend="bm25"' in (message.content or "")
+    assert 'schema_projection="summary"' in (message.content or "")
+    assert "RouteDecision candidates" in (message.content or "")
+    assert "input_schema_summary" in (message.content or "")
+    assert "call_hint: bfc_funeral_area_fee({...schema fields...})" in (message.content or "")
+    assert "input_schema_json" not in (message.content or "")
     assert 'find({"tool_id":"bfc_funeral_area_fee"' not in (message.content or "")
     assert "Do not call the concrete tool_id as a function name" not in (message.content or "")
+
+
+def test_available_adapters_context_projection_matches_exposed_tools() -> None:
+    registry = ToolRegistry()
+    register_mvp_surface(registry)
+    registry.register(_adapter_context_tool())
+    executor = ToolExecutor(registry)
+    engine = QueryEngine(
+        llm_client=_FailingMockClient(),
+        tool_registry=registry,
+        tool_executor=executor,
+    )
+
+    message, turn_tool_ids = engine._build_available_adapters_context(  # noqa: SLF001
+        "부산광역시 장례식장 시설 사용료 목록을 조회해줘"
+    )
+
+    assert message is not None
+    content = message.content or ""
+    projected_tool_ids = _projected_tool_ids(content)
+    assert projected_tool_ids == turn_tool_ids
+    assert not (set(projected_tool_ids) & {"find", "locate", "check", "send", "search_tools"})
 
 
 @pytest.mark.asyncio
@@ -289,7 +322,8 @@ def test_available_adapters_context_prioritizes_document_primitive() -> None:
     content = message.content or ""
     assert "tool_id: document" in content
     assert "document.path" in content
-    assert "Do not call locate" in content
+    assert 'schema_projection="summary"' in content
+    assert "input_schema_json" not in content
     assert "tool_id: kakao_keyword_search" not in content
     assert "tool_id: kakao_address_search" not in content
 
@@ -359,7 +393,7 @@ def test_available_adapters_context_constrains_aed_region_filters_to_find() -> N
     assert message is not None
     content = message.content or ""
     assert "nmc_aed_site_locate" in content
-    assert "kakao_keyword_search" not in content
+    assert "tool_id: kakao_keyword_search" not in content
     assert "nmc_aed_site_locate" in turn_tool_ids
     assert "kakao_keyword_search" not in turn_tool_ids
 

--- a/tests/evidence/test_evidence_runner.py
+++ b/tests/evidence/test_evidence_runner.py
@@ -7,6 +7,7 @@ from pathlib import Path
 
 def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
     from ummaya.evidence.runner import run_dataset
+    from ummaya.tools.routing import RouteStopReason
 
     evidence = run_dataset(
         scenario_path=Path("evidence/scenarios/national_ax_citizen_requests_v1.yaml"),
@@ -17,6 +18,18 @@ def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
     assert evidence.source_ref == "test"
     assert evidence.scenario_count > 0
     assert evidence.scenario_ids
+    assert evidence.route_trace_records
+    assert all(
+        record.scenario_id in evidence.scenario_ids for record in evidence.route_trace_records
+    )
+    assert all(
+        record.stop_reason in RouteStopReason.__args__
+        for record in evidence.route_trace_records
+    )
+    assert any(
+        record.stop_reason == "permission_required"
+        for record in evidence.route_trace_records
+    )
     assert {gate.name for gate in evidence.gates} == {
         "contract",
         "scenario",
@@ -30,6 +43,8 @@ def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
     output_path.write_text(evidence.model_dump_json(indent=2), encoding="utf-8")
     decoded = json.loads(output_path.read_text(encoding="utf-8"))
     assert decoded["schema_version"] == "evidence.v2"
+    assert decoded["route_trace_records"][0]["stop_reason"] in RouteStopReason.__args__
+    assert "clarification_reason" in decoded["route_trace_records"][0]
     assert decoded["task_registry_id"] == "ummaya/evidence-task-registry"
     assert decoded["dataset_ref"] == "ummaya/national-ax-core@local"
     assert decoded["task_count"] == 1

--- a/tests/evidence/test_evidence_runner.py
+++ b/tests/evidence/test_evidence_runner.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import json
+import re
 from pathlib import Path
 
 
@@ -19,8 +20,11 @@ def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
     assert evidence.scenario_count > 0
     assert evidence.scenario_ids
     assert evidence.route_trace_records
+    assert evidence.route_selection_assertions
     assert all(
-        record.scenario_id in evidence.scenario_ids for record in evidence.route_trace_records
+        record.scenario_id in evidence.scenario_ids
+        for record in evidence.route_trace_records
+        if record.trace_kind == "scenario_route"
     )
     assert all(
         record.stop_reason in RouteStopReason.__args__
@@ -30,6 +34,66 @@ def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
         record.stop_reason == "permission_required"
         for record in evidence.route_trace_records
     )
+    scenario_assertions = [
+        assertion
+        for assertion in evidence.route_selection_assertions
+        if assertion.assertion_kind == "scenario_route"
+    ]
+    negative_assertions = [
+        assertion
+        for assertion in evidence.route_selection_assertions
+        if assertion.assertion_kind == "negative_control"
+    ]
+    assert len(scenario_assertions) == evidence.scenario_count
+    assert {assertion.scenario_id for assertion in scenario_assertions} == set(
+        evidence.scenario_ids
+    )
+    assert {assertion.selected_domain for assertion in scenario_assertions} >= {
+        "tax",
+        "civil_affairs",
+        "mobility",
+        "business",
+        "safety",
+        "personal_data",
+        "public_data",
+    }
+    assert {assertion.adapter_family for assertion in scenario_assertions} >= {
+        "public_service_channel",
+        "location_channel",
+        "weather_channel",
+        "safety_channel",
+        "procurement_channel",
+        "public_data_channel",
+    }
+    assert any("document_harness" in assertion.coverage_tags for assertion in scenario_assertions)
+    assert any("aviation_weather" in assertion.coverage_tags for assertion in scenario_assertions)
+    assert any("aed_safety" in assertion.coverage_tags for assertion in scenario_assertions)
+    assert any("procurement" in assertion.coverage_tags for assertion in scenario_assertions)
+    assert any("public_data_search" in assertion.coverage_tags for assertion in scenario_assertions)
+    assert any(
+        "side_effecting_government_request" in assertion.coverage_tags
+        for assertion in scenario_assertions
+    )
+    assert all(
+        assertion.route_source == "expected_route_contract"
+        for assertion in scenario_assertions
+    )
+    assert negative_assertions
+    assert all(assertion.adapter_family == "no_tool" for assertion in negative_assertions)
+    assert all(assertion.status == "pass" for assertion in evidence.route_selection_assertions)
+    trace_by_id = {record.trace_id: record for record in evidence.route_trace_records}
+    hash_pattern = re.compile(r"^[0-9a-f]{64}$")
+    for assertion in evidence.route_selection_assertions:
+        trace = trace_by_id[assertion.trace_id]
+        assert assertion.correlation_id == trace.correlation_id
+        assert assertion.route_source == trace.route_source
+        assert assertion.prompt_manifest_hash == trace.prompt_manifest_hash
+        assert assertion.tool_catalog_hash == trace.tool_catalog_hash
+        assert hash_pattern.fullmatch(trace.query_hash)
+        assert hash_pattern.fullmatch(trace.manifest_hash)
+        assert hash_pattern.fullmatch(trace.prompt_manifest_hash)
+        assert hash_pattern.fullmatch(trace.tool_catalog_hash)
+        assert not assertion.selected_tool_ids
     assert {gate.name for gate in evidence.gates} == {
         "contract",
         "scenario",
@@ -45,6 +109,9 @@ def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
     assert decoded["schema_version"] == "evidence.v2"
     assert decoded["route_trace_records"][0]["stop_reason"] in RouteStopReason.__args__
     assert "clarification_reason" in decoded["route_trace_records"][0]
+    assert decoded["route_trace_records"][0]["correlation_id"].startswith("corr-route-")
+    assert decoded["route_trace_records"][0]["route_source"] == "expected_route_contract"
+    assert decoded["route_selection_assertions"][0]["status"] == "pass"
     assert decoded["task_registry_id"] == "ummaya/evidence-task-registry"
     assert decoded["dataset_ref"] == "ummaya/national-ax-core@local"
     assert decoded["task_count"] == 1
@@ -78,6 +145,90 @@ scenarios:
 
     with pytest.raises(EvidenceContractError, match="tool_id"):
         run_dataset(scenario_path=scenario_path, source_ref="test")
+
+
+def test_evidence_runner_rejects_route_assertion_cheat_keys(tmp_path: Path) -> None:
+    import pytest
+
+    from ummaya.evidence.runner import EvidenceContractError, run_dataset
+
+    scenario_path = tmp_path / "bad-route-assertion.yaml"
+    scenario_path.write_text(
+        "version: 1\n"
+        "dataset_id: bad\n"
+        "coverage_domains: [tax]\n"
+        "scenarios:\n"
+        "  - id: TAX-001\n"
+        "    lifecycle_domain: tax\n"
+        "    request_ko: \"세금 신고해줘.\"\n"
+        "    adapter_family: hometax_internal\n"
+        "    selected_tools:\n"
+        "        - hometax_vat_submit\n"
+        "    expected_ax_chain:\n"
+        "      - primitive: verify\n"
+        "        purpose: identity\n"
+        "    permission_requirements:\n"
+        "      identity_assurance: high\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EvidenceContractError, match="adapter_family"):
+        run_dataset(scenario_path=scenario_path, source_ref="test")
+
+
+def test_evidence_runner_rejects_selected_route_state_keys(tmp_path: Path) -> None:
+    import pytest
+
+    from ummaya.evidence.runner import EvidenceContractError, run_dataset
+
+    scenario_path = tmp_path / "bad-selected-route-state.yaml"
+    scenario_path.write_text(
+        "version: 1\n"
+        "dataset_id: bad\n"
+        "coverage_domains: [tax]\n"
+        "scenarios:\n"
+        "  - id: TAX-001\n"
+        "    lifecycle_domain: tax\n"
+        "    request_ko: \"세금 신고해줘.\"\n"
+        "    selected_domain: tax\n"
+        "    selected_primitives: [verify, submit]\n"
+        "    stop_reason: permission_required\n"
+        "    failure_recovery: permission_gate\n"
+        "    route_source: route_decision\n"
+        "    expected_ax_chain:\n"
+        "      - primitive: verify\n"
+        "        purpose: identity\n"
+        "    permission_requirements:\n"
+        "      identity_assurance: high\n",
+        encoding="utf-8",
+    )
+
+    with pytest.raises(EvidenceContractError, match="selected_domain"):
+        run_dataset(scenario_path=scenario_path, source_ref="test")
+
+
+def test_route_selection_assertion_marks_divergent_route_trace_failed() -> None:
+    from ummaya.evidence.runner import (
+        _parse_dataset,
+        _route_selection_assertions,
+        _route_trace_records,
+    )
+
+    dataset = _parse_dataset(Path("evidence/scenarios/national_ax_citizen_requests_v1.yaml"))
+    original = _route_trace_records(dataset)[0]
+    divergent = original.model_copy(
+        update={
+            "route_source": "route_decision",
+            "selected_domain": "wrong_domain",
+            "selected_primitives": ("lookup",),
+        }
+    )
+
+    assertion = _route_selection_assertions(dataset, (divergent,))[0]
+
+    assert assertion.route_source == "route_decision"
+    assert assertion.status == "fail"
+    assert assertion.expected_domain != assertion.selected_domain
 
 
 def test_default_task_registry_resolves_harbor_style_dataset() -> None:

--- a/tests/evidence/test_evidence_runner.py
+++ b/tests/evidence/test_evidence_runner.py
@@ -27,12 +27,10 @@ def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
         if record.trace_kind == "scenario_route"
     )
     assert all(
-        record.stop_reason in RouteStopReason.__args__
-        for record in evidence.route_trace_records
+        record.stop_reason in RouteStopReason.__args__ for record in evidence.route_trace_records
     )
     assert any(
-        record.stop_reason == "permission_required"
-        for record in evidence.route_trace_records
+        record.stop_reason == "permission_required" for record in evidence.route_trace_records
     )
     scenario_assertions = [
         assertion
@@ -75,8 +73,7 @@ def test_evidence_runner_emits_required_gates(tmp_path: Path) -> None:
         for assertion in scenario_assertions
     )
     assert all(
-        assertion.route_source == "expected_route_contract"
-        for assertion in scenario_assertions
+        assertion.route_source == "expected_route_contract" for assertion in scenario_assertions
     )
     assert negative_assertions
     assert all(assertion.adapter_family == "no_tool" for assertion in negative_assertions)
@@ -160,7 +157,7 @@ def test_evidence_runner_rejects_route_assertion_cheat_keys(tmp_path: Path) -> N
         "scenarios:\n"
         "  - id: TAX-001\n"
         "    lifecycle_domain: tax\n"
-        "    request_ko: \"세금 신고해줘.\"\n"
+        '    request_ko: "세금 신고해줘."\n'
         "    adapter_family: hometax_internal\n"
         "    selected_tools:\n"
         "        - hometax_vat_submit\n"
@@ -189,7 +186,7 @@ def test_evidence_runner_rejects_selected_route_state_keys(tmp_path: Path) -> No
         "scenarios:\n"
         "  - id: TAX-001\n"
         "    lifecycle_domain: tax\n"
-        "    request_ko: \"세금 신고해줘.\"\n"
+        '    request_ko: "세금 신고해줘."\n'
         "    selected_domain: tax\n"
         "    selected_primitives: [verify, submit]\n"
         "    stop_reason: permission_required\n"

--- a/tests/ipc/test_route_diagnostics.py
+++ b/tests/ipc/test_route_diagnostics.py
@@ -1,0 +1,79 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import UTC, datetime
+
+import pytest
+from pydantic import BaseModel
+
+from ummaya.ipc.route_diagnostics import log_route_decision_diagnostic
+from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.routing import RouteDecisionService
+
+
+class AviationWeatherInput(BaseModel):
+    airport_name: str
+
+
+class AviationWeatherOutput(BaseModel):
+    report: str
+
+
+def _policy() -> AdapterRealDomainPolicy:
+    return AdapterRealDomainPolicy(
+        real_classification_url="https://example.go.kr/policy",
+        real_classification_text="Published agency policy",
+        citizen_facing_gate="read-only",
+        last_verified=datetime(2026, 6, 5, tzinfo=UTC),
+    )
+
+
+def test_log_route_decision_diagnostic_records_joinable_route_receipt(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        GovAPITool(
+            id="kma_airport_aviation_weather",
+            name_ko="항공기상",
+            ministry="KMA",
+            category=["항공", "기상"],
+            endpoint="internal://kma-airport",
+            auth_type="public",
+            primitive="find",
+            policy=_policy(),
+            input_schema=AviationWeatherInput,
+            output_schema=AviationWeatherOutput,
+            search_hint="김해공항 항공기상 AMOS METAR airport aviation weather",
+        )
+    )
+    decision = RouteDecisionService(registry).select_adapters(
+        "김해공항 항공기상과 AMOS 확인",
+        initial_scores=(("kma_airport_aviation_weather", 12.0),),
+    )
+
+    logger = logging.getLogger("tests.route_diagnostics")
+    with caplog.at_level(logging.INFO, logger="tests.route_diagnostics"):
+        log_route_decision_diagnostic(
+            logger=logger,
+            turn_index=3,
+            session_id="session-1",
+            correlation_id="corr-1",
+            decision=decision,
+        )
+
+    records = [record for record in caplog.records if "[ROUTE_DECISION]" in record.message]
+    assert len(records) == 1
+    payload = json.loads(records[0].message.split("payload=", maxsplit=1)[1])
+    assert payload["turn_index"] == 3
+    assert payload["session_id"] == "session-1"
+    assert payload["correlation_id"] == "corr-1"
+    assert payload["decision_id"] == decision.decision_id
+    assert payload["manifest_hash"] == decision.manifest_hash
+    assert payload["selected_tools"] == ["kma_airport_aviation_weather"]
+    assert payload["stop_reason"] == "answerable"
+    assert payload["schema_projection_level"] == "summary"

--- a/tests/ipc/test_stdio.py
+++ b/tests/ipc/test_stdio.py
@@ -158,6 +158,30 @@ def _encode_frame(frame: Any) -> bytes:
     return (frame.model_dump_json() + "\n").encode("utf-8")
 
 
+def _llm_tool_names(tools: object) -> tuple[str, ...]:
+    if not isinstance(tools, list):
+        return ()
+    names: list[str] = []
+    for tool in tools:
+        if isinstance(tool, dict):
+            function = tool.get("function")
+            name = function.get("name") if isinstance(function, dict) else None
+        else:
+            function = getattr(tool, "function", None)
+            name = getattr(function, "name", None)
+        if isinstance(name, str):
+            names.append(name)
+    return tuple(names)
+
+
+def _projected_adapter_tool_ids(content: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip().removeprefix("- tool_id:").strip()
+        for line in content.splitlines()
+        if line.strip().startswith("- tool_id:")
+    )
+
+
 # ---------------------------------------------------------------------------
 # In-process harness: fake stdout buffer
 # ---------------------------------------------------------------------------
@@ -525,6 +549,46 @@ async def test_chat_request_appends_available_tools_section(
         "Expected at least one concrete adapter header in the system prompt "
         f"Available tools section. Content preview: {system_content[:500]!r}"
     )
+
+
+@pytest.mark.asyncio
+async def test_chat_request_appends_route_decision_adapter_projection(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    frame = _make_chat_request(
+        tools=[],
+        system="Base system prompt.",
+        content="이번 주 부산시 전기공사 입찰 올라온 거 있어?",
+    )
+
+    _buf, fake_client = await _run_with_frame(
+        frame,
+        _FakeLLMClientNoTools,
+        monkeypatch=monkeypatch,
+    )
+
+    assert fake_client.recorded_calls
+    first_call = fake_client.recorded_calls[0]
+    messages_sent = first_call.get("messages", [])
+    system_content = next(
+        (
+            getattr(msg, "content", None)
+            for msg in messages_sent
+            if getattr(msg, "role", None) == "system"
+        ),
+        None,
+    )
+
+    assert isinstance(system_content, str)
+    assert "<available_adapters" in system_content
+    assert 'schema_projection="summary"' in system_content
+    assert "RouteDecision candidates" in system_content
+    assert "input_schema_summary" in system_content
+    assert "백엔드 BM25 후보" not in system_content
+    projected_tool_ids = _projected_adapter_tool_ids(system_content)
+    tool_names = _llm_tool_names(first_call.get("tools"))
+    assert projected_tool_ids == tool_names
+    assert not (set(projected_tool_ids) & {"find", "locate", "check", "send", "search_tools"})
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ipc/test_stdio_chain_followup_gate.py
+++ b/tests/ipc/test_stdio_chain_followup_gate.py
@@ -111,6 +111,21 @@ def test_available_adapters_find_candidate_triggers_followup_signal() -> None:
     assert _available_adapters_block_has_find_candidate(block)
 
 
+def test_available_adapters_new_projection_find_candidate_triggers_followup_signal() -> None:
+    block = "\n".join(
+        [
+            '<available_adapters query="다대1동 근처 내과" decision_id="abc" '
+            'backend="bm25" schema_projection="summary">',
+            "RouteDecision candidates (top 1, backend=bm25, manifest_hash=123).",
+            "- tool_id: hira_hospital_search",
+            "  primitive: find",
+            "  source_mode: live",
+            "</available_adapters>",
+        ]
+    )
+    assert _available_adapters_block_has_find_candidate(block)
+
+
 def test_locate_only_available_adapters_do_not_trigger_followup_signal() -> None:
     """Pure locate candidate blocks stay out of the follow-up gate."""
     block = "\n".join(
@@ -381,6 +396,25 @@ def _msg_available_adapters(*, find: bool = True) -> LLMChatMessage:
             [
                 '<available_adapters query="테스트">',
                 candidate,
+                "</available_adapters>",
+            ]
+        ),
+    )
+
+
+def _msg_available_adapters_new_projection(*, find: bool = True) -> LLMChatMessage:
+    tool_id = "kma_current_observation" if find else "kakao_address_search"
+    primitive = "find" if find else "locate"
+    return LLMChatMessage(
+        role="system",
+        content="\n".join(
+            [
+                '<available_adapters query="테스트" decision_id="abc" '
+                'backend="bm25" schema_projection="summary">',
+                "RouteDecision candidates (top 1, backend=bm25, manifest_hash=123).",
+                f"- tool_id: {tool_id}",
+                f"  primitive: {primitive}",
+                "  source_mode: live",
                 "</available_adapters>",
             ]
         ),
@@ -2706,6 +2740,23 @@ def test_resolve_only_then_terminate_is_rejected() -> None:
     assert "Chain incomplete" in msg
     assert "find" in msg.lower()
     assert "fabrication" in msg.lower()
+
+
+def test_resolve_only_then_terminate_is_rejected_with_new_projection() -> None:
+    msgs: list[Any] = [
+        _msg_available_adapters_new_projection(find=True),
+        LLMChatMessage(role="user", content="지금 부산 사하구 다대1동 날씨 어때"),
+        _msg_assistant_tool_call(
+            "locate",
+            {"query": "부산 사하구 다대1동", "want": "coords_and_admcd"},
+        ),
+        _msg_tool_result("locate", {"lat": 35.05915, "lon": 128.97132}),
+    ]
+
+    msg = _check_resolve_terminated_without_followup(msgs, "지금 부산 사하구 다대1동 날씨 어때")
+
+    assert msg is not None
+    assert "Chain incomplete" in msg
 
 
 def test_resolve_only_with_non_observable_query_passes() -> None:

--- a/tests/ipc/test_stdio_chain_followup_gate.py
+++ b/tests/ipc/test_stdio_chain_followup_gate.py
@@ -1046,8 +1046,9 @@ def test_latest_citizen_user_utterance_skips_available_adapters_suffix() -> None
     )
 
 
-def test_initial_concrete_tool_choice_for_unambiguous_public_data_queries() -> None:
+def test_initial_concrete_tool_choice_only_for_document_queries() -> None:
     available = {
+        "document",
         "find",
         "locate",
         "pps_bid_public_info",
@@ -1062,35 +1063,42 @@ def test_initial_concrete_tool_choice_for_unambiguous_public_data_queries() -> N
             "이번 주 부산시 전기공사 입찰 올라온 거 있어?",
             available,
         )
-        == "pps_bid_public_info"
+        is None
     )
     assert (
         _initial_concrete_tool_choice_for_query(
             "지금 부산 중구 미세먼지 괜찮아? 마스크 써야 해?",
             available,
         )
-        == "airkorea_ctprvn_air_quality"
+        is None
     )
     assert (
         _initial_concrete_tool_choice_for_query(
             "오늘 오후 전국 비구름 흐름이 어떤지 공식 기상도나 위성 자료 기준으로 설명해줘",
             available,
         )
-        == "kma_apihub_url_analysis_weather_chart_image"
+        is None
+    )
+    assert (
+        _initial_concrete_tool_choice_for_query(
+            "다운로드 폴더의 신청서.hwpx 문서를 작성해줘",
+            available,
+        )
+        == "document"
     )
     assert (
         _initial_concrete_tool_choice_for_query(
             "오늘 밤 김해에서 김포 가는데 비행기 뜰만해? 바람이랑 시정도 봐줘",
             available,
         )
-        == "kma_apihub_url_air_metar_decoded"
+        is None
     )
     assert (
         _initial_concrete_tool_choice_for_query(
             "부산역에서 1001번 버스 곧 와?",
             available,
         )
-        == "tago_bus_route_search"
+        is None
     )
 
 
@@ -1362,7 +1370,19 @@ def test_public_data_tool_choice_rejects_unrelated_concrete_adapters() -> None:
     ) or (None, "")
     assert preferred == "tago_bus_route_search"
     assert "Public-data tool-choice mismatch" in message
-    assert "airkorea_ctprvn_air_quality" in message
+    assert "target=bus_realtime" in message
+    assert "airkorea_ctprvn_air_quality" not in message
+    assert "tago_bus_route_search" not in message
+
+    preferred, message = _check_direct_public_data_tool_choice_prerequisite(
+        "kma_current_observation",
+        {"nx": 98, "ny": 75},
+        "내일 비구름 흐름 일기도 지도 자료 보여줘",
+    ) or (None, "")
+    assert preferred == "kma_apihub_url_analysis_weather_chart_image"
+    assert "target=weather_chart" in message
+    assert "kma_apihub_url_analysis_weather_chart_image" not in message
+    assert "kma_current_observation" not in message
 
     preferred, message = _check_direct_public_data_tool_choice_prerequisite(
         "airkorea_ctprvn_air_quality",
@@ -1370,7 +1390,20 @@ def test_public_data_tool_choice_rejects_unrelated_concrete_adapters() -> None:
         "퇴근하고 해운대 산책 갈 건데 지금 비 와? 우산 챙겨야 해?",
     ) or (None, "")
     assert preferred == "kakao_keyword_search"
+    assert "target=current_weather" in message
     assert "KMA current observation" in message
+    assert "airkorea_ctprvn_air_quality" not in message
+    assert "kakao_keyword_search" not in message
+
+    preferred, message = _check_direct_public_data_tool_choice_prerequisite(
+        "kma_current_observation",
+        {"nx": 98, "ny": 75},
+        "이번 주 부산시 전기공사 입찰 올라온 거 있어?",
+    ) or (None, "")
+    assert preferred == "pps_bid_public_info"
+    assert "target=procurement_bid" in message
+    assert "pps_bid_public_info" not in message
+    assert "kma_current_observation" not in message
 
     assert (
         _check_direct_public_data_tool_choice_prerequisite(

--- a/tests/tools/test_adapter_cards.py
+++ b/tests/tools/test_adapter_cards.py
@@ -1,0 +1,197 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from ummaya.tools.executor import ToolExecutor
+from ummaya.tools.models import AdapterRealDomainPolicy
+from ummaya.tools.register_all import register_all_tools
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.routing.cards import (
+    AdapterCard,
+    SchemaFieldSummary,
+    assert_adapter_card_quality,
+    build_adapter_card,
+    lint_adapter_card,
+)
+
+
+def _read_only_policy() -> AdapterRealDomainPolicy:
+    return AdapterRealDomainPolicy(
+        real_classification_url="https://www.kma.go.kr/kma/notice/personal.jsp",
+        real_classification_text="KMA published read-only public weather policy",
+        citizen_facing_gate="read-only",
+        last_verified=datetime(2026, 6, 5, tzinfo=UTC),
+    )
+
+
+def test_build_adapter_card_compacts_schema_and_hashes(sample_tool_factory):
+    tool = sample_tool_factory(
+        id="kma_weather_forecast",
+        policy=_read_only_policy(),
+        primitive="find",
+        llm_description="Find KMA weather forecasts by city and optional date.",
+        trigger_examples=["서울 내일 날씨 알려줘"],
+    )
+
+    card = build_adapter_card(tool)
+
+    assert card.tool_id == "kma_weather_forecast"
+    assert card.primitive_family == "find"
+    assert card.legacy_primitive_aliases == ("lookup",)
+    assert card.source_mode == "live"
+    assert card.policy_authority_url == "https://www.kma.go.kr/kma/notice/personal.jsp"
+    assert card.required_slots == ("city",)
+    assert len(card.input_schema_hash) == 64
+    assert len(card.manifest_hash) == 64
+    assert {field.name for field in card.input_schema_summary} == {"city", "date"}
+    assert "properties" not in card.routing_text
+    assert "$defs" not in card.routing_text
+    assert "{" not in card.routing_text
+    assert lint_adapter_card(card) == ()
+
+
+def test_registry_exports_one_card_per_active_tool(sample_tool_factory):
+    registry = ToolRegistry()
+    active = sample_tool_factory(
+        id="kma_weather_forecast",
+        policy=_read_only_policy(),
+        primitive="find",
+        trigger_examples=["부산 기상 예보 확인"],
+    )
+    inactive = sample_tool_factory(
+        id="koroad_accident_stats",
+        ministry="KOROAD",
+        policy=_read_only_policy(),
+        primitive="find",
+        trigger_examples=["교통사고 통계 찾아줘"],
+    )
+    registry.register(active)
+    registry.register(inactive)
+    registry.set_active("koroad_accident_stats", False)
+
+    cards = registry.adapter_cards()
+
+    assert [card.tool_id for card in cards] == ["kma_weather_forecast"]
+    assert_adapter_card_quality(cards[0])
+
+
+def test_adapter_card_hashes_are_stable(sample_tool_factory):
+    tool = sample_tool_factory(
+        id="kma_weather_forecast",
+        policy=_read_only_policy(),
+        primitive="find",
+        trigger_examples=["강릉 날씨 확인"],
+    )
+
+    first = build_adapter_card(tool)
+    second = build_adapter_card(tool)
+
+    assert first.input_schema_hash == second.input_schema_hash
+    assert first.manifest_hash == second.manifest_hash
+    assert first.routing_text == second.routing_text
+
+
+def test_build_adapter_card_rejects_missing_primitive(sample_tool_factory):
+    tool = sample_tool_factory(policy=_read_only_policy(), primitive=None)
+
+    with pytest.raises(ValueError, match="primitive"):
+        build_adapter_card(tool)
+
+
+def test_register_all_mock_bridge_cards_use_mock_source_mode():
+    registry = ToolRegistry()
+    executor = ToolExecutor(registry=registry)
+    register_all_tools(registry, executor)
+
+    mock_bridge_cards = [
+        card
+        for card in registry.adapter_cards()
+        if card.tool_id.startswith(("mock_verify", "mock_submit"))
+    ]
+
+    assert mock_bridge_cards
+    assert {card.source_mode for card in mock_bridge_cards} == {"mock"}
+    by_tool_id = {card.tool_id: card for card in mock_bridge_cards}
+    assert by_tool_id["mock_submit_module_gov24_minwon"].mock_fidelity_grade == "OOS"
+
+
+def test_lint_flags_missing_policy_and_card_quality_metadata():
+    card = AdapterCard(
+        tool_id="kma_weather_forecast",
+        primitive_family="find",
+        legacy_primitive_aliases=("lookup",),
+        domain="weather",
+        agency="KMA",
+        source_mode="live",
+        capabilities=("weather",),
+        intent_verbs=("find",),
+        entity_types=("city",),
+        required_slots=(),
+        optional_slots=(),
+        prerequisite_tools=(),
+        input_schema_hash="0" * 64,
+        input_schema_summary=(),
+        output_schema_summary=(),
+        policy_authority_url=None,
+        safety_annotations=(),
+        side_effect_level="read_only",
+        credential_requirements=(),
+        mock_fidelity_grade="not_applicable",
+        examples_ko=(),
+        examples_en=(),
+        negative_examples=(),
+        limitations=(),
+        manifest_hash="1" * 64,
+        routing_text='{"properties": {"city": {"type": "string"}}}',
+    )
+
+    violations = {violation.code for violation in lint_adapter_card(card)}
+
+    assert violations == {
+        "missing_policy_citation",
+        "missing_required_slot_metadata",
+        "missing_safety_annotations",
+        "missing_credential_requirements",
+        "missing_examples",
+        "missing_negative_examples",
+        "missing_limitations",
+        "raw_schema_leakage",
+    }
+
+
+def test_assert_adapter_card_quality_raises_named_violations():
+    card = AdapterCard(
+        tool_id="kma_weather_forecast",
+        primitive_family="find",
+        legacy_primitive_aliases=("lookup",),
+        domain="weather",
+        agency="KMA",
+        source_mode="mock",
+        capabilities=("weather",),
+        intent_verbs=("find",),
+        entity_types=("city",),
+        required_slots=(),
+        optional_slots=("city",),
+        prerequisite_tools=(),
+        input_schema_hash="2" * 64,
+        input_schema_summary=(SchemaFieldSummary(name="city", type="string", required=False),),
+        output_schema_summary=(),
+        policy_authority_url=None,
+        safety_annotations=("read-only",),
+        side_effect_level="read_only",
+        credential_requirements=("api_key",),
+        mock_fidelity_grade="unknown",
+        examples_ko=("날씨를 알려줘",),
+        examples_en=("Find a weather forecast.",),
+        negative_examples=(),
+        limitations=("Fixture-backed mock output.",),
+        manifest_hash="3" * 64,
+        routing_text="kma_weather_forecast primitive find required_slots city",
+    )
+
+    with pytest.raises(ValueError, match="missing_policy_citation.*missing_negative_examples"):
+        assert_adapter_card_quality(card)

--- a/tests/tools/test_route_decision_service.py
+++ b/tests/tools/test_route_decision_service.py
@@ -272,6 +272,37 @@ def test_route_decision_permission_gate_uses_selected_slice(sample_tool_factory)
     assert decision.permission_gate is False
 
 
+def test_route_decision_tie_breaks_by_tool_id(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="zeta_weather_forecast",
+            primitive="find",
+            policy=_policy(),
+            search_hint="weather forecast",
+        )
+    )
+    registry.register(
+        sample_tool_factory(
+            id="alpha_weather_forecast",
+            primitive="find",
+            policy=_policy(),
+            search_hint="weather forecast",
+        )
+    )
+
+    decision = RouteDecisionService(registry).select_adapters(
+        "weather forecast",
+        initial_scores=(
+            ("zeta_weather_forecast", 10.0),
+            ("alpha_weather_forecast", 10.0),
+        ),
+        max_selected=1,
+    )
+
+    assert decision.selected_tools == ("alpha_weather_forecast",)
+
+
 def test_route_decision_include_infeasible_retains_soft_rejection_reasons() -> None:
     registry = ToolRegistry()
     tool = GovAPITool(

--- a/tests/tools/test_route_decision_service.py
+++ b/tests/tools/test_route_decision_service.py
@@ -54,6 +54,37 @@ def test_route_decision_uses_registry_retrieval_and_selects_feasible_candidate(
     assert decision.effective_top_k == 1
 
 
+def test_route_decision_blocks_multi_candidate_all_zero_scores(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="alpha_tool",
+            primitive="find",
+            policy=_policy(),
+            search_hint="alpha domain",
+        )
+    )
+    registry.register(
+        sample_tool_factory(
+            id="beta_tool",
+            primitive="find",
+            policy=_policy(),
+            search_hint="beta domain",
+        )
+    )
+
+    decision = RouteDecisionService(registry).select_adapters(
+        "unrelated no match query",
+        initial_scores=(("alpha_tool", 0.0), ("beta_tool", 0.0)),
+    )
+
+    assert decision.selected_tools == ()
+    assert decision.candidate_set == ()
+    assert decision.stop_reason == "blocked_no_adapter"
+    assert "soft_excluded:zero_retrieval_score:alpha_tool" in decision.evidence_events
+    assert "soft_excluded:zero_retrieval_score:beta_tool" in decision.evidence_events
+
+
 def test_route_decision_models_reject_unknown_fields(sample_tool_factory) -> None:
     registry = ToolRegistry()
     registry.register(sample_tool_factory(id="kma_weather_forecast", policy=_policy()))
@@ -360,6 +391,54 @@ def test_route_decision_side_effect_without_confirmation_requires_clarification(
     assert decision.clarification is not None
     assert decision.clarification.reason == "side_effect_confirmation"
     assert decision.clarification_question == "Should I proceed with gov24_minwon_submit?"
+
+
+def test_route_decision_ignores_lower_ranked_side_effect_noise(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="koroad_accident_hazard_search",
+            primitive="find",
+            policy=_policy(),
+            search_hint="교통사고 다발지역 공공데이터",
+        )
+    )
+    registry.register(
+        sample_tool_factory(
+            id="simple_auth_check",
+            ministry="UMMAYA",
+            auth_type="oauth",
+            primitive="check",
+            policy=_policy("login"),
+            search_hint="identity check verify",
+        )
+    )
+    registry.register(
+        sample_tool_factory(
+            id="mock_submit_module_public_mydata_action",
+            ministry="OTHER",
+            auth_type="oauth",
+            primitive="send",
+            policy=_policy("send"),
+            search_hint="public mydata action submit",
+        )
+    )
+
+    decision = RouteDecisionService(registry).decide(
+        "서울 강남구 교통사고 다발지역을 공공 API로 조회해줘",
+        initial_scores=(
+            ("koroad_accident_hazard_search", 80.0),
+            ("mock_submit_module_public_mydata_action", 1.0),
+            ("simple_auth_check", 0.5),
+        ),
+        max_selected=1,
+    )
+
+    assert decision.stop_reason == "answerable"
+    assert decision.selected_tools == ("koroad_accident_hazard_search",)
+    assert decision.clarification is None
 
 
 def test_route_decision_repeated_tool_mismatch_terminates_with_reason(

--- a/tests/tools/test_route_decision_service.py
+++ b/tests/tools/test_route_decision_service.py
@@ -1,0 +1,358 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from pydantic import BaseModel, ValidationError
+
+from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.routing import RouteDecision, RouteDecisionService
+from ummaya.tools.routing import decision_service as decision_service_module
+
+
+class CoordinateInput(BaseModel):
+    lat: float
+    lon: float
+
+
+class EmptyOutput(BaseModel):
+    ok: bool
+
+
+def _policy(gate: str = "read-only") -> AdapterRealDomainPolicy:
+    return AdapterRealDomainPolicy(
+        real_classification_url="https://example.go.kr/policy",
+        real_classification_text="Published agency policy",
+        citizen_facing_gate=gate,
+        last_verified=datetime(2026, 6, 5, tzinfo=UTC),
+    )
+
+
+def test_route_decision_uses_registry_retrieval_and_selects_feasible_candidate(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    tool = sample_tool_factory(
+        id="kma_weather_forecast",
+        primitive="find",
+        policy=_policy(),
+        search_hint="서울 날씨 forecast weather",
+    )
+    registry.register(tool)
+
+    decision = RouteDecisionService(registry).decide("서울 날씨 알려줘")
+
+    assert decision.selected_tools == ("kma_weather_forecast",)
+    assert decision.schema_projection_level == "summary"
+    assert decision.stop_reason is None
+    assert decision.candidate_set[0].feasible is True
+    assert decision.candidate_set[0].filter_reasons == ()
+    assert decision.backend_label == "bm25"
+    assert decision.effective_top_k == 1
+
+
+def test_route_decision_models_reject_unknown_fields(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="kma_weather_forecast", policy=_policy()))
+    decision = RouteDecisionService(registry).select_adapters("서울 날씨 알려줘")
+
+    payload = decision.model_dump()
+    payload["unexpected"] = True
+
+    try:
+        RouteDecision.model_validate(payload)
+    except ValidationError as exc:
+        assert "unexpected" in str(exc)
+    else:
+        raise AssertionError("RouteDecision accepted an unknown field")
+
+
+def test_route_decision_filters_missing_coordinate_slots() -> None:
+    registry = ToolRegistry()
+    tool = GovAPITool(
+        id="nmc_aed_site_locate",
+        name_ko="AED 위치",
+        ministry="NMC",
+        category=["응급", "AED"],
+        endpoint="internal://nmc-aed",
+        auth_type="public",
+        primitive="find",
+        policy=_policy(),
+        input_schema=CoordinateInput,
+        output_schema=EmptyOutput,
+        search_hint="AED 자동심장충격기 위치",
+    )
+    registry.register(tool)
+
+    decision = RouteDecisionService(registry).decide(
+        "하단역 근처 AED 위치 알려줘",
+        initial_scores=(("nmc_aed_site_locate", 10.0),),
+    )
+
+    assert decision.selected_tools == ()
+    assert decision.schema_projection_level == "none"
+    assert decision.stop_reason == "no_feasible_candidate"
+    assert decision.clarification_question == "Required slot missing: lat, lon."
+    assert set(decision.candidate_set[0].filter_reasons) == {
+        "missing_slot:lat",
+        "missing_slot:lon",
+    }
+
+
+def test_route_decision_filters_inactive_and_missing_prerequisite(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    submit = sample_tool_factory(
+        id="gov24_minwon_submit",
+        ministry="GOV24",
+        auth_type="oauth",
+        primitive="send",
+        policy=_policy("send"),
+        llm_description="Requires prior check before submission.",
+        search_hint="민원 신청 제출 submit",
+    )
+    registry.register(submit)
+    service = RouteDecisionService(registry)
+
+    missing_prereq = service.decide(
+        "민원 신청 제출해줘",
+        initial_scores=(("gov24_minwon_submit", 9.0),),
+    )
+
+    assert missing_prereq.selected_tools == ()
+    assert "missing_prerequisite_primitive:check" in missing_prereq.candidate_set[0].filter_reasons
+
+    check = sample_tool_factory(
+        id="simple_auth_check",
+        ministry="UMMAYA",
+        auth_type="oauth",
+        primitive="check",
+        policy=_policy("login"),
+        search_hint="본인인증 check verify",
+    )
+    registry.register(check)
+    feasible = service.decide(
+        "민원 신청 제출해줘",
+        initial_scores=(("gov24_minwon_submit", 9.0),),
+    )
+
+    assert feasible.selected_tools == ("gov24_minwon_submit",)
+    assert feasible.permission_gate is True
+
+    registry.set_active("gov24_minwon_submit", False)
+    inactive = service.decide(
+        "민원 신청 제출해줘",
+        initial_scores=(("gov24_minwon_submit", 9.0),),
+    )
+
+    assert inactive.selected_tools == ()
+    assert inactive.candidate_set == ()
+    assert "hard_excluded:inactive_adapter:gov24_minwon_submit" in inactive.evidence_events
+
+
+def test_route_decision_preserves_mock_source_mode(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    tool = sample_tool_factory(
+        id="mock_public_fixture_find",
+        primitive="find",
+        adapter_mode="mock",
+        mock_fidelity_grade="OOS",
+        policy=_policy(),
+        search_hint="fixture mock public data",
+    )
+    registry.register(tool)
+
+    decision = RouteDecisionService(registry).decide(
+        "fixture public data",
+        initial_scores=(("mock_public_fixture_find", 5.0),),
+    )
+
+    assert decision.selected_tools == ("mock_public_fixture_find",)
+    assert decision.candidate_set[0].card.source_mode == "mock"
+    assert decision.candidate_set[0].card.mock_fidelity_grade == "OOS"
+
+
+def test_route_decision_hard_excludes_disallowed_source_modes(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    tool = sample_tool_factory(
+        id="mock_public_fixture_find",
+        primitive="find",
+        adapter_mode="mock",
+        policy=_policy(),
+        search_hint="fixture mock public data",
+    )
+    registry.register(tool)
+
+    decision = RouteDecisionService(registry).select_adapters(
+        "fixture public data",
+        initial_scores=(("mock_public_fixture_find", 5.0),),
+        allowed_source_modes=("live",),
+        include_infeasible=True,
+    )
+
+    assert decision.selected_tools == ()
+    assert decision.candidate_set == ()
+    assert "hard_excluded:disallowed_source_mode:mock:mock_public_fixture_find" in (
+        decision.evidence_events
+    )
+
+
+def test_route_decision_hard_excludes_disallowed_credentials(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    tool = sample_tool_factory(
+        id="kma_weather_forecast",
+        primitive="find",
+        auth_type="api_key",
+        policy=_policy(),
+        search_hint="weather forecast",
+    )
+    registry.register(tool)
+
+    decision = RouteDecisionService(registry).select_adapters(
+        "weather forecast",
+        initial_scores=(("kma_weather_forecast", 7.0),),
+        allowed_credentials=("public",),
+        include_infeasible=True,
+    )
+
+    assert decision.selected_tools == ()
+    assert decision.candidate_set == ()
+    assert "hard_excluded:disallowed_credential:api_key:kma_weather_forecast" in (
+        decision.evidence_events
+    )
+
+
+def test_route_decision_keeps_login_gate_candidates_visible(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    tool = sample_tool_factory(
+        id="nmc_emergency_search",
+        primitive="find",
+        auth_type="oauth",
+        policy=_policy("login"),
+        search_hint="응급실 응급의료 hospital emergency",
+    )
+    registry.register(tool)
+
+    decision = RouteDecisionService(registry).select_adapters(
+        "하단역 근처 야간 응급실 어디야",
+        initial_scores=(("nmc_emergency_search", 12.0),),
+    )
+
+    assert decision.selected_tools == ("nmc_emergency_search",)
+    assert decision.permission_gate is True
+
+
+def test_route_decision_permission_gate_uses_selected_slice(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    read_only = sample_tool_factory(
+        id="kma_weather_forecast",
+        primitive="find",
+        policy=_policy(),
+        search_hint="weather forecast",
+    )
+    login = sample_tool_factory(
+        id="nmc_emergency_search",
+        primitive="find",
+        auth_type="oauth",
+        policy=_policy("login"),
+        search_hint="emergency hospital",
+    )
+    registry.register(read_only)
+    registry.register(login)
+
+    decision = RouteDecisionService(registry).select_adapters(
+        "weather forecast",
+        initial_scores=(("kma_weather_forecast", 10.0), ("nmc_emergency_search", 1.0)),
+        top_k=2,
+        max_selected=1,
+    )
+
+    assert decision.selected_tools == ("kma_weather_forecast",)
+    assert decision.permission_gate is False
+
+
+def test_route_decision_include_infeasible_retains_soft_rejection_reasons() -> None:
+    registry = ToolRegistry()
+    tool = GovAPITool(
+        id="nmc_aed_site_locate",
+        name_ko="AED 위치",
+        ministry="NMC",
+        category=["응급", "AED"],
+        endpoint="internal://nmc-aed",
+        auth_type="public",
+        primitive="find",
+        policy=_policy(),
+        input_schema=CoordinateInput,
+        output_schema=EmptyOutput,
+        search_hint="AED 자동심장충격기 위치",
+    )
+    registry.register(tool)
+
+    hidden = RouteDecisionService(registry).select_adapters(
+        "하단역 근처 AED 위치 알려줘",
+        initial_scores=(("nmc_aed_site_locate", 10.0),),
+    )
+    visible = RouteDecisionService(registry).select_adapters(
+        "하단역 근처 AED 위치 알려줘",
+        initial_scores=(("nmc_aed_site_locate", 10.0),),
+        include_infeasible=True,
+    )
+
+    assert hidden.candidate_set == ()
+    assert visible.candidate_set[0].filter_reasons == ("missing_slot:lat", "missing_slot:lon")
+
+
+def test_route_decision_extracts_intent_once_when_not_supplied(
+    monkeypatch, sample_tool_factory
+) -> None:
+    registry = ToolRegistry()
+    registry.register(sample_tool_factory(id="kma_weather_forecast", policy=_policy()))
+    calls = 0
+    real_extract = decision_service_module.extract_tool_selection_intent
+
+    def counting_extract(query: str, *, known_tool_ids=()):
+        nonlocal calls
+        calls += 1
+        return real_extract(query, known_tool_ids=known_tool_ids)
+
+    monkeypatch.setattr(decision_service_module, "extract_tool_selection_intent", counting_extract)
+
+    RouteDecisionService(registry).select_adapters("서울 날씨 알려줘")
+
+    assert calls == 1
+
+
+def test_route_decision_falls_back_to_bm25_companion_when_retriever_raises(
+    sample_tool_factory,
+) -> None:
+    class CompanionRetriever:
+        def rebuild(self, corpus: dict[str, str]) -> None:
+            self.corpus = corpus
+
+        def score(self, query: str) -> list[tuple[str, float]]:
+            return [("kma_current_observation", 11.0)]
+
+    class BrokenHybridRetriever:
+        _requested_backend_label = "hybrid"
+
+        def __init__(self) -> None:
+            self._bm25 = CompanionRetriever()
+
+        def rebuild(self, corpus: dict[str, str]) -> None:
+            self._bm25.rebuild(corpus)
+
+        def score(self, query: str) -> list[tuple[str, float]]:
+            raise RuntimeError("dense path failed")
+
+    registry = ToolRegistry()
+    registry._retriever = BrokenHybridRetriever()
+    registry.register(
+        sample_tool_factory(id="kma_current_observation", primitive="find", policy=_policy())
+    )
+
+    decision = RouteDecisionService(registry).select_adapters("서울 날씨 알려줘")
+
+    assert decision.selected_tools == ("kma_current_observation",)
+    assert decision.backend_label == "bm25"
+    assert decision.degradation_reason == "hybrid_score_failed"

--- a/tests/tools/test_route_decision_service.py
+++ b/tests/tools/test_route_decision_service.py
@@ -8,7 +8,7 @@ from pydantic import BaseModel, ValidationError
 
 from ummaya.tools.models import AdapterRealDomainPolicy, GovAPITool
 from ummaya.tools.registry import ToolRegistry
-from ummaya.tools.routing import RouteDecision, RouteDecisionService
+from ummaya.tools.routing import RouteDecision, RouteDecisionService, RouteStopReason
 from ummaya.tools.routing import decision_service as decision_service_module
 
 
@@ -46,7 +46,8 @@ def test_route_decision_uses_registry_retrieval_and_selects_feasible_candidate(
 
     assert decision.selected_tools == ("kma_weather_forecast",)
     assert decision.schema_projection_level == "summary"
-    assert decision.stop_reason is None
+    assert decision.stop_reason == "answerable"
+    assert decision.clarification is None
     assert decision.candidate_set[0].feasible is True
     assert decision.candidate_set[0].filter_reasons == ()
     assert decision.backend_label == "bm25"
@@ -93,8 +94,11 @@ def test_route_decision_filters_missing_coordinate_slots() -> None:
 
     assert decision.selected_tools == ()
     assert decision.schema_projection_level == "none"
-    assert decision.stop_reason == "no_feasible_candidate"
-    assert decision.clarification_question == "Required slot missing: lat, lon."
+    assert decision.stop_reason == "needs_input"
+    assert decision.clarification is not None
+    assert decision.clarification.reason == "missing_slots"
+    assert decision.clarification.missing_slots == ("lat", "lon")
+    assert decision.clarification_question == "Which values should I use for lat and lon?"
     assert set(decision.candidate_set[0].filter_reasons) == {
         "missing_slot:lat",
         "missing_slot:lon",
@@ -135,10 +139,12 @@ def test_route_decision_filters_inactive_and_missing_prerequisite(sample_tool_fa
     feasible = service.decide(
         "민원 신청 제출해줘",
         initial_scores=(("gov24_minwon_submit", 9.0),),
+        session_identity={"citizen_id": "fixture"},
     )
 
     assert feasible.selected_tools == ("gov24_minwon_submit",)
     assert feasible.permission_gate is True
+    assert feasible.stop_reason == "permission_required"
 
     registry.set_active("gov24_minwon_submit", False)
     inactive = service.decide(
@@ -218,6 +224,7 @@ def test_route_decision_hard_excludes_disallowed_credentials(sample_tool_factory
 
     assert decision.selected_tools == ()
     assert decision.candidate_set == ()
+    assert decision.stop_reason == "blocked_no_credential"
     assert "hard_excluded:disallowed_credential:api_key:kma_weather_forecast" in (
         decision.evidence_events
     )
@@ -272,7 +279,7 @@ def test_route_decision_permission_gate_uses_selected_slice(sample_tool_factory)
     assert decision.permission_gate is False
 
 
-def test_route_decision_tie_breaks_by_tool_id(sample_tool_factory) -> None:
+def test_route_decision_equal_candidates_require_clarification(sample_tool_factory) -> None:
     registry = ToolRegistry()
     registry.register(
         sample_tool_factory(
@@ -300,7 +307,103 @@ def test_route_decision_tie_breaks_by_tool_id(sample_tool_factory) -> None:
         max_selected=1,
     )
 
-    assert decision.selected_tools == ("alpha_weather_forecast",)
+    assert decision.selected_tools == ()
+    assert tuple(candidate.tool_id for candidate in decision.candidate_set[:2]) == (
+        "alpha_weather_forecast",
+        "zeta_weather_forecast",
+    )
+    assert decision.stop_reason == "needs_input"
+    assert decision.clarification is not None
+    assert decision.clarification.reason == "equal_candidates"
+    assert decision.clarification.candidate_tool_ids == (
+        "alpha_weather_forecast",
+        "zeta_weather_forecast",
+    )
+    assert decision.clarification_question == (
+        "Which service should I use: alpha_weather_forecast or zeta_weather_forecast?"
+    )
+
+
+def test_route_decision_side_effect_without_confirmation_requires_clarification(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="simple_auth_check",
+            ministry="UMMAYA",
+            auth_type="oauth",
+            primitive="check",
+            policy=_policy("login"),
+            search_hint="identity check verify",
+        )
+    )
+    registry.register(
+        sample_tool_factory(
+            id="gov24_minwon_submit",
+            ministry="GOV24",
+            auth_type="oauth",
+            primitive="send",
+            policy=_policy("send"),
+            llm_description="Submit a civil-affairs request after explicit citizen confirmation.",
+            search_hint="민원 신청 제출 submit",
+        )
+    )
+
+    decision = RouteDecisionService(registry).decide(
+        "민원 신청 제출해줘",
+        initial_scores=(("gov24_minwon_submit", 9.0),),
+    )
+
+    assert decision.selected_tools == ()
+    assert decision.stop_reason == "needs_input"
+    assert decision.clarification is not None
+    assert decision.clarification.reason == "side_effect_confirmation"
+    assert decision.clarification_question == "Should I proceed with gov24_minwon_submit?"
+
+
+def test_route_decision_repeated_tool_mismatch_terminates_with_reason(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="kma_weather_forecast",
+            primitive="find",
+            policy=_policy(),
+            search_hint="weather forecast",
+        )
+    )
+
+    decision = RouteDecisionService(registry).select_adapters(
+        "weather forecast",
+        initial_scores=(("kma_weather_forecast", 10.0),),
+        validation_events=(
+            "tool_mismatch:kma_weather_forecast:locate",
+            "tool_mismatch:kma_weather_forecast:search_tools",
+        ),
+    )
+
+    assert decision.selected_tools == ()
+    assert decision.schema_projection_level == "none"
+    assert decision.stop_reason == "repeated_tool_mismatch"
+    assert decision.degradation_reason == "repeated_tool_mismatch"
+    assert "termination:repeated_tool_mismatch" in decision.evidence_events
+
+
+def test_route_decision_stop_reasons_match_plan_contract() -> None:
+    assert set(RouteStopReason.__args__) == {
+        "answerable",
+        "needs_input",
+        "permission_required",
+        "handoff_required",
+        "blocked_no_adapter",
+        "blocked_no_credential",
+        "max_turns",
+        "repeated_tool_mismatch",
+        "no_new_evidence",
+        "runtime_tool_failure_unrecovered",
+    }
 
 
 def test_route_decision_include_infeasible_retains_soft_rejection_reasons() -> None:

--- a/tests/tools/test_route_projection.py
+++ b/tests/tools/test_route_projection.py
@@ -1,0 +1,164 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from ummaya.tools.models import AdapterRealDomainPolicy
+from ummaya.tools.registry import ToolRegistry
+from ummaya.tools.routing import RouteDecisionService
+from ummaya.tools.routing.projection import build_available_adapters_projection
+
+
+def _policy() -> AdapterRealDomainPolicy:
+    return AdapterRealDomainPolicy(
+        real_classification_url="https://example.go.kr/policy",
+        real_classification_text="Published agency policy",
+        citizen_facing_gate="read-only",
+        last_verified=datetime(2026, 6, 5, tzinfo=UTC),
+    )
+
+
+def _projected_tool_id_lines(content: str) -> tuple[str, ...]:
+    return tuple(
+        line.strip().removeprefix("- tool_id:").strip()
+        for line in content.splitlines()
+        if line.strip().startswith("- tool_id:")
+    )
+
+
+def test_available_adapter_projection_summary_uses_route_decision_backend(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="kma_weather_forecast",
+            primitive="find",
+            policy=_policy(),
+            llm_description="Official weather forecast lookup.",
+            search_hint="weather forecast",
+        )
+    )
+    decision = RouteDecisionService(registry).select_adapters(
+        "weather forecast",
+        initial_scores=(("kma_weather_forecast", 10.0),),
+    )
+
+    projection = build_available_adapters_projection(
+        decision,
+        registry,
+        query="weather forecast",
+        projection_level="summary",
+    )
+
+    assert projection.tool_ids == ("kma_weather_forecast",)
+    assert projection.content is not None
+    assert 'backend="injected"' in projection.content
+    assert 'schema_projection="summary"' in projection.content
+    assert "input_schema_summary" in projection.content
+    assert "city" in projection.content
+    assert "input_schema_json" not in projection.content
+    assert '"properties"' not in projection.content
+    assert "백엔드 BM25 후보" not in projection.content
+
+
+def test_available_adapter_projection_full_schema_is_explicit(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="kma_weather_forecast",
+            primitive="find",
+            policy=_policy(),
+            search_hint="weather forecast",
+        )
+    )
+    decision = RouteDecisionService(registry).select_adapters(
+        "weather forecast",
+        initial_scores=(("kma_weather_forecast", 10.0),),
+    )
+
+    projection = build_available_adapters_projection(
+        decision,
+        registry,
+        query="weather forecast",
+        projection_level="full_schema",
+    )
+
+    assert projection.content is not None
+    assert 'schema_projection="full_schema"' in projection.content
+    assert "input_schema_json:" in projection.content
+    assert '"properties"' in projection.content
+
+
+def test_available_adapter_projection_none_hides_candidates(sample_tool_factory) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="kma_weather_forecast",
+            primitive="find",
+            policy=_policy(),
+            search_hint="weather forecast",
+        )
+    )
+    decision = RouteDecisionService(registry).select_adapters(
+        "weather forecast",
+        initial_scores=(("kma_weather_forecast", 10.0),),
+    )
+
+    projection = build_available_adapters_projection(
+        decision,
+        registry,
+        query="weather forecast",
+        projection_level="none",
+    )
+
+    assert projection.tool_ids == ()
+    assert projection.content is None
+
+
+def test_available_adapter_projection_renders_only_visible_tool_ids(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="find",
+            primitive="find",
+            policy=_policy(),
+            search_hint="generic root primitive search",
+        )
+    )
+    registry.register(
+        sample_tool_factory(
+            id="bfc_funeral_area_fee",
+            primitive="find",
+            policy=_policy(),
+            search_hint="부산 장례식장 시설 사용료 public data",
+        )
+    )
+    decision = RouteDecisionService(registry).select_adapters(
+        "부산광역시 장례식장 시설 사용료 목록을 조회해줘",
+        initial_scores=(("find", 10.0), ("bfc_funeral_area_fee", 9.0)),
+        max_selected=2,
+    )
+
+    projection = build_available_adapters_projection(
+        decision,
+        registry,
+        query="부산광역시 장례식장 시설 사용료 목록을 조회해줘",
+        projection_level="summary",
+        visible_tool_ids=("bfc_funeral_area_fee",),
+    )
+
+    assert projection.tool_ids == ("bfc_funeral_area_fee",)
+    assert projection.content is not None
+    assert _projected_tool_id_lines(projection.content) == ("bfc_funeral_area_fee",)
+    assert "tool_id: bfc_funeral_area_fee" in projection.content
+    assert "tool_id: find" not in projection.content
+    assert not (
+        set(_projected_tool_id_lines(projection.content))
+        & {"find", "locate", "check", "send", "search_tools"}
+    )

--- a/tests/tools/test_route_projection.py
+++ b/tests/tools/test_route_projection.py
@@ -7,14 +7,17 @@ from datetime import UTC, datetime
 from ummaya.tools.models import AdapterRealDomainPolicy
 from ummaya.tools.registry import ToolRegistry
 from ummaya.tools.routing import RouteDecisionService
-from ummaya.tools.routing.projection import build_available_adapters_projection
+from ummaya.tools.routing.projection import (
+    build_available_adapters_projection,
+    selected_concrete_adapter_tools,
+)
 
 
-def _policy() -> AdapterRealDomainPolicy:
+def _policy(citizen_facing_gate: str = "read-only") -> AdapterRealDomainPolicy:
     return AdapterRealDomainPolicy(
         real_classification_url="https://example.go.kr/policy",
         real_classification_text="Published agency policy",
-        citizen_facing_gate="read-only",
+        citizen_facing_gate=citizen_facing_gate,
         last_verified=datetime(2026, 6, 5, tzinfo=UTC),
     )
 
@@ -162,3 +165,48 @@ def test_available_adapter_projection_renders_only_visible_tool_ids(
         set(_projected_tool_id_lines(projection.content))
         & {"find", "locate", "check", "send", "search_tools"}
     )
+
+
+def test_available_adapter_projection_does_not_resurrect_clarification_candidates(
+    sample_tool_factory,
+) -> None:
+    registry = ToolRegistry()
+    registry.register(
+        sample_tool_factory(
+            id="simple_auth_check",
+            ministry="UMMAYA",
+            auth_type="oauth",
+            primitive="check",
+            policy=_policy("login"),
+            search_hint="identity check verify",
+        )
+    )
+    registry.register(
+        sample_tool_factory(
+            id="gov24_minwon_submit",
+            ministry="GOV24",
+            auth_type="oauth",
+            primitive="send",
+            policy=_policy("send"),
+            llm_description="Submit a civil-affairs request after explicit citizen confirmation.",
+            search_hint="민원 신청 제출 submit",
+        )
+    )
+    decision = RouteDecisionService(registry).decide(
+        "민원 신청 제출해줘",
+        initial_scores=(("gov24_minwon_submit", 9.0),),
+    )
+
+    projection = build_available_adapters_projection(
+        decision,
+        registry,
+        query="민원 신청 제출해줘",
+        projection_level="summary",
+    )
+
+    assert decision.stop_reason == "needs_input"
+    assert decision.selected_tools == ()
+    assert decision.candidate_set
+    assert selected_concrete_adapter_tools(decision, registry) == ()
+    assert projection.tool_ids == ()
+    assert projection.content is None

--- a/tests/tools/test_tool_selection_intent.py
+++ b/tests/tools/test_tool_selection_intent.py
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import inspect
+
+from ummaya.tools import search as search_module
+from ummaya.tools.routing.intent import (
+    ACTIVE_PRIMITIVES,
+    LEGACY_PRIMITIVE_ALIASES,
+    ToolSelectionIntent,
+    extract_tool_selection_intent,
+)
+from ummaya.tools.search import _expand_query_for_adapter_retrieval
+
+
+def test_extracts_explicit_tool_id_and_public_data_operation_without_scores() -> None:
+    intent = extract_tool_selection_intent(
+        "tool_id=kma_apihub_url_air_metar_decoded 로 METAR getSurfaceChart 해독",
+        known_tool_ids={"kma_apihub_url_air_metar_decoded"},
+    )
+
+    assert intent.explicit_tool_ids == ("kma_apihub_url_air_metar_decoded",)
+    assert "operation:getSurfaceChart" in intent.public_data_refs
+    assert "kma_airport_aviation" in intent.public_data_refs
+    assert intent.candidate_primitives == ("find",)
+    assert not any(
+        "score" in field or "rank" in field for field in ToolSelectionIntent.model_fields
+    )
+
+
+def test_extracts_document_path_artifact_and_side_effect_marker() -> None:
+    intent = extract_tool_selection_intent(
+        "~/Downloads/신청서.hwpx 파일을 artifact-abc123 기준으로 채워서 저장해줘"
+    )
+
+    assert "~/Downloads/신청서.hwpx" in intent.document_refs
+    assert "format:hwpx" in intent.document_refs
+    assert "document_harness" in intent.document_refs
+    assert intent.explicit_artifact_ids == ("artifact-abc123",)
+    assert "document_write" in intent.side_effect_markers
+    assert "send" in intent.candidate_primitives
+    assert intent.requires_permission is True
+
+
+def test_extracts_coordinate_location_and_missing_slots_boundary() -> None:
+    coordinate_intent = extract_tool_selection_intent("37.5665, 126.9780 근처 AED 위치 알려줘")
+    poi_intent = extract_tool_selection_intent("하단역 근처 응급실 어디야?")
+
+    assert "coordinate:37.5665,126.978" in coordinate_intent.location_refs
+    assert "poi" in coordinate_intent.location_refs
+    assert coordinate_intent.missing_slots == ()
+    assert "aed" in coordinate_intent.public_data_refs
+    assert "locate" in coordinate_intent.candidate_primitives
+    assert "poi_requires_location_resolution" in poi_intent.unsafe_assumptions
+    assert poi_intent.missing_slots == ("lat", "lon")
+
+
+def test_active_primitives_exclude_legacy_aliases_from_candidate_surface() -> None:
+    intent = extract_tool_selection_intent("lookup으로 resolve_location 말고 부산시 날씨 찾아줘")
+
+    assert ACTIVE_PRIMITIVES == ("find", "locate", "send", "check")
+    assert LEGACY_PRIMITIVE_ALIASES["lookup"] == "find"
+    assert LEGACY_PRIMITIVE_ALIASES["resolve_location"] == "locate"
+    assert set(intent.candidate_primitives) <= set(ACTIVE_PRIMITIVES)
+    assert "lookup" not in intent.candidate_primitives
+    assert "resolve_location" not in intent.candidate_primitives
+
+
+def test_search_expansion_uses_intent_for_explicit_metar_signal() -> None:
+    expanded = _expand_query_for_adapter_retrieval("METAR 해독자료 보여줘")
+
+    assert "항공기상" in expanded
+    assert "METAR" in expanded
+
+
+def test_search_active_path_extracts_tool_selection_intent_once(
+    monkeypatch, populated_registry
+) -> None:
+    calls = 0
+    real_extract = search_module.extract_tool_selection_intent
+
+    def counting_extract(query: str, *, known_tool_ids=()):
+        nonlocal calls
+        calls += 1
+        return real_extract(query, known_tool_ids=known_tool_ids)
+
+    monkeypatch.setattr(search_module, "extract_tool_selection_intent", counting_extract)
+
+    search_module.search(
+        "날씨 METAR 해독자료 보여줘",
+        populated_registry.bm25_index,
+        populated_registry,
+    )
+
+    assert calls == 1
+
+
+def test_search_module_no_longer_owns_domain_regex_tables() -> None:
+    source = inspect.getsource(search_module)
+
+    assert "re.compile(" not in source
+    assert "_RE.search(" not in source
+
+
+def test_emergency_call_box_is_protected_from_medical_emergency_chain() -> None:
+    intent = extract_tool_selection_intent("부산역 근처 emergency call box 위치 알려줘")
+
+    assert "mois_emergency_call_box" in intent.public_data_refs
+    assert "emergency_medical" not in intent.public_data_refs
+    assert "implicit_emergency" not in intent.public_data_refs
+    assert "poi" in intent.location_refs
+
+
+def test_kcue_finance_subsignal_implies_regional_parent_ref() -> None:
+    intent = extract_tool_selection_intent(
+        "대학 등록금이 지역별로 얼마나 차이 나는지 공식 자료로 보고 싶어"
+    )
+
+    assert "kcue_regional" in intent.public_data_refs
+    assert "kcue_regional_finance" in intent.public_data_refs

--- a/tests/tools/test_tool_selection_intent.py
+++ b/tests/tools/test_tool_selection_intent.py
@@ -119,3 +119,10 @@ def test_kcue_finance_subsignal_implies_regional_parent_ref() -> None:
 
     assert "kcue_regional" in intent.public_data_refs
     assert "kcue_regional_finance" in intent.public_data_refs
+
+
+def test_airkorea_air_quality_signal_is_not_weather_ref() -> None:
+    intent = extract_tool_selection_intent("부산 공기질과 미세먼지 지금 어때? air quality 확인해줘")
+
+    assert "airkorea_air_quality" in intent.public_data_refs
+    assert "kma_lifestyle_weather" not in intent.public_data_refs

--- a/tests/unit/ipc/test_adapter_manifest_emitter.py
+++ b/tests/unit/ipc/test_adapter_manifest_emitter.py
@@ -366,6 +366,13 @@ def test_full_runtime_manifest_exports_model_facing_tool_metadata() -> None:
     assert "check:mobile_id.identity" in str(mobile_id.llm_description)
     assert "mobile ID" in str(mobile_id.search_hint)
 
+    for entry in entries:
+        if entry.primitive != "check" or entry.source_mode != "internal":
+            continue
+        description = str(entry.llm_description)
+        assert "mock_verify" not in description
+        assert "bridged adapter id" not in description
+
     _EXTRA_REGISTRY.clear()
 
 

--- a/tui/src/hooks/toolPermission/handlers/interactiveHandler.ts
+++ b/tui/src/hooks/toolPermission/handlers/interactiveHandler.ts
@@ -18,6 +18,7 @@ import {
 } from '../../../services/mcp/channelPermissions.js'
 import { executeAsyncClassifierCheck } from '../../../tools/BashTool/bashPermissions.js'
 import { BASH_TOOL_NAME } from '../../../tools/BashTool/toolName.js'
+import { appendRoutePermissionPromptDiagnostic } from '../../../tools/AdapterTool/routeDiagnostics.js'
 import {
   clearClassifierChecking,
   setClassifierApproval,
@@ -229,6 +230,15 @@ function handleInteractivePermission(
         resolveOnce(ctx.buildAllow(freshResult.updatedInput ?? ctx.input))
       }
     },
+  })
+  appendRoutePermissionPromptDiagnostic({
+    toolName: ctx.tool.name,
+    input: displayInput,
+    toolUseID: ctx.toolUseID,
+    messageID: ctx.messageId,
+    queryChainID: ctx.toolUseContext.queryTracking?.chainId ?? null,
+    queryDepth: ctx.toolUseContext.queryTracking?.depth ?? null,
+    permissionMode: ctx.toolUseContext.getAppState().toolPermissionContext.mode ?? null,
   })
 
   // Race 4: Bridge permission response from CCR (claude.ai)

--- a/tui/src/query.ts
+++ b/tui/src/query.ts
@@ -200,6 +200,7 @@ function* yieldMissingToolResultBlocks(
  * rules, ye will be punished with an entire day of debugging and hair pulling.
  */
 const MAX_OUTPUT_TOKENS_RECOVERY_LIMIT = 3
+const ADAPTER_MANIFEST_BOOTSTRAP_TIMEOUT_MS = 30_000
 
 /**
  * Is this a max_output_tokens error message? If so, the streaming loop should
@@ -325,7 +326,9 @@ async function* queryLoop(
     params.deps === undefined &&
     process.env.UMMAYA_SKIP_ADAPTER_MANIFEST_BOOTSTRAP !== 'true'
   ) {
-    const manifestSynced = await ensureUmmayaAdapterManifest(10_000)
+    const manifestSynced = await ensureUmmayaAdapterManifest(
+      ADAPTER_MANIFEST_BOOTSTRAP_TIMEOUT_MS,
+    )
     if (manifestSynced && state.toolUseContext.options.refreshTools) {
       const refreshedTools = state.toolUseContext.options.refreshTools()
       if (refreshedTools !== state.toolUseContext.options.tools) {

--- a/tui/src/services/api/adapterManifest.ts
+++ b/tui/src/services/api/adapterManifest.ts
@@ -94,6 +94,10 @@ export function listAdapters(): AdapterManifestEntry[] {
   )
 }
 
+export function getAdapterManifestHash(): string | null {
+  return _cache?.manifestHash ?? null
+}
+
 /**
  * Returns ``true`` when at least one manifest frame has been ingested.
  *

--- a/tui/src/services/api/claude.ts
+++ b/tui/src/services/api/claude.ts
@@ -220,8 +220,16 @@ import {
   getAdapterToolByName,
   selectTopKAdapterToolNamesForQuery,
 } from '../../tools/AdapterTool/AdapterTool.js'
+import {
+  appendRouteDiagnostic,
+  hashRouteDiagnosticText,
+} from '../../tools/AdapterTool/routeDiagnostics.js'
 import { isNonSyntheticUserText } from '../../tools/_shared/citizenUserText.js'
 import { shouldSuppressUmmayaToolCallsForAnswerSynthesis } from '../../tools/_shared/toolChoiceRepair.js'
+import {
+  getAdapterManifestHash,
+  listAdapters,
+} from './adapterManifest.js'
 import { count } from '../../utils/array.js'
 import { insertBlockAfterToolResults } from '../../utils/contentArray.js'
 import { validateBoundedIntEnvVar } from '../../utils/envValidation.js'
@@ -295,6 +303,9 @@ const {
 type JsonValue = string | number | boolean | null | JsonObject | JsonArray
 type JsonObject = { [key: string]: JsonValue }
 type JsonArray = JsonValue[]
+
+const forcedToolChoiceSystemInstruction = (toolName: string): string =>
+  `Mandatory tool call: the host selected ${toolName} for this turn. Do not answer with prose, do not ask a follow-up question, and do not choose another tool. Emit exactly one ${toolName} tool call with valid JSON arguments.`
 
 /**
  * Assemble the extra body parameters for the API request, based on the
@@ -1187,11 +1198,11 @@ async function* queryModel(
     'query',
   )
 
-  const turnLocalAdapterToolNames = new Set(
-    selectTopKAdapterToolNamesForQuery(
-      latestUserTextForToolRetrieval(messages),
-    ),
+  const latestUserTextForAdapters = latestUserTextForToolRetrieval(messages)
+  const selectedAdapterToolNames = selectTopKAdapterToolNamesForQuery(
+    latestUserTextForAdapters,
   )
+  const turnLocalAdapterToolNames = new Set(selectedAdapterToolNames)
   if (options.toolChoice?.type === 'tool') {
     turnLocalAdapterToolNames.add(options.toolChoice.name)
   }
@@ -1348,6 +1359,23 @@ async function* queryModel(
       }),
     ),
   )
+  appendRouteDiagnostic('adapter_selection', {
+    query_hash: hashRouteDiagnosticText(latestUserTextForAdapters),
+    query_source: options.querySource,
+    manifest_hash: getAdapterManifestHash(),
+    selected_tools: selectedAdapterToolNames,
+    final_adapter_tools: filteredTools
+      .filter(tool => turnLocalAdapterToolNames.has(tool.name))
+      .map(tool => tool.name),
+    candidate_count: listAdapters().length,
+    request_tool_count: requestTools.length,
+    filtered_tool_count: filteredTools.length,
+    tool_schema_count: toolSchemas.length,
+    tool_search_enabled: useToolSearch,
+    schema_projection_level: 'top_k_concrete_adapter_schemas',
+    forced_tool_choice:
+      options.toolChoice?.type === 'tool' ? options.toolChoice.name : null,
+  })
 
   if (useToolSearch) {
     const includedDeferredTools = count(filteredTools, t =>
@@ -1469,6 +1497,9 @@ async function* queryModel(
       ...systemPrompt,
       ...(advisorModel ? [ADVISOR_TOOL_INSTRUCTIONS] : []),
       ...(injectChromeHere ? [CHROME_TOOL_SEARCH_INSTRUCTIONS] : []),
+      ...(options.toolChoice?.type === 'tool'
+        ? [forcedToolChoiceSystemInstruction(options.toolChoice.name)]
+        : []),
     ].filter(Boolean),
   )
 

--- a/tui/src/services/tools/toolExecution.ts
+++ b/tui/src/services/tools/toolExecution.ts
@@ -51,7 +51,9 @@ import {
 import {
   getAdapterToolByName,
   isAdapterToolName,
+  isRootPrimitiveToolName,
 } from '../../tools/AdapterTool/AdapterTool.js'
+import { appendRouteDiagnostic } from '../../tools/AdapterTool/routeDiagnostics.js'
 import { getAllBaseTools } from '../../tools.js'
 import type { HookProgress } from '../../types/hooks.js'
 import type {
@@ -366,6 +368,21 @@ export async function* runToolUse(
   }
   const messageId = assistantMessage.message.id
   const requestId = assistantMessage.requestId
+  const isAdapterTool = isAdapterToolName(toolName)
+  const isRouteTool = isAdapterTool || isRootPrimitiveToolName(toolName)
+  const routeTargetToolId = extractRouteTargetToolId(toolUse.input)
+  if (isRouteTool) {
+    appendRouteDiagnostic('route_tool_dispatch', {
+      tool_name: toolName,
+      tool_surface: isAdapterTool ? 'concrete_adapter' : 'root_primitive',
+      target_tool_id: routeTargetToolId,
+      tool_use_id: toolUse.id,
+      message_id: messageId,
+      request_id: requestId ?? null,
+      query_chain_id: toolUseContext.queryTracking?.chainId ?? null,
+      query_depth: toolUseContext.queryTracking?.depth ?? null,
+    })
+  }
   const mcpServerType = getMcpServerType(
     toolName,
     toolUseContext.options.mcpClients,
@@ -762,6 +779,9 @@ async function checkPermissionsAndCallTool(
   }
 
   const resultingMessages = []
+  const isAdapterTool = isAdapterToolName(tool.name)
+  const isRouteTool = isAdapterTool || isRootPrimitiveToolName(tool.name)
+  const toolSurface = isAdapterTool ? 'concrete_adapter' : 'root_primitive'
 
   // Defense-in-depth: strip _simulatedSedEdit from model-provided Bash input.
   // This field is internal-only — it must only be injected by the permission
@@ -1003,6 +1023,21 @@ async function checkPermissionsAndCallTool(
   }
 
   if (permissionDecision.behavior !== 'allow') {
+    if (isRouteTool) {
+      appendRouteDiagnostic('route_tool_permission', {
+        tool_name: tool.name,
+        tool_surface: toolSurface,
+        target_tool_id: extractRouteTargetToolId(processedInput),
+        tool_use_id: toolUseID,
+        message_id: messageId,
+        request_id: requestId ?? null,
+        query_chain_id: toolUseContext.queryTracking?.chainId ?? null,
+        query_depth: toolUseContext.queryTracking?.depth ?? null,
+        permission_mode: permissionMode,
+        permission_behavior: permissionDecision.behavior,
+        result_status: 'blocked',
+      })
+    }
     logForDebugging(`${tool.name} tool permission denied`)
     const decisionInfo = toolUseContext.toolDecisions?.get(toolUseID)
     endToolBlockedOnUserSpan('reject', decisionInfo?.source || 'unknown')
@@ -1214,6 +1249,20 @@ async function checkPermissionsAndCallTool(
     callInput = processedInput
   }
   try {
+    if (isRouteTool) {
+      appendRouteDiagnostic('route_tool_call_start', {
+        tool_name: tool.name,
+        tool_surface: toolSurface,
+        target_tool_id: extractRouteTargetToolId(callInput),
+        tool_use_id: toolUseID,
+        message_id: messageId,
+        request_id: requestId ?? null,
+        query_chain_id: toolUseContext.queryTracking?.chainId ?? null,
+        query_depth: toolUseContext.queryTracking?.depth ?? null,
+        permission_mode: permissionMode,
+        permission_behavior: permissionDecision.behavior,
+      })
+    }
     const result = await tool.call(
       callInput,
       {
@@ -1309,6 +1358,21 @@ async function checkPermissionsAndCallTool(
       : typeof mappedContent === 'string'
         ? mappedContent.length
         : jsonStringify(mappedContent).length
+    if (isRouteTool) {
+      appendRouteDiagnostic('route_tool_result', {
+        tool_name: tool.name,
+        tool_surface: toolSurface,
+        target_tool_id: extractRouteTargetToolId(callInput),
+        tool_use_id: toolUseID,
+        message_id: messageId,
+        request_id: requestId ?? null,
+        query_chain_id: toolUseContext.queryTracking?.chainId ?? null,
+        query_depth: toolUseContext.queryTracking?.depth ?? null,
+        duration_ms: durationMs,
+        result_status: 'success',
+        tool_result_size_bytes: toolResultSizeBytes,
+      })
+    }
 
     // Extract file extension for file-related tools
     let fileExtension: ReturnType<typeof getFileExtensionForAnalytics>
@@ -1605,6 +1669,21 @@ async function checkPermissionsAndCallTool(
       error: errorMessage(error),
     })
     endToolSpan()
+    if (isRouteTool) {
+      appendRouteDiagnostic('route_tool_result', {
+        tool_name: tool.name,
+        tool_surface: toolSurface,
+        target_tool_id: extractRouteTargetToolId(callInput),
+        tool_use_id: toolUseID,
+        message_id: messageId,
+        request_id: requestId ?? null,
+        query_chain_id: toolUseContext.queryTracking?.chainId ?? null,
+        query_depth: toolUseContext.queryTracking?.depth ?? null,
+        duration_ms: durationMs,
+        result_status: 'error',
+        error_kind: classifyToolError(error),
+      })
+    }
 
     // Handle MCP auth errors by updating the client status to 'needs-auth'
     // This updates the /mcp display to show the server needs re-authorization
@@ -1752,4 +1831,10 @@ async function checkPermissionsAndCallTool(
       toolUseContext.toolDecisions?.delete(toolUseID)
     }
   }
+}
+
+function extractRouteTargetToolId(input: unknown): string | null {
+  if (!input || typeof input !== 'object') return null
+  const value = (input as { tool_id?: unknown }).tool_id
+  return typeof value === 'string' ? value : null
 }

--- a/tui/src/tools/AdapterTool/AdapterTool.ts
+++ b/tui/src/tools/AdapterTool/AdapterTool.ts
@@ -109,6 +109,8 @@ const KMA_ANALYSIS_POINT_RE =
   /(주변|근처|특정지점|좌표|위도|경도|\blat\b|\blon\b|공항\s*주변)/iu
 const KMA_LIFESTYLE_WEATHER_RE =
   /(날씨|현재\s*기상|실황|관측|예보|기온|습도|풍속|지금\s*비|비\s*(와|오|올|내리)|우산|강수|소나기|산책|퇴근|current\s+weather|forecast|rain|umbrella|precipitation|temperature)/iu
+const AIRKOREA_AIR_QUALITY_RE =
+  /(미세먼지|초미세먼지|초미세|대기질|대기오염|공기질|마스크|pm\s*2\.?5|pm\s*10|air\s*korea|airkorea|air\s*quality|airquality)/iu
 const KMA_LIFESTYLE_WEATHER_TOOL_NAMES = new Set([
   'kma_current_observation',
   'kma_ultra_short_term_forecast',
@@ -130,6 +132,8 @@ const PROTECTED_MOBILE_ID_RE = /(mobile\s*id|모바일\s*(?:신분증|id)|mobile
 const PROTECTED_SIMPLE_AUTH_RE =
   /(simple_auth|간편인증|ganpyeon|소득금액증명|증명원|민원|발급)/iu
 const PROTECTED_MYDATA_RE = /(mydata|마이데이터)/iu
+const GOV24_MINWON_SUBMIT_RE =
+  /(?=.*(?:정부24|gov24))(?=.*(?:주민등록등본|등본|민원|발급))(?=.*(?:신청|접수|발급|submit|apply|issue))/iu
 const PROTECTED_CHECK_TOOL_NAMES = [
   'mock_verify_module_simple_auth',
   'mock_verify_ganpyeon_injeung',
@@ -1476,12 +1480,17 @@ function isKmaAnalysisQuery(query: string): boolean {
 function isLifestyleWeatherQuery(query: string): boolean {
   return (
     KMA_LIFESTYLE_WEATHER_RE.test(query) &&
+    !isAirKoreaAirQualityQuery(query) &&
     !isAirportAviationQuery(query) &&
     !isKmaAnalysisQuery(query) &&
     !isMedicalEmergencyQuery(query) &&
     !TRAFFIC_HAZARD_RE.test(query) &&
     !MOF_OCEAN_WATER_QUALITY_RE.test(query)
   )
+}
+
+function isAirKoreaAirQualityQuery(query: string): boolean {
+  return AIRKOREA_AIR_QUALITY_RE.test(query)
 }
 
 function isPpsBidQuery(query: string): boolean {
@@ -1501,6 +1510,20 @@ function protectedCheckToolPreference(query: string): string[] {
     ...PROTECTED_CHECK_TOOL_NAMES,
   ].filter((toolName): toolName is string => typeof toolName === 'string')
   return [...new Set(preferred)]
+}
+
+function isGov24MinwonSubmitQuery(query: string): boolean {
+  return GOV24_MINWON_SUBMIT_RE.test(query)
+}
+
+function gov24MinwonToolPreference(): string[] {
+  return [
+    'mock_verify_module_simple_auth',
+    'mock_submit_module_gov24_minwon',
+    'mock_lookup_module_gov24_certificate',
+    'mock_verify_ganpyeon_injeung',
+    'mock_verify_mobile_id',
+  ]
 }
 
 function isTagoBusQuery(query: string): boolean {
@@ -1579,6 +1602,11 @@ function scoreAdapterEntry(
     if (entry.tool_id === 'juso_adm_cd_lookup') score += 260
     if (entry.tool_id === 'sgis_adm_cd_lookup') score += 260
   }
+  if (isAirKoreaAirQualityQuery(query)) {
+    if (entry.tool_id === 'airkorea_ctprvn_air_quality') score += 1400
+    if (isLocationAdapter(entry)) score = Math.max(0, score - 120)
+    if (entry.tool_id.startsWith('kma_')) score = Math.max(0, score - 160)
+  }
   if (HIRA_MEDICAL_DETAIL_RE.test(query)) {
     if (entry.tool_id === 'hira_medical_institution_detail') score += 650
   }
@@ -1595,6 +1623,12 @@ function scoreAdapterEntry(
   }
   if (isPpsBidQuery(query)) {
     if (entry.tool_id === 'pps_bid_public_info') score += 1000
+  }
+  if (isGov24MinwonSubmitQuery(query)) {
+    const preference = gov24MinwonToolPreference()
+    const index = preference.indexOf(entry.tool_id)
+    if (index >= 0) score += 1400 - index * 40
+    if (isLocationAdapter(entry)) score = Math.max(0, score - 180)
   }
   if (isProtectedCheckQuery(query) && entry.primitive === 'check') {
     const preference = protectedCheckToolPreference(query)
@@ -1629,6 +1663,12 @@ function filterSpecialCaseRanked(
   ranked: ScoredAdapterEntry[],
 ): ScoredAdapterEntry[] {
   let filtered = ranked
+  if (isAirKoreaAirQualityQuery(query)) {
+    const allowed = filtered.filter(
+      candidate => candidate.entry.tool_id === 'airkorea_ctprvn_air_quality',
+    )
+    if (allowed.length > 0) return allowed
+  }
   if (isKmaAnalysisQuery(query)) {
     const allowLocation = isKmaAnalysisPointQuery(query)
     const preferPoiLocation = queryPrefersPoiLocation(query)
@@ -1669,6 +1709,19 @@ function filterSpecialCaseRanked(
     const allowed = filtered.filter(candidate => candidate.entry.tool_id === 'pps_bid_public_info')
     if (allowed.length > 0) {
       filtered = allowed.sort((a, b) => {
+        if (b.score !== a.score) return b.score - a.score
+        return a.entry.tool_id.localeCompare(b.entry.tool_id)
+      })
+    }
+  }
+  if (isGov24MinwonSubmitQuery(query)) {
+    const preference = gov24MinwonToolPreference()
+    const allowed = filtered.filter(candidate => preference.includes(candidate.entry.tool_id))
+    if (allowed.length > 0) {
+      return allowed.sort((a, b) => {
+        const aRank = preference.indexOf(a.entry.tool_id)
+        const bRank = preference.indexOf(b.entry.tool_id)
+        if (aRank !== bRank) return aRank - bRank
         if (b.score !== a.score) return b.score - a.score
         return a.entry.tool_id.localeCompare(b.entry.tool_id)
       })
@@ -1788,6 +1841,8 @@ function buildAdapterTool(entry: AdapterManifestEntry): Tool {
   const primitiveTool = primitiveToolFor(primitive)
   const adapterInputSchema = inputSchemaFor(entry)
   const adapterInputJSONSchema = inputJSONSchemaFor(entry)
+  const directCheckAdapterRequiresPermission =
+    primitive === 'check' && !ROOT_PRIMITIVE_TOOL_NAMES.has(entry.tool_id)
 
   return buildTool({
     name: entry.tool_id,
@@ -1818,11 +1873,17 @@ function buildAdapterTool(entry: AdapterManifestEntry): Tool {
     },
 
     isReadOnly(input) {
+      if (directCheckAdapterRequiresPermission) return false
       return primitiveTool.isReadOnly(rootInputFor(entry, input))
     },
 
     isDestructive(input) {
+      if (directCheckAdapterRequiresPermission) return true
       return primitiveTool.isDestructive?.(rootInputFor(entry, input)) ?? false
+    },
+
+    async checkPermissions(input, context) {
+      return primitiveTool.checkPermissions(rootInputFor(entry, input), context)
     },
 
     async description() {

--- a/tui/src/tools/AdapterTool/routeDiagnostics.ts
+++ b/tui/src/tools/AdapterTool/routeDiagnostics.ts
@@ -1,0 +1,75 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import { createHash } from 'node:crypto'
+import { appendFileSync, mkdirSync } from 'node:fs'
+import { dirname } from 'node:path'
+import { logForDebugging } from '../../utils/debug.js'
+
+type RouteDiagnosticValue = string | number | boolean | null | string[]
+
+type RouteDiagnosticPayload = Record<string, RouteDiagnosticValue>
+
+const ROUTE_ROOT_TOOL_NAMES = new Set(['locate', 'find', 'check', 'send', 'document'])
+
+export function hashRouteDiagnosticText(text: string): string {
+  return createHash('sha256').update(text, 'utf8').digest('hex')
+}
+
+export function appendRouteDiagnostic(
+  event: string,
+  payload: RouteDiagnosticPayload,
+): void {
+  const path = process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE
+  if (!path) return
+
+  const record = {
+    ts: new Date().toISOString(),
+    event,
+    ...payload,
+  }
+  try {
+    mkdirSync(dirname(path), { recursive: true })
+    appendFileSync(path, `${JSON.stringify(record)}\n`, 'utf8')
+  } catch (error) {
+    logForDebugging(`route diagnostics write failed: ${String(error)}`)
+  }
+}
+
+export function appendRoutePermissionPromptDiagnostic(payload: {
+  toolName: string
+  input: Record<string, unknown>
+  toolUseID: string
+  messageID: string
+  queryChainID: string | null
+  queryDepth: number | null
+  permissionMode: string | null
+}): void {
+  const toolSurface = routeToolSurface(payload.toolName)
+  if (toolSurface === null) return
+  appendRouteDiagnostic('route_tool_permission', {
+    tool_name: payload.toolName,
+    tool_surface: toolSurface,
+    target_tool_id: routeTargetToolID(payload.input),
+    tool_use_id: payload.toolUseID,
+    message_id: payload.messageID,
+    request_id: null,
+    query_chain_id: payload.queryChainID,
+    query_depth: payload.queryDepth,
+    permission_mode: payload.permissionMode,
+    permission_behavior: 'ask',
+    result_status: 'prompted',
+  })
+}
+
+function routeToolSurface(toolName: string): string | null {
+  if (ROUTE_ROOT_TOOL_NAMES.has(toolName)) return 'root_primitive'
+  if (/^[a-z][a-z0-9_]*$/u.test(toolName) && toolName.includes('_')) {
+    return 'concrete_adapter'
+  }
+  return null
+}
+
+function routeTargetToolID(input: Record<string, unknown>): string | null {
+  const toolID = input.tool_id
+  return typeof toolID === 'string' && toolID.length > 0 ? toolID : null
+}

--- a/tui/src/tools/_shared/directPublicDataGuard.ts
+++ b/tui/src/tools/_shared/directPublicDataGuard.ts
@@ -5,7 +5,7 @@ import { textFromContent } from './nmcAedGuard.js'
 
 const PPS_BID_RE = /(입찰|나라장터|조달청|공고|전기공사|bid|procurement)/iu
 const AIRKOREA_RE =
-  /(미세먼지|초미세먼지|대기질|대기오염|마스크|pm\s*2\.?5|pm\s*10|air\s*korea|airkorea)/iu
+  /(미세먼지|초미세먼지|초미세|대기질|대기오염|공기질|마스크|pm\s*2\.?5|pm\s*10|air\s*korea|airkorea|air\s*quality|airquality)/iu
 const KMA_CHART_RE = /(일기도|분석일기도|지도\s*자료|비구름|바람\s*흐름|synoptic|weather\s*chart)/iu
 const KMA_WEATHER_RE =
   /(날씨|현재\s*기상|실황|관측|예보|기온|습도|풍속|지금\s*비|비\s*(와|오|올|내리)|우산|강수|소나기|산책|퇴근|current\s+weather|forecast|rain|umbrella|precipitation|temperature)/iu
@@ -57,7 +57,8 @@ const AIRKOREA_SIDO_ALIASES: Record<string, string> = {
 
 type DirectTarget = {
   toolIds: readonly string[]
-  label: string
+  routeKind: string
+  displayLabel: string
   hint: string
 }
 
@@ -161,25 +162,28 @@ function directTargetForUserText(text: string): DirectTarget | undefined {
   if (KMA_CHART_RE.test(text)) {
     return {
       toolIds: ['kma_apihub_url_analysis_weather_chart_image'],
-      label: 'kma_apihub_url_analysis_weather_chart_image',
+      routeKind: 'weather_chart',
+      displayLabel: 'official weather chart data',
       hint:
-        "params must follow the weather chart/map schema: anal_time is required as UTC YYYYMMDDHHMM. Use the latest completed official analysis slot and include minutes, for example '202605281200', not a 10-digit KST hour.",
+        "Use the weather chart/map schema. The analysis time must be UTC YYYYMMDDHHMM, for example '202605281200'.",
     }
   }
   if (PPS_BID_RE.test(text)) {
     return {
       toolIds: ['pps_bid_public_info'],
-      label: 'pps_bid_public_info',
+      routeKind: 'procurement_bid',
+      displayLabel: 'official procurement notice data',
       hint:
-        "params must include inqry_bgn_dt/inqry_end_dt as valid YYYYMMDDHHMM and inqry_div:'1' unless the citizen asks for opening datetime. Keep each PPS call within a 31-day window. Copy citizen keywords into bid_ntce_nm and use region/industry filters only when the citizen supplied them; do not hard-code 전기공사 or 부산광역시 for unrelated procurement questions.",
+        'Use the procurement notice schema. Keep each query window within 31 days and only apply region or industry filters the citizen supplied.',
     }
   }
   if (AIRKOREA_RE.test(text)) {
     return {
       toolIds: ['airkorea_ctprvn_air_quality'],
-      label: 'airkorea_ctprvn_air_quality',
+      routeKind: 'air_quality',
+      displayLabel: 'official city/province air-quality data',
       hint:
-        "params should include sido_name:'부산', plus optional page_no/num_of_rows/ver exactly as the adapter schema exposes.",
+        'Use the city/province air-quality schema with the requested Korean city or province name.',
     }
   }
   if (TAGO_BUS_RE.test(text)) {
@@ -191,9 +195,10 @@ function directTargetForUserText(text: string): DirectTarget | undefined {
         'tago_bus_route_station_search',
         'tago_bus_location_search',
       ],
-      label: 'TAGO bus adapters',
+      routeKind: 'bus_realtime',
+      displayLabel: 'official bus route or arrival data',
       hint:
-        "use TAGO bus schemas for bus arrival/route requests. If a route number is named, call tago_bus_route_search for route_id, then tago_bus_route_station_search with route_id and node_nm to find passing stops. Call tago_bus_arrival_search with city_code, node_id, and route_no or route_id. If node_id is unknown, tago_bus_station_search can list nearby named stops.",
+        'Use the bus route, stop, or arrival schema. If the citizen named a route number, resolve the route before checking passing stops or arrivals.',
     }
   }
   if (KMA_WEATHER_RE.test(text)) {
@@ -206,9 +211,10 @@ function directTargetForUserText(text: string): DirectTarget | undefined {
         'kma_ultra_short_term_forecast',
         'kma_short_term_forecast',
       ],
-      label: 'KMA weather/location adapters',
+      routeKind: 'weather_current',
+      displayLabel: 'official weather or location data',
       hint:
-        'use a location adapter first when coordinates are missing, then KMA current-observation or forecast schemas for rain/umbrella/current-weather values. Do not use air-quality or bus adapters for ordinary weather.',
+        'Use location evidence first when coordinates are missing, then current observation or forecast data for ordinary weather values.',
     }
   }
   return undefined
@@ -354,8 +360,8 @@ export function validateDirectPublicDataToolChoice(
   return {
     result: false,
     message:
-      `Public-data tool-choice mismatch: the latest citizen request matches ${target.label}. ` +
-      `Call ${target.label} through the correct primitive instead of ${toolId}. ` +
+      `Public-data tool-choice mismatch: target=${target.routeKind}. ` +
+      `The latest citizen request needs ${target.displayLabel}; the previous tool choice does not match that route. ` +
       target.hint,
     errorCode: 1,
   }

--- a/tui/src/tools/_shared/toolChoiceRepair.ts
+++ b/tui/src/tools/_shared/toolChoiceRepair.ts
@@ -113,6 +113,84 @@ interface DocumentPathRef {
   expectedFormat: DocumentFormat
 }
 
+export interface UmmayaTuiRepairPolicy {
+  id: string
+  kind: 'display_or_answer_repair'
+  owner: string
+  evidenceEvent: string
+  removalCondition: string
+}
+
+export interface UmmayaBackendRepairReceipt {
+  source: 'backend_route_decision' | 'backend_validation'
+  reason: string
+  evidenceEvent: string
+  toolName?: string
+}
+
+export const UMMAYA_TUI_REPAIR_POLICIES: readonly UmmayaTuiRepairPolicy[] = [
+  {
+    id: 'document_observable_operation_backfill',
+    kind: 'display_or_answer_repair',
+    owner: 'ummaya:tui-display-repair',
+    evidenceEvent: 'ummaya.tui.repair.document_observable_operation_backfill',
+    removalCondition:
+      'Delete when document adapters emit display_operation in backend tool-use receipts.',
+  },
+  {
+    id: 'document_completion_prompt',
+    kind: 'display_or_answer_repair',
+    owner: 'ummaya:tui-answer-repair',
+    evidenceEvent: 'ummaya.tui.repair.document_completion_prompt',
+    removalCondition:
+      'Delete when backend RouteDecision stop reasons emit terminal document answer instructions.',
+  },
+  {
+    id: 'tago_bus_followup_prompt',
+    kind: 'display_or_answer_repair',
+    owner: 'ummaya:tui-answer-repair',
+    evidenceEvent: 'ummaya.tui.repair.tago_bus_followup_prompt',
+    removalCondition:
+      'Delete when backend route decisions encode TAGO chain prerequisites and next required adapter.',
+  },
+  {
+    id: 'tago_bus_completion_prompt',
+    kind: 'display_or_answer_repair',
+    owner: 'ummaya:tui-answer-repair',
+    evidenceEvent: 'ummaya.tui.repair.tago_bus_completion_prompt',
+    removalCondition:
+      'Delete when TAGO adapters return a backend terminal answer contract.',
+  },
+  {
+    id: 'airkorea_completion_prompt',
+    kind: 'display_or_answer_repair',
+    owner: 'ummaya:tui-answer-repair',
+    evidenceEvent: 'ummaya.tui.repair.airkorea_completion_prompt',
+    removalCondition:
+      'Delete when AirKorea adapter output includes backend answer-synthesis constraints.',
+  },
+  {
+    id: 'generic_pending_final_answer_repair',
+    kind: 'display_or_answer_repair',
+    owner: 'ummaya:tui-answer-repair',
+    evidenceEvent: 'ummaya.tui.repair.generic_pending_final_answer_repair',
+    removalCondition:
+      'Delete when backend stop reasons reject plan-only final answers after tool_result evidence.',
+  },
+]
+
+function hasBackendRepairReceipt(
+  receipt: UmmayaBackendRepairReceipt | undefined,
+): boolean {
+  return (
+    receipt !== undefined &&
+    (receipt.source === 'backend_route_decision' ||
+      receipt.source === 'backend_validation') &&
+    receipt.reason.trim() !== '' &&
+    receipt.evidenceEvent.startsWith('ummaya.')
+  )
+}
+
 function asRecord(value: unknown): Record<string, unknown> | undefined {
   return typeof value === 'object' && value !== null
     ? (value as Record<string, unknown>)
@@ -698,12 +776,15 @@ export function repairUmmayaExplicitDocumentToolUseFromUserQuery({
   input,
   messages,
   tools,
+  backendRepairReceipt,
 }: {
   toolName: string
   input: Record<string, unknown>
   messages: readonly Message[]
   tools: Tools
+  backendRepairReceipt?: UmmayaBackendRepairReceipt
 }): ForcedUmmayaToolUse | undefined {
+  if (!hasBackendRepairReceipt(backendRepairReceipt)) return undefined
   const available = availableToolNamesFromTools(tools)
   if (!isAvailableOrSyncedAdapter(available, DOCUMENT_TOOL_NAME)) return undefined
 
@@ -760,10 +841,13 @@ export function backfillUmmayaObservableToolInputFromUserQuery({
 export function selectUmmayaClientForcedToolUse({
   messages,
   tools,
+  backendRepairReceipt,
 }: {
   messages: readonly Message[]
   tools: Tools
+  backendRepairReceipt?: UmmayaBackendRepairReceipt
 }): ForcedUmmayaToolUse | undefined {
+  if (!hasBackendRepairReceipt(backendRepairReceipt)) return undefined
   const available = availableToolNamesFromTools(tools)
   const userText = latestUserText(messages)
   const documentToolName = selectDocumentWorkflowTargetToolName(
@@ -1403,37 +1487,12 @@ export function selectUmmayaToolChoiceOverride({
     return undefined
   }
 
-  const documentToolName = selectDocumentWorkflowToolChoice(
-    userText,
-    available,
-    messages,
-  )
-  if (documentToolName) {
-    return { type: 'tool', name: documentToolName }
-  }
-
   if (
     publicDataTargetTool &&
     !usedToolNames.has(publicDataTargetTool) &&
     isAvailableOrSyncedAdapter(available, publicDataTargetTool)
   ) {
     return { type: 'tool', name: publicDataTargetTool }
-  }
-
-  if (
-    AIRKOREA_RE.test(userText) &&
-    !usedToolNames.has(AIRKOREA_TOOL_NAME) &&
-    isAvailableOrSyncedAdapter(available, AIRKOREA_TOOL_NAME)
-  ) {
-    return { type: 'tool', name: AIRKOREA_TOOL_NAME }
-  }
-
-  if (
-    PPS_BID_RE.test(userText) &&
-    !usedToolNames.has(PPS_BID_TOOL_NAME) &&
-    isAvailableOrSyncedAdapter(available, PPS_BID_TOOL_NAME)
-  ) {
-    return { type: 'tool', name: PPS_BID_TOOL_NAME }
   }
 
   if (
@@ -1464,7 +1523,6 @@ export function selectUmmayaToolChoiceOverride({
 
   const shouldForceAviation =
     latestToolResult.includes('KMA aviation tool-choice mismatch') ||
-    (airportAviationQuery && !usedAviationTool) ||
     needsGimpoAviationFollowup
   if (shouldForceAviation) {
     const name = selectKmaAviationTool(
@@ -1477,9 +1535,7 @@ export function selectUmmayaToolChoiceOverride({
   }
 
   const shouldForceKmaAnalysis =
-    latestToolResult.includes('KMA analysis tool-choice mismatch') ||
-    (isKmaAnalysisMapText(userText) &&
-      !usedToolNames.has(KMA_ANALYSIS_CHART_TOOL_NAME))
+    latestToolResult.includes('KMA analysis tool-choice mismatch')
   if (
     shouldForceKmaAnalysis &&
     isAvailableOrSyncedAdapter(available, KMA_ANALYSIS_CHART_TOOL_NAME)
@@ -1501,14 +1557,19 @@ export function selectUmmayaToolChoiceOverride({
     usedToolNames,
     messages,
   )
-  if (tagoToolName) {
+  const hasTagoBusFollowupEvidence =
+    hasSuccessfulStationSearch(messages) ||
+    hasSuccessfulRouteSearch(messages) ||
+    hasSuccessfulRouteStationSearch(messages)
+  const hasTagoBusValidationMismatch =
+    latestToolResult.includes('Public-data tool-choice mismatch') &&
+    latestToolResult.includes('matches TAGO bus adapters')
+  if (tagoToolName && (hasTagoBusFollowupEvidence || hasTagoBusValidationMismatch)) {
     return { type: 'tool', name: tagoToolName }
   }
 
   const shouldForceProtected =
-    latestToolResult.includes('Protected-domain tool-choice mismatch') ||
-    (PROTECTED_QUERY_RE.test(userText) &&
-      !hasAnyToolUse(usedToolNames, PROTECTED_CHECK_TOOLS))
+    latestToolResult.includes('Protected-domain tool-choice mismatch')
   if (shouldForceProtected) {
     const name = selectProtectedCheckTool(`${userText}\n${latestToolResult}`, available)
     if (name) return { type: 'tool', name }

--- a/tui/src/tools/_shared/toolChoiceRepair.ts
+++ b/tui/src/tools/_shared/toolChoiceRepair.ts
@@ -50,6 +50,8 @@ const MOBILE_ID_RE = /(mobile\s*id|모바일\s*(?:신분증|id)|mobile_id)/iu
 const SIMPLE_AUTH_RE =
   /(simple_auth|간편인증|ganpyeon|소득금액증명|증명원|민원|발급)/iu
 const MYDATA_RE = /(mydata|마이데이터)/iu
+const GOV24_MINWON_SUBMIT_RE =
+  /(?=.*(?:정부24|gov24))(?=.*(?:주민등록등본|등본|민원|발급))(?=.*(?:신청|접수|발급|submit|apply|issue))/iu
 const MEDICAL_COLLAPSE_RE =
   /(사람이\s*쓰러|쓰러졌|쓰러짐|쓰러져|의식[을이가은는\s]*(없|잃|불명)|무의식|심정지|심폐소생|cpr|호흡\s*(없|곤란)|숨\s*(안|못)|collapse|collapsed|unconscious|cardiac\s*arrest|not\s*breathing|aed|자동심장|심장충격|제세동)/iu
 const MEDICAL_COLLAPSE_OR_ER_RE =
@@ -62,7 +64,7 @@ const TAGO_ROUTE_NO_RE = /(?:^|[^\d])(\d{1,4}(?:-\d)?)\s*번/u
 const TAGO_PLACE_RE = /([가-힣A-Za-z0-9().·\s]+?)(?:에서|근처|앞|인근)/u
 const PPS_BID_RE = /(입찰|나라장터|조달청|공고|공사조회|전기공사|bid|procurement)/iu
 const AIRKOREA_RE =
-  /(미세먼지|초미세먼지|대기질|대기오염|마스크|pm\s*2\.?5|pm\s*10|air\s*korea|airkorea)/iu
+  /(미세먼지|초미세먼지|초미세|대기질|대기오염|공기질|마스크|pm\s*2\.?5|pm\s*10|air\s*korea|airkorea|air\s*quality|airquality)/iu
 const DOCUMENT_PATH_RE =
   /(?:^|[\s:'"(])(?:~|\/|[A-Za-z]:\\|\.{1,2}\/)?[^\s:'"]*\.(?:hwpx|hwp|docx|pdf|xlsx|pptx)\b/iu
 const DOCUMENT_EXPLICIT_PATH_SCAN_RE =
@@ -84,6 +86,8 @@ const DOCUMENT_DIFF_AND_SAVE_ONLY_FINAL_RE =
   /(실제(?:로)?\s*바뀐\s*내용\s*(?:과|및|랑|하고)\s*저장\s*(?:위치|경로)만|변경(?:된)?\s*(?:내용|부분|사항).{0,24}저장\s*(?:위치|경로)만|changed.{0,24}(?:save|saved).{0,24}(?:location|path).{0,24}only)/iu
 const DOCUMENT_LOCAL_HINT_RE =
   /(다운로드|downloads?|폴더|파일|양식|서식|활동일지|신청서|등본|증명서)/iu
+const PUBLIC_DATA_MISMATCH_TARGET_RE =
+  /Public-data tool-choice mismatch:\s*target=([a-z_]+)/iu
 const PUBLIC_DATA_MISMATCH_CALL_RE =
   /Public-data tool-choice mismatch:[\s\S]*?\bCall\s+([a-z][a-z0-9_]*)\s+/iu
 const TAGO_BUS_COMPLETION_PROMPT =
@@ -91,7 +95,7 @@ const TAGO_BUS_COMPLETION_PROMPT =
 const TAGO_BUS_REPAIR_PROMPT =
   'TAGO bus final answer repair: the previous answer still promised another stop/route lookup after TAGO arrival evidence was already attempted. Rewrite the final Korean answer now from the actual TAGO tool_result only. Do not say 확인하겠습니다, 확인해보겠습니다, 검색해 보겠습니다, 다시 조회, or that you will check another stop. If the arrival result has zero items, say no current arrival is shown for the checked 부산역 stop and ask the citizen for a specific route number or exact stop only as a next-step option.'
 const AIRKOREA_COMPLETION_PROMPT =
-  'AirKorea air-quality evidence complete: airkorea_ctprvn_air_quality has already returned the official result for this 미세먼지/초미세먼지 request. Do not call another location, weather, public-data, or AirKorea tool in this turn. Write the final Korean answer now from the actual tool_result only. Include stationName, dataTime, PM10 value and pm10GradeLabelKo, PM2.5 value and pm25GradeLabelKo, and CAI/khaiValue with khaiGradeLabelKo when present. This adapter returns city/province measurement rows, not a geocoded nearest-station result: say it is city/province station data, use only exact stationName rows present in tool_result, and do not infer the citizen place district, distance, nearest station, station groups, or value ranges unless those exact fields exist in tool_result. If totalCount is 0 or items are empty, say the official AirKorea API returned no rows for the checked sidoName and do not say you are still checking.'
+  'AirKorea air-quality evidence complete: the official AirKorea result has already returned for this 미세먼지/초미세먼지 request. Do not call another location, weather, public-data, or AirKorea tool in this turn. Write the final Korean answer now from the actual tool_result only. Include stationName, dataTime, PM10 value and pm10GradeLabelKo, PM2.5 value and pm25GradeLabelKo, and CAI/khaiValue with khaiGradeLabelKo when present. This result returns city/province measurement rows, not a geocoded nearest-station result: say it is city/province station data, use only exact stationName rows present in tool_result, and do not infer the citizen place district, distance, nearest station, station groups, or value ranges unless those exact fields exist in tool_result. If totalCount is 0 or items are empty, say the official AirKorea API returned no rows for the checked sidoName and do not say you are still checking.'
 const AIRKOREA_REPAIR_PROMPT =
   'AirKorea final answer repair: the previous answer inferred nearest/direction/distance, average/range values, district groups, or changed raw values beyond the official tool_result. Rewrite the final Korean answer using only the exact AirKorea rows listed below. Do not say 가장 가까운, 인근, 동쪽, 서쪽, 남쪽, 북쪽, distance, nearest, 평균, 범위, 대부분, 해운대구 지역, or average unless those exact fields exist in tool_result. Copy PM10, PM2.5, CAI, stationName, dataTime, and grade labels literally. If the citizen named a place but the tool returned only city/province rows, say this is city/province station data rather than a nearest-station answer.'
 const AIRKOREA_UNSUPPORTED_LOCATION_CLAIM_RE =
@@ -1459,9 +1463,12 @@ export function shouldSuppressUmmayaToolCallsForAnswerSynthesis({
 function publicDataMismatchTargetTool(
   latestToolResult: string,
 ): string | undefined {
-  const candidate = PUBLIC_DATA_MISMATCH_CALL_RE.exec(latestToolResult)?.[1]
-  if (!candidate) return undefined
-  return candidate
+  const targetKind = PUBLIC_DATA_MISMATCH_TARGET_RE.exec(latestToolResult)?.[1]
+  if (targetKind === 'weather_chart') return KMA_ANALYSIS_CHART_TOOL_NAME
+  if (targetKind === 'air_quality') return AIRKOREA_TOOL_NAME
+  if (targetKind === 'procurement_bid') return PPS_BID_TOOL_NAME
+  const legacyCandidate = PUBLIC_DATA_MISMATCH_CALL_RE.exec(latestToolResult)?.[1]
+  return legacyCandidate
 }
 
 export function selectUmmayaToolChoiceOverride({
@@ -1493,6 +1500,14 @@ export function selectUmmayaToolChoiceOverride({
     isAvailableOrSyncedAdapter(available, publicDataTargetTool)
   ) {
     return { type: 'tool', name: publicDataTargetTool }
+  }
+
+  if (
+    GOV24_MINWON_SUBMIT_RE.test(userText) &&
+    !usedToolNames.has('mock_verify_module_simple_auth') &&
+    isAvailableOrSyncedAdapter(available, 'mock_verify_module_simple_auth')
+  ) {
+    return { type: 'tool', name: 'mock_verify_module_simple_auth' }
   }
 
   if (
@@ -1563,7 +1578,7 @@ export function selectUmmayaToolChoiceOverride({
     hasSuccessfulRouteStationSearch(messages)
   const hasTagoBusValidationMismatch =
     latestToolResult.includes('Public-data tool-choice mismatch') &&
-    latestToolResult.includes('matches TAGO bus adapters')
+    latestToolResult.includes('target=bus_realtime')
   if (tagoToolName && (hasTagoBusFollowupEvidence || hasTagoBusValidationMismatch)) {
     return { type: 'tool', name: tagoToolName }
   }

--- a/tui/src/tools/_shared/toolChoiceRepair.ts
+++ b/tui/src/tools/_shared/toolChoiceRepair.ts
@@ -17,6 +17,8 @@ const KMA_AIR_TOOLS = [
   'kma_apihub_url_air_metar_decoded',
   'kma_apihub_url_air_amos_minute',
 ] as const
+const KAKAO_KEYWORD_TOOL_NAME = 'kakao_keyword_search'
+const KMA_CURRENT_OBSERVATION_TOOL_NAME = 'kma_current_observation'
 const NMC_EMERGENCY_TOOL_NAME = 'nmc_emergency_search'
 const NMC_AED_TOOL_NAME = 'nmc_aed_site_locate'
 const KAKAO_COORD_TO_REGION_TOOL_NAME = 'kakao_coord_to_region'
@@ -1462,9 +1464,20 @@ export function shouldSuppressUmmayaToolCallsForAnswerSynthesis({
 
 function publicDataMismatchTargetTool(
   latestToolResult: string,
+  available: Set<string>,
+  usedToolNames: Set<string>,
 ): string | undefined {
   const targetKind = PUBLIC_DATA_MISMATCH_TARGET_RE.exec(latestToolResult)?.[1]
   if (targetKind === 'weather_chart') return KMA_ANALYSIS_CHART_TOOL_NAME
+  if (targetKind === 'current_weather' || targetKind === 'weather_current') {
+    return chooseAvailableOrSyncedAdapter(
+      available,
+      [
+        !usedToolNames.has(KAKAO_KEYWORD_TOOL_NAME) ? KAKAO_KEYWORD_TOOL_NAME : '',
+        KMA_CURRENT_OBSERVATION_TOOL_NAME,
+      ].filter(Boolean),
+    )
+  }
   if (targetKind === 'air_quality') return AIRKOREA_TOOL_NAME
   if (targetKind === 'procurement_bid') return PPS_BID_TOOL_NAME
   const legacyCandidate = PUBLIC_DATA_MISMATCH_CALL_RE.exec(latestToolResult)?.[1]
@@ -1484,7 +1497,11 @@ export function selectUmmayaToolChoiceOverride({
   const usedToolNames = toolUseNames(messages)
   const airportAviationQuery = isAirportAviationQuery(userText)
   const usedAviationTool = hasAnyToolUse(usedToolNames, KMA_AIR_TOOLS)
-  const publicDataTargetTool = publicDataMismatchTargetTool(latestToolResult)
+  const publicDataTargetTool = publicDataMismatchTargetTool(
+    latestToolResult,
+    available,
+    usedToolNames,
+  )
   if (
     shouldSuppressUmmayaToolCallsForAnswerSynthesis({
       messages,

--- a/tui/tests/services/api/claude-provider-friendli.test.ts
+++ b/tui/tests/services/api/claude-provider-friendli.test.ts
@@ -1,4 +1,6 @@
 import { describe, expect, mock, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { assembleToolPool } from '../../../src/tools.js'
@@ -205,6 +207,9 @@ describe('CC provider wired to FriendliAI client shim', () => {
         type: 'function',
         function: { name: 'kma_apihub_url_air_metar_decoded' },
       })
+      expect(JSON.stringify(requestBody?.['messages'])).toContain(
+        'Mandatory tool call: the host selected kma_apihub_url_air_metar_decoded',
+      )
     } finally {
       clearManifestCache()
       if (previousToken === undefined) {
@@ -216,6 +221,111 @@ describe('CC provider wired to FriendliAI client shim', () => {
         delete process.env.CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK
       } else {
         process.env.CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK = previousDisableFallback
+      }
+    }
+  })
+
+  test('records turn-local adapter selection diagnostics for provider requests', async () => {
+    let requestBody: Record<string, unknown> | undefined
+    const previousToken = process.env.UMMAYA_FRIENDLI_TOKEN
+    const previousDisableFallback = process.env.CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK
+    const previousDiagnosticsFile = process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE
+    const diagnosticsDir = mkdtempSync(join(tmpdir(), 'ummaya-route-diagnostics-'))
+    const diagnosticsPath = join(diagnosticsDir, 'route.jsonl')
+    process.env.UMMAYA_FRIENDLI_TOKEN = 'friendli-token'
+    process.env.CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK = '1'
+    process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE = diagnosticsPath
+    clearManifestCache()
+    ingestManifestFrame({
+      kind: 'adapter_manifest_sync',
+      version: '1.0',
+      session_id: 'test-session',
+      correlation_id: '01HXKQ7Z3M1V8K2YQ8A6P4F9EF',
+      ts: new Date().toISOString(),
+      role: 'backend',
+      frame_seq: 0,
+      entries: [
+        {
+          tool_id: 'kma_apihub_url_air_metar_decoded',
+          name: 'KMA APIHub decoded METAR',
+          primitive: 'find',
+          policy_authority_url: 'https://apihub.kma.go.kr/',
+          source_mode: 'live',
+          search_hint: 'METAR SPECI decoded airport weather aviation',
+          llm_description: 'Decoded METAR airport weather.',
+          input_schema_json: {
+            type: 'object',
+            properties: { org: { type: 'string' } },
+            additionalProperties: false,
+          },
+        },
+      ],
+      manifest_hash: 'b'.repeat(64),
+      emitter_pid: 12345,
+    })
+
+    try {
+      const tools = assembleToolPool(getEmptyToolPermissionContext(), [])
+      for await (const _event of queryModelWithStreaming({
+        messages: [createUserMessage({ content: 'METAR airport weather 확인해줘' })],
+        systemPrompt: asSystemPrompt(['System prompt']),
+        thinkingConfig: { type: 'disabled' },
+        tools,
+        signal: new AbortController().signal,
+        options: {
+          getToolPermissionContext: async () => getEmptyToolPermissionContext(),
+          model: 'LGAI-EXAONE/K-EXAONE-236B-A23B',
+          isNonInteractiveSession: false,
+          querySource: 'repl_main_thread',
+          agents: [],
+          allowedAgentTypes: [],
+          mcpTools: [],
+          fetchOverride: async (_input: string | URL | Request, init?: RequestInit) => {
+            requestBody = JSON.parse(String(init?.body))
+            return responseForTextDelta('ok')
+          },
+        },
+      })) {
+      }
+
+      const diagnosticLines = readFileSync(diagnosticsPath, 'utf8')
+        .trim()
+        .split('\n')
+        .map(line => JSON.parse(line) as Record<string, unknown>)
+      const selection = diagnosticLines.find(record => record.event === 'adapter_selection')
+      expect(selection).toEqual(
+        expect.objectContaining({
+          manifest_hash: 'b'.repeat(64),
+          query_source: 'repl_main_thread',
+          schema_projection_level: 'top_k_concrete_adapter_schemas',
+        }),
+      )
+      expect(selection?.selected_tools).toContain('kma_apihub_url_air_metar_decoded')
+      expect(selection?.final_adapter_tools).toContain('kma_apihub_url_air_metar_decoded')
+      expect(selection?.query_hash).toMatch(/^[a-f0-9]{64}$/)
+      const toolsPayload = requestBody?.['tools'] as
+        | Array<{ function?: { name?: string } }>
+        | undefined
+      expect(toolsPayload?.map(tool => tool.function?.name)).toContain(
+        'kma_apihub_url_air_metar_decoded',
+      )
+    } finally {
+      clearManifestCache()
+      rmSync(diagnosticsDir, { recursive: true, force: true })
+      if (previousToken === undefined) {
+        delete process.env.UMMAYA_FRIENDLI_TOKEN
+      } else {
+        process.env.UMMAYA_FRIENDLI_TOKEN = previousToken
+      }
+      if (previousDisableFallback === undefined) {
+        delete process.env.CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK
+      } else {
+        process.env.CLAUDE_CODE_DISABLE_NONSTREAMING_FALLBACK = previousDisableFallback
+      }
+      if (previousDiagnosticsFile === undefined) {
+        delete process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE
+      } else {
+        process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE = previousDiagnosticsFile
       }
     }
   })

--- a/tui/tests/tools/_shared/toolChoiceRepair.test.ts
+++ b/tui/tests/tools/_shared/toolChoiceRepair.test.ts
@@ -6,6 +6,7 @@ import { join } from 'node:path'
 import type { Tools } from '../../../src/Tool.js'
 import type { Message } from '../../../src/types/message.js'
 import {
+  UMMAYA_TUI_REPAIR_POLICIES,
   backfillUmmayaObservableToolInputFromUserQuery,
   buildDocumentCompletionPromptIfNeeded,
   repairUmmayaExplicitDocumentToolUseFromUserQuery,
@@ -36,6 +37,12 @@ const documentAndLegacyGlobTools = [
 ].map(name => ({ name })) as Tools
 
 const toolSearchOnlyTools = [{ name: 'ToolSearch' }] as Tools
+const backendRepairReceipt = {
+  source: 'backend_route_decision' as const,
+  reason: 'backend recorded an explicit document repair for this turn',
+  evidenceEvent: 'ummaya.route_decision.document_repair',
+  toolName: 'document',
+}
 
 function user(text: string): Message {
   return {
@@ -71,16 +78,53 @@ function toolResult(id: string, payload: Record<string, unknown>): Message {
 }
 
 describe('document harness tool-choice repair', () => {
-  test('starts local HWPX write/diff requests with the document primitive', () => {
+  test('backend route decision validation blocks initial document tool-choice override', () => {
     expect(
       selectUmmayaToolChoiceOverride({
         messages: [user(docQuery)],
         tools: documentTools,
       }),
-    ).toEqual({ type: 'tool', name: 'document' })
+    ).toBeUndefined()
   })
 
-  test('routes explicit current-session artifact render requests to the document primitive', () => {
+  test('does not synthesize unsourced virtual tool use for explicit document paths', () => {
+    const prompt =
+      '웹에서 받은 서울문화포털 DDP 참가신청서 DOCX 사본 /tmp/ummaya-g011-live-tui/inputs/seoul-culture-application-plan.docx 내용을 파악해서 접수번호 옆 빈칸에 UMMAYA-G011-2026을 넣고 저장해줘.'
+
+    expect(selectUmmayaClientForcedToolUse({
+      messages: [user(prompt)],
+      tools: documentTools,
+    })).toBeUndefined()
+    expect(
+      repairUmmayaExplicitDocumentToolUseFromUserQuery({
+        toolName: 'tago_bus_station_search',
+        input: { city_code: '21', node_nm: '/tmp/ummaya-g011-live-tui/inputs/seoul-culture-application-plan.docx' },
+        messages: [user(prompt)],
+        tools: documentTools,
+      }),
+    ).toBeUndefined()
+  })
+
+  test('display-only repair policies carry audit marker and deletion condition', () => {
+    expect(UMMAYA_TUI_REPAIR_POLICIES.length).toBeGreaterThan(0)
+    for (const policy of UMMAYA_TUI_REPAIR_POLICIES) {
+      expect(policy.owner).toMatch(/^ummaya:/u)
+      expect(policy.evidenceEvent).toMatch(/^ummaya\./u)
+      expect(policy.removalCondition.length).toBeGreaterThan(20)
+      expect(policy.kind).toBe('display_or_answer_repair')
+    }
+  })
+
+  test('does not force local HWPX write/diff requests from TUI intent alone', () => {
+    expect(
+      selectUmmayaToolChoiceOverride({
+        messages: [user(docQuery)],
+        tools: documentTools,
+      }),
+    ).toBeUndefined()
+  })
+
+  test('does not force explicit current-session artifact render requests from TUI intent alone', () => {
     expect(
       selectUmmayaToolChoiceOverride({
         messages: [
@@ -90,10 +134,10 @@ describe('document harness tool-choice repair', () => {
         ],
         tools: documentTools,
       }),
-    ).toEqual({ type: 'tool', name: 'document' })
+    ).toBeUndefined()
   })
 
-  test('keeps visual diff wording on the document primitive', () => {
+  test('does not force visual diff wording onto the document primitive from TUI intent alone', () => {
     expect(
       selectUmmayaToolChoiceOverride({
         messages: [
@@ -103,7 +147,7 @@ describe('document harness tool-choice repair', () => {
         ],
         tools: documentTools,
       }),
-    ).toEqual({ type: 'tool', name: 'document' })
+    ).toBeUndefined()
   })
 
   test('does not synthesize incomplete document arguments when the primitive is available', () => {
@@ -126,7 +170,7 @@ describe('document harness tool-choice repair', () => {
     expect(selectUmmayaClientForcedToolUse({ messages, tools: documentTools })).toBeUndefined()
   })
 
-  test('routes deferred document requests through ToolSearch before prose fallback', () => {
+  test('does not route deferred document requests through ToolSearch from TUI intent alone', () => {
     const messages = [
       user(
         '다운로드 폴더에 있는 SW중심대학사업 현장미러형연계프로젝트 주간활동일지 HWPX 양식을 13주차 활동일지로 작성해줘. 작성이 끝나면 원본과 달라진 부분을 문서 화면으로 비교해서 보여줘.',
@@ -138,14 +182,8 @@ describe('document harness tool-choice repair', () => {
         messages,
         tools: toolSearchOnlyTools,
       }),
-    ).toEqual({ type: 'tool', name: 'ToolSearch' })
-    expect(selectUmmayaClientForcedToolUse({ messages, tools: toolSearchOnlyTools })).toEqual({
-      name: 'ToolSearch',
-      input: {
-        query: 'select:document',
-        max_results: 1,
-      },
-    })
+    ).toBeUndefined()
+    expect(selectUmmayaClientForcedToolUse({ messages, tools: toolSearchOnlyTools })).toBeUndefined()
   })
 
   test('does not bypass model intent analysis for Downloads HWPX edit requests', () => {
@@ -158,7 +196,7 @@ describe('document harness tool-choice repair', () => {
     expect(selectUmmayaClientForcedToolUse({ messages, tools: documentTools })).toBeUndefined()
   })
 
-  test('client-forces the document primitive when provider ignores tool_choice for an explicit local path', () => {
+  test('backend route decision validation permits receipted virtual document repair', () => {
     const prompt =
       '웹에서 받은 서울문화포털 DDP 참가신청서 DOCX 사본 /tmp/ummaya-g011-live-tui/inputs/seoul-culture-application-plan.docx 내용을 파악해서 접수번호 옆 빈칸에 UMMAYA-G011-2026을 넣고, 그 칸을 Malgun Gothic 12pt 굵게, 글자색 1F4E79, 배경색 FFF2CC, 가운데 정렬로 보정한 뒤 /tmp/ummaya-g011-live-tui/tui-exports/g011-seoul-culture-application-plan.docx 로 저장해줘. 수정 후 변경된 부분을 바로 확인할 수 있게 보여줘.'
     const messages = [
@@ -177,7 +215,12 @@ describe('document harness tool-choice repair', () => {
       } as Message,
     ]
 
-    expect(selectUmmayaClientForcedToolUse({ messages, tools: documentTools })).toEqual({
+    expect(selectUmmayaClientForcedToolUse({ messages, tools: documentTools })).toBeUndefined()
+    expect(selectUmmayaClientForcedToolUse({
+      messages,
+      tools: documentTools,
+      backendRepairReceipt,
+    })).toEqual({
       name: 'document',
       input: {
         correlation_id: expect.stringMatching(/^client-forced-document-[a-f0-9]{8}$/),
@@ -206,6 +249,18 @@ describe('document harness tool-choice repair', () => {
         },
         messages: [user(prompt)],
         tools: documentTools,
+      }),
+    ).toBeUndefined()
+    expect(
+      repairUmmayaExplicitDocumentToolUseFromUserQuery({
+        toolName: 'tago_bus_station_search',
+        input: {
+          city_code: '21',
+          node_nm: '/Users/example/nts_business_registration_individual.hwpx',
+        },
+        messages: [user(prompt)],
+        tools: documentTools,
+        backendRepairReceipt,
       }),
     ).toEqual({
       name: 'document',
@@ -237,11 +292,11 @@ describe('document harness tool-choice repair', () => {
     expect(selectUmmayaToolChoiceOverride({
       messages: [user(prompt)],
       tools: documentTools,
-    })).toEqual({ type: 'tool', name: 'document' })
+    })).toBeUndefined()
     expect(selectUmmayaClientForcedToolUse({
       messages: [user(prompt)],
       tools: documentTools,
-    })?.input.operation).toBe('inspect')
+    })).toBeUndefined()
 
     backfillUmmayaObservableToolInputFromUserQuery({
       toolName: 'document',
@@ -259,7 +314,7 @@ describe('document harness tool-choice repair', () => {
     expect(selectUmmayaClientForcedToolUse({
       messages: [user(prompt)],
       tools: documentTools,
-    })?.input.operation).toBe('fill')
+    })).toBeUndefined()
   })
 
   test('repairs provider document fill calls back to inspect for explicit read-only requests', () => {
@@ -280,6 +335,7 @@ describe('document harness tool-choice repair', () => {
         },
         messages: [user(prompt)],
         tools: documentTools,
+        backendRepairReceipt,
       }),
     ).toEqual({
       name: 'document',
@@ -330,7 +386,7 @@ describe('document harness tool-choice repair', () => {
         messages,
         tools: documentAndGlobTools,
       }),
-    ).toEqual({ type: 'tool', name: 'workspace_glob' })
+    ).toBeUndefined()
   })
 
   test('keeps a legacy CC glob fallback only when the workspace adapter is absent', () => {
@@ -345,7 +401,7 @@ describe('document harness tool-choice repair', () => {
         messages,
         tools: documentAndLegacyGlobTools,
       }),
-    ).toEqual({ type: 'tool', name: 'Glob' })
+    ).toBeUndefined()
   })
 
   test('uses document directly when the user already supplied an exact local document path', () => {
@@ -360,7 +416,7 @@ describe('document harness tool-choice repair', () => {
         messages,
         tools: documentAndGlobTools,
       }),
-    ).toEqual({ type: 'tool', name: 'document' })
+    ).toBeUndefined()
   })
 
   test('reroutes a new explicit artifact render request even when the session has an older render', () => {
@@ -380,7 +436,7 @@ describe('document harness tool-choice repair', () => {
         messages: priorRendered,
         tools: documentTools,
       }),
-    ).toEqual({ type: 'tool', name: 'document' })
+    ).toBeUndefined()
     expect(
       shouldSuppressUmmayaToolCallsForAnswerSynthesis({
         messages: priorRendered,
@@ -527,7 +583,7 @@ describe('document harness tool-choice repair', () => {
         messages,
         tools: documentTools,
       }),
-    ).toEqual({ type: 'tool', name: 'document' })
+    ).toBeUndefined()
   })
 
   test('requires one successful document primitive result instead of an exposed stage chain', () => {
@@ -539,7 +595,7 @@ describe('document harness tool-choice repair', () => {
         messages: beforeResult,
         tools: documentTools,
       }),
-    ).toEqual({ type: 'tool', name: 'document' })
+    ).toBeUndefined()
 
     const rendered = [
       ...beforeResult,

--- a/tui/tests/tools/routeDiagnostics.test.ts
+++ b/tui/tests/tools/routeDiagnostics.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from 'bun:test'
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { appendRoutePermissionPromptDiagnostic } from '../../src/tools/AdapterTool/routeDiagnostics.js'
+
+describe('route diagnostics', () => {
+  test('records prompted permission boundary for concrete adapters', () => {
+    const previousPath = process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE
+    const dir = mkdtempSync(join(tmpdir(), 'ummaya-route-prompt-'))
+    const path = join(dir, 'route.jsonl')
+    process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE = path
+
+    try {
+      appendRoutePermissionPromptDiagnostic({
+        toolName: 'mock_verify_module_simple_auth',
+        input: { scope_list: ['send:gov24.minwon'] },
+        toolUseID: 'tool-use-1',
+        messageID: 'message-1',
+        queryChainID: 'chain-1',
+        queryDepth: 0,
+        permissionMode: 'default',
+      })
+
+      const record = JSON.parse(readFileSync(path, 'utf8').trim()) as Record<
+        string,
+        unknown
+      >
+      expect(record).toEqual(
+        expect.objectContaining({
+          event: 'route_tool_permission',
+          tool_name: 'mock_verify_module_simple_auth',
+          tool_surface: 'concrete_adapter',
+          permission_behavior: 'ask',
+          result_status: 'prompted',
+        }),
+      )
+    } finally {
+      if (previousPath === undefined) {
+        delete process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE
+      } else {
+        process.env.UMMAYA_TUI_ROUTE_DIAGNOSTIC_FILE = previousPath
+      }
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})

--- a/tui/tests/tools/ummaya-model-facing-tool-surface.test.ts
+++ b/tui/tests/tools/ummaya-model-facing-tool-surface.test.ts
@@ -425,7 +425,7 @@ describe('UMMAYA model-facing tool surface', () => {
     expect(selected).not.toContain('kakao_address_search')
   })
 
-  test('PPS bid wording forces synced concrete adapter even before tool pool refresh', () => {
+  test('PPS bid wording does not force synced concrete adapter before backend validation', () => {
     clearManifestCache()
     ingestManifestFrame({
       kind: 'adapter_manifest_sync',
@@ -477,10 +477,7 @@ describe('UMMAYA model-facing tool surface', () => {
       tools: [toolNamed('find'), toolNamed('locate'), toolNamed('ToolSearch')],
     })
 
-    expect(override).toEqual({
-      type: 'tool',
-      name: 'pps_bid_public_info',
-    })
+    expect(override).toBeUndefined()
   })
 
   test('direct public-data wording rejects unrelated primitive substitutions', async () => {
@@ -930,10 +927,7 @@ describe('UMMAYA model-facing tool surface', () => {
       },
     ] as any
 
-    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toEqual({
-      type: 'tool',
-      name: 'tago_bus_route_search',
-    })
+    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toBeUndefined()
 
     const afterRouteSearch = [
       ...firstTurn,
@@ -1169,10 +1163,7 @@ describe('UMMAYA model-facing tool surface', () => {
       },
     ] as any
 
-    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toEqual({
-      type: 'tool',
-      name: 'tago_bus_station_search',
-    })
+    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toBeUndefined()
 
     const afterStation = [
       ...firstTurn,
@@ -1284,10 +1275,7 @@ describe('UMMAYA model-facing tool surface', () => {
       },
     ] as any
 
-    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toEqual({
-      type: 'tool',
-      name: 'tago_bus_station_search',
-    })
+    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toBeUndefined()
 
     const afterStation = [
       ...firstTurn,
@@ -1446,10 +1434,7 @@ describe('UMMAYA model-facing tool surface', () => {
         },
       },
     ] as any
-    expect(selectUmmayaToolChoiceOverride({ messages: airFirstTurn, tools })).toEqual({
-      type: 'tool',
-      name: 'airkorea_ctprvn_air_quality',
-    })
+    expect(selectUmmayaToolChoiceOverride({ messages: airFirstTurn, tools })).toBeUndefined()
 
     const afterAirKorea = [
       ...airFirstTurn,
@@ -1797,7 +1782,7 @@ describe('UMMAYA model-facing tool surface', () => {
     expect(selected).not.toContain('kma_current_observation')
   })
 
-  test('airport aviation wording forces concrete METAR tool choice on first live turn', () => {
+  test('airport aviation wording does not force concrete METAR tool choice on first live turn', () => {
     const override = selectUmmayaToolChoiceOverride({
       messages: [
         {
@@ -1818,13 +1803,10 @@ describe('UMMAYA model-facing tool surface', () => {
       ],
     })
 
-    expect(override).toEqual({
-      type: 'tool',
-      name: 'kma_apihub_url_air_metar_decoded',
-    })
+    expect(override).toBeUndefined()
   })
 
-  test('KMA aviation wording forces synced adapter before tool pool refresh', () => {
+  test('KMA aviation wording does not force synced adapter before backend validation', () => {
     clearManifestCache()
     ingestManifestFrame({
       kind: 'adapter_manifest_sync',
@@ -1872,13 +1854,10 @@ describe('UMMAYA model-facing tool surface', () => {
       tools: [toolNamed('find'), toolNamed('locate'), toolNamed('kma_current_observation')],
     })
 
-    expect(override).toEqual({
-      type: 'tool',
-      name: 'kma_apihub_url_air_metar_decoded',
-    })
+    expect(override).toBeUndefined()
   })
 
-  test('airport runway wording prefers AMOS when the adapter is visible', () => {
+  test('airport runway wording does not force AMOS before backend validation', () => {
     const override = selectUmmayaToolChoiceOverride({
       messages: [
         {
@@ -1896,10 +1875,7 @@ describe('UMMAYA model-facing tool surface', () => {
       ],
     })
 
-    expect(override).toEqual({
-      type: 'tool',
-      name: 'kma_apihub_url_air_amos_minute',
-    })
+    expect(override).toBeUndefined()
   })
 
   test('airport aviation tool choice override stops after an aviation tool was attempted', () => {
@@ -2488,10 +2464,7 @@ describe('UMMAYA model-facing tool surface', () => {
       toolNamed('kma_current_observation'),
     ]
 
-    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toEqual({
-      type: 'tool',
-      name: 'kma_apihub_url_analysis_weather_chart_image',
-    })
+    expect(selectUmmayaToolChoiceOverride({ messages: firstTurn, tools })).toBeUndefined()
 
     const afterChartAttempt = [
       ...firstTurn,
@@ -2677,7 +2650,7 @@ describe('UMMAYA model-facing tool surface', () => {
     ).toContain('Do not ask for coordinates')
   })
 
-  test('analysis map wording forces synced chart adapter before tool pool refresh', () => {
+  test('analysis map wording does not force synced chart adapter before backend validation', () => {
     clearManifestCache()
     ingestManifestFrame({
       kind: 'adapter_manifest_sync',
@@ -2725,10 +2698,7 @@ describe('UMMAYA model-facing tool surface', () => {
       tools: [toolNamed('find'), toolNamed('locate'), toolNamed('kma_current_observation')],
     })
 
-    expect(override).toEqual({
-      type: 'tool',
-      name: 'kma_apihub_url_analysis_weather_chart_image',
-    })
+    expect(override).toBeUndefined()
   })
 
   test('AED wording rejects ER adapter substitution at validation time', async () => {
@@ -4665,7 +4635,7 @@ describe('UMMAYA model-facing tool surface', () => {
     }
   })
 
-  test('protected certificate wording forces concrete check adapter tool choice', () => {
+  test('protected certificate wording does not force concrete check adapter tool choice before validation', () => {
     const override = selectUmmayaToolChoiceOverride({
       messages: [
         {
@@ -4685,13 +4655,10 @@ describe('UMMAYA model-facing tool surface', () => {
       ],
     })
 
-    expect(override).toEqual({
-      type: 'tool',
-      name: 'mock_verify_module_simple_auth',
-    })
+    expect(override).toBeUndefined()
   })
 
-  test('protected certificate wording retrieves and forces check adapter before unrelated find tools', () => {
+  test('protected certificate wording retrieves check adapters without forcing before validation', () => {
     clearManifestCache()
     ingestManifestFrame({
       kind: 'adapter_manifest_sync',
@@ -4783,10 +4750,7 @@ describe('UMMAYA model-facing tool surface', () => {
       ] as any,
       tools: [toolNamed('find'), toolNamed('check'), toolNamed('ToolSearch')],
     })
-    expect(override).toEqual({
-      type: 'tool',
-      name: 'mock_verify_mobile_id',
-    })
+    expect(override).toBeUndefined()
   })
 
   test('protected certificate wording suppresses further tools after a check attempt', () => {

--- a/tui/tests/tools/ummaya-model-facing-tool-surface.test.ts
+++ b/tui/tests/tools/ummaya-model-facing-tool-surface.test.ts
@@ -1506,6 +1506,101 @@ describe('UMMAYA model-facing tool surface', () => {
       name: 'kma_apihub_url_analysis_weather_chart_image',
     })
 
+    const weatherMismatchMessages = [
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '부산역 지금 비 와? 우산 챙겨야 해?',
+        },
+      },
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'air-1',
+              name: 'airkorea_ctprvn_air_quality',
+              input: { sido_name: '부산' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'air-1',
+              is_error: true,
+              content:
+                '<tool_use_error>Public-data tool-choice mismatch: target=weather_current. The latest citizen request needs official weather or location data; the previous tool choice does not match that route.</tool_use_error>',
+            },
+          ],
+        },
+      },
+    ] as any
+    const weatherTools = [
+      toolNamed('airkorea_ctprvn_air_quality'),
+      toolNamed('kakao_keyword_search'),
+      toolNamed('kma_current_observation'),
+    ]
+    expect(
+      selectUmmayaToolChoiceOverride({
+        messages: weatherMismatchMessages,
+        tools: weatherTools,
+      }),
+    ).toEqual({ type: 'tool', name: 'kakao_keyword_search' })
+
+    const weatherAfterLocationMessages = [
+      ...weatherMismatchMessages,
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'loc-1',
+              name: 'kakao_keyword_search',
+              input: { query: '부산역' },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'loc-1',
+              content:
+                '{"ok":true,"result":{"kind":"poi","lat":35.115,"lon":129.041,"nx":98,"ny":76}}',
+            },
+            {
+              type: 'tool_result',
+              tool_use_id: 'air-1',
+              is_error: true,
+              content:
+                '<tool_use_error>Public-data tool-choice mismatch: target=current_weather. The latest citizen request needs that route; the previous tool choice does not match that route.</tool_use_error>',
+            },
+          ],
+        },
+      },
+    ] as any
+    expect(
+      selectUmmayaToolChoiceOverride({
+        messages: weatherAfterLocationMessages,
+        tools: weatherTools,
+      }),
+    ).toEqual({ type: 'tool', name: 'kma_current_observation' })
+
     const afterAirKorea = [
       ...airFirstTurn,
       {

--- a/tui/tests/tools/ummaya-model-facing-tool-surface.test.ts
+++ b/tui/tests/tools/ummaya-model-facing-tool-surface.test.ts
@@ -425,7 +425,7 @@ describe('UMMAYA model-facing tool surface', () => {
     expect(selected).not.toContain('kakao_address_search')
   })
 
-  test('PPS bid wording does not force synced concrete adapter before backend validation', () => {
+  test('PPS bid wording does not force synced concrete adapter on the first turn', () => {
     clearManifestCache()
     ingestManifestFrame({
       kind: 'adapter_manifest_sync',
@@ -582,7 +582,10 @@ describe('UMMAYA model-facing tool surface', () => {
       ppsContext,
     )
     expect(ppsLocate.result).toBe(false)
-    if (!ppsLocate.result) expect(ppsLocate.message).toContain('pps_bid_public_info')
+    if (!ppsLocate.result) {
+      expect(ppsLocate.message).toContain('target=procurement_bid')
+      expect(ppsLocate.message).not.toContain('pps_bid_public_info')
+    }
 
     const ppsTool = getAdapterToolByName('pps_bid_public_info')
     expect(ppsTool).toBeDefined()
@@ -611,7 +614,23 @@ describe('UMMAYA model-facing tool surface', () => {
       airContext,
     )
     expect(airWeather.result).toBe(false)
-    if (!airWeather.result) expect(airWeather.message).toContain('airkorea_ctprvn_air_quality')
+    if (!airWeather.result) {
+      expect(airWeather.message).toContain('target=air_quality')
+      expect(airWeather.message).not.toContain('airkorea_ctprvn_air_quality')
+    }
+    const airQualityContext = {
+      options: { tools: [] },
+      messages: [{ role: 'user', content: '부산 공기질 지금 어때? air quality 확인해줘' }],
+    } as any
+    const airQualityWeather = await LookupPrimitive.validateInput!(
+      { tool_id: 'kma_current_observation', params: { nx: 98, ny: 75 } },
+      airQualityContext,
+    )
+    expect(airQualityWeather.result).toBe(false)
+    if (!airQualityWeather.result) {
+      expect(airQualityWeather.message).toContain('target=air_quality')
+      expect(airQualityWeather.message).not.toContain('airkorea_ctprvn_air_quality')
+    }
     const broadAirKorea = normalizeDirectPublicDataToolInput(
       'airkorea_ctprvn_air_quality',
       airContext,
@@ -632,7 +651,7 @@ describe('UMMAYA model-facing tool surface', () => {
     )
     expect(weatherAir.result).toBe(false)
     if (!weatherAir.result) {
-      expect(weatherAir.message).toContain('KMA weather/location adapters')
+      expect(weatherAir.message).toContain('target=weather_current')
     }
 
     const weatherWithMetaContext = {
@@ -663,7 +682,7 @@ describe('UMMAYA model-facing tool surface', () => {
     )
     expect(weatherWithMetaAir.result).toBe(false)
     if (!weatherWithMetaAir.result) {
-      expect(weatherWithMetaAir.message).toContain('KMA weather/location adapters')
+      expect(weatherWithMetaAir.message).toContain('target=weather_current')
       expect(weatherWithMetaAir.message).not.toContain(
         'kma_apihub_url_analysis_weather_chart_image',
       )
@@ -681,7 +700,7 @@ describe('UMMAYA model-facing tool surface', () => {
     )
     expect(chartWeather.result).toBe(false)
     if (!chartWeather.result) {
-      expect(chartWeather.message).toContain('kma_apihub_url_analysis_weather_chart_image')
+      expect(chartWeather.message).toContain('target=weather_chart')
       expect(chartWeather.message).toContain('YYYYMMDDHHMM')
       expect(chartWeather.message).toContain('UTC')
     }
@@ -885,7 +904,10 @@ describe('UMMAYA model-facing tool surface', () => {
       context,
     )
     expect(weather.result).toBe(false)
-    if (!weather.result) expect(weather.message).toContain('TAGO')
+    if (!weather.result) {
+      expect(weather.message).toContain('target=bus_realtime')
+      expect(weather.message).not.toContain('tago_bus_')
+    }
 
     const wrongBusanCode = await LookupPrimitive.validateInput!(
       { tool_id: 'tago_bus_station_search', params: { city_code: '11', node_nm: '부산역' } },
@@ -1359,7 +1381,7 @@ describe('UMMAYA model-facing tool surface', () => {
               tool_use_id: 'locate-1',
               is_error: true,
               content:
-                '<tool_use_error>Public-data tool-choice mismatch: the latest citizen request matches TAGO bus adapters. Call TAGO bus adapters through the correct primitive instead of kakao_keyword_search.</tool_use_error>',
+                '<tool_use_error>Public-data tool-choice mismatch: target=bus_realtime. The latest citizen request needs official bus route or arrival data; the previous tool choice does not match that route.</tool_use_error>',
             },
           ],
         },
@@ -1413,7 +1435,7 @@ describe('UMMAYA model-facing tool surface', () => {
               tool_use_id: 'locate-2',
               is_error: true,
               content:
-                "<tool_use_error>Public-data tool-choice mismatch: the latest citizen request matches airkorea_ctprvn_air_quality. Call airkorea_ctprvn_air_quality through the correct primitive instead of kakao_address_search. params should include sido_name:'부산'.</tool_use_error>",
+                '<tool_use_error>Public-data tool-choice mismatch: target=air_quality. The latest citizen request needs official city/province air-quality data; the previous tool choice does not match that route.</tool_use_error>',
             },
           ],
         },
@@ -1435,6 +1457,54 @@ describe('UMMAYA model-facing tool surface', () => {
       },
     ] as any
     expect(selectUmmayaToolChoiceOverride({ messages: airFirstTurn, tools })).toBeUndefined()
+
+    const chartMessages = [
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: '내일 비구름 흐름 일기도 지도 자료 보여줘',
+        },
+      },
+      {
+        type: 'assistant',
+        message: {
+          role: 'assistant',
+          content: [
+            {
+              type: 'tool_use',
+              id: 'weather-1',
+              name: 'kma_current_observation',
+              input: { nx: 98, ny: 76 },
+            },
+          ],
+        },
+      },
+      {
+        type: 'user',
+        message: {
+          role: 'user',
+          content: [
+            {
+              type: 'tool_result',
+              tool_use_id: 'weather-1',
+              is_error: true,
+              content:
+                '<tool_use_error>Public-data tool-choice mismatch: target=weather_chart. The latest citizen request needs official weather chart data; the previous tool choice does not match that route.</tool_use_error>',
+            },
+          ],
+        },
+      },
+    ] as any
+    const chartTools = [
+      toolNamed('kma_current_observation'),
+      toolNamed('kma_apihub_url_analysis_weather_chart_image'),
+      toolNamed('pps_bid_public_info'),
+    ]
+    expect(selectUmmayaToolChoiceOverride({ messages: chartMessages, tools: chartTools })).toEqual({
+      type: 'tool',
+      name: 'kma_apihub_url_analysis_weather_chart_image',
+    })
 
     const afterAirKorea = [
       ...airFirstTurn,
@@ -1464,6 +1534,7 @@ describe('UMMAYA model-facing tool surface', () => {
     })
     expect(airKoreaCompletionPrompt).toContain('actual tool_result')
     expect(airKoreaCompletionPrompt).toContain('do not infer the citizen place district')
+    expect(airKoreaCompletionPrompt).not.toContain('airkorea_ctprvn_air_quality')
     const airKoreaNearestClaim = {
       type: 'assistant',
       message: {
@@ -1483,6 +1554,11 @@ describe('UMMAYA model-facing tool surface', () => {
         messages: [...afterAirKorea, airKoreaNearestClaim],
       }),
     ).toContain('city/province station data')
+    expect(
+      buildAirKoreaFinalAnswerRepairPromptIfNeeded({
+        messages: [...afterAirKorea, airKoreaNearestClaim],
+      }),
+    ).not.toContain('airkorea_ctprvn_air_quality')
   })
 
   test('textual tool-call final answers are withheld and repaired after tool evidence', () => {
@@ -4200,6 +4276,75 @@ describe('UMMAYA model-facing tool surface', () => {
     expect(forecastSelected).not.toContain('bfc_funeral_area_fee')
   })
 
+  test('air-quality public-data query selects AirKorea over location and KMA weather', () => {
+    clearManifestCache()
+    ingestManifestFrame({
+      kind: 'adapter_manifest_sync',
+      version: '1.0',
+      session_id: 'test-session',
+      correlation_id: '01HXKQ7Z3M1V8K2YQ8A6P4F9C7',
+      ts: new Date().toISOString(),
+      role: 'backend',
+      frame_seq: 0,
+      entries: [
+        {
+          tool_id: 'kakao_keyword_search',
+          name: 'Kakao Keyword Search',
+          primitive: 'locate',
+          policy_authority_url: 'https://developers.kakao.com/',
+          source_mode: 'live',
+          search_hint: '장소 키워드 POI 부산 위치 keyword place station',
+          llm_description: 'Resolve POI/place names to coordinates.',
+          input_schema_json: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          },
+        },
+        {
+          tool_id: 'kma_current_observation',
+          name: 'KMA Current Observation',
+          primitive: 'find',
+          policy_authority_url: 'https://apihub.kma.go.kr/',
+          source_mode: 'live',
+          search_hint: '현재 날씨 비 예보 기상청 KMA current weather',
+          llm_description: 'KMA current weather observation.',
+          input_schema_json: {
+            type: 'object',
+            properties: { nx: { type: 'integer' }, ny: { type: 'integer' } },
+            required: ['nx', 'ny'],
+            additionalProperties: false,
+          },
+        },
+        {
+          tool_id: 'airkorea_ctprvn_air_quality',
+          name: 'AirKorea Air Quality',
+          primitive: 'find',
+          policy_authority_url: 'https://www.data.go.kr/data/15073861/openapi.do',
+          source_mode: 'live',
+          search_hint: '에어코리아 미세먼지 초미세먼지 대기질 대기오염 PM10 PM2.5',
+          llm_description: 'AirKorea city/province air quality.',
+          input_schema_json: {
+            type: 'object',
+            properties: { sido_name: { type: 'string' } },
+            required: ['sido_name'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      manifest_hash: 'b'.repeat(64),
+      emitter_pid: 12345,
+    } satisfies AdapterManifestSyncFrame)
+
+    const selected = selectTopKAdapterToolNamesForQuery(
+      '공공데이터에서 부산 미세먼지 관련 자료 찾아줘',
+      5,
+    )
+
+    expect(selected).toEqual(['airkorea_ctprvn_air_quality'])
+  })
+
   test('public safety and assistive location wording keeps dedicated adapters', () => {
     clearManifestCache()
     ingestManifestFrame({
@@ -4751,6 +4896,207 @@ describe('UMMAYA model-facing tool surface', () => {
       tools: [toolNamed('find'), toolNamed('check'), toolNamed('ToolSearch')],
     })
     expect(override).toBeUndefined()
+  })
+
+  test('Gov24 minwon submit wording retrieves protected check and submit chain', () => {
+    clearManifestCache()
+    ingestManifestFrame({
+      kind: 'adapter_manifest_sync',
+      version: '1.0',
+      session_id: 'test-session',
+      correlation_id: '01HXKQ7Z3M1V8K2YQ8A6P4F9A3',
+      ts: new Date().toISOString(),
+      role: 'backend',
+      frame_seq: 0,
+      entries: [
+        {
+          tool_id: 'kakao_keyword_search',
+          name: 'Kakao Keyword Search',
+          primitive: 'locate',
+          policy_authority_url: 'https://developers.kakao.com/',
+          source_mode: 'live',
+          search_hint: '장소 키워드 위치 검색',
+          llm_description: 'Resolve place names.',
+          input_schema_json: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          },
+        },
+        {
+          tool_id: 'ccourt_publication_documents',
+          name: 'Court Publications',
+          primitive: 'find',
+          policy_authority_url: 'https://www.scourt.go.kr/',
+          source_mode: 'live',
+          search_hint: '공고 문서 열람',
+          llm_description: 'Court document publication search.',
+          input_schema_json: {
+            type: 'object',
+            properties: { query: { type: 'string' } },
+            required: ['query'],
+            additionalProperties: false,
+          },
+        },
+        {
+          tool_id: 'mock_lookup_module_gov24_certificate',
+          name: 'Government24 certificate lookup',
+          primitive: 'find',
+          policy_authority_url: 'https://www.gov.kr/',
+          source_mode: 'mock',
+          search_hint: '정부24 주민등록등본 증명서 조회',
+          llm_description: 'Mock Government24 certificate lookup.',
+          input_schema_json: {
+            type: 'object',
+            properties: {
+              certificate_type: { type: 'string' },
+              purpose: { type: 'string' },
+            },
+            required: ['certificate_type', 'purpose'],
+            additionalProperties: false,
+          },
+        },
+        {
+          tool_id: 'mock_verify_module_simple_auth',
+          name: 'Simple Auth Module',
+          primitive: 'check',
+          policy_authority_url: 'https://www.gov.kr/',
+          source_mode: 'mock',
+          search_hint: '간편인증 정부24 주민등록등본 민원 발급',
+          llm_description: 'Simple auth check for protected Gov24 requests.',
+          input_schema_json: {
+            type: 'object',
+            properties: { scope_list: { type: 'array', items: { type: 'string' } } },
+            required: ['scope_list'],
+            additionalProperties: false,
+          },
+        },
+        {
+          tool_id: 'mock_submit_module_gov24_minwon',
+          name: 'Government24 civil petition submit',
+          primitive: 'send',
+          policy_authority_url: 'https://www.gov.kr/',
+          source_mode: 'mock',
+          search_hint: '정부24 주민등록등본 민원 신청 발급 제출',
+          llm_description: 'Mock Government24 civil petition submission adapter.',
+          input_schema_json: {
+            type: 'object',
+            properties: {
+              form_code: { type: 'string' },
+              delegation_token: { type: 'string' },
+            },
+            required: ['form_code', 'delegation_token'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      manifest_hash: 'c'.repeat(64),
+      emitter_pid: 12345,
+    } satisfies AdapterManifestSyncFrame)
+
+    const selected = selectTopKAdapterToolNamesForQuery(
+      '정부24에서 주민등록등본 발급 민원 신청해줘',
+      5,
+    )
+
+    expect(selected[0]).toBe('mock_verify_module_simple_auth')
+    expect(selected).toContain('mock_submit_module_gov24_minwon')
+    expect(selected).toContain('mock_lookup_module_gov24_certificate')
+    expect(selected).not.toContain('kakao_keyword_search')
+    expect(selected).not.toContain('ccourt_publication_documents')
+
+    const override = selectUmmayaToolChoiceOverride({
+      messages: [
+        {
+          type: 'user',
+          message: { role: 'user', content: '정부24에서 주민등록등본 발급 민원 신청해줘' },
+        },
+      ] as any,
+      tools: [
+        toolNamed('ToolSearch'),
+        toolNamed('mock_verify_module_simple_auth'),
+        toolNamed('mock_submit_module_gov24_minwon'),
+      ],
+    })
+    expect(override).toEqual({
+      type: 'tool',
+      name: 'mock_verify_module_simple_auth',
+    })
+  })
+
+  test('protected concrete check adapters require permission before direct execution', async () => {
+    clearManifestCache()
+    ingestManifestFrame({
+      kind: 'adapter_manifest_sync',
+      version: '1.0',
+      session_id: 'test-session',
+      correlation_id: '01HXKQ7Z3M1V8K2YQ8A6P4F9B1',
+      ts: new Date().toISOString(),
+      role: 'backend',
+      frame_seq: 0,
+      entries: [
+        {
+          tool_id: 'mock_verify_module_simple_auth',
+          name: 'Simple Auth Module',
+          primitive: 'check',
+          policy_authority_url: 'https://www.gov.kr/',
+          source_mode: 'mock',
+          search_hint: '간편인증 주민등록등본 민원 발급 simple auth',
+          llm_description: 'Mock simple-auth verification adapter.',
+          input_schema_json: {
+            type: 'object',
+            properties: { scope_list: { type: 'array', items: { type: 'string' } } },
+            required: ['scope_list'],
+            additionalProperties: false,
+          },
+        },
+        {
+          tool_id: 'mock_submit_module_gov24_minwon',
+          name: 'Government24 civil petition submit',
+          primitive: 'send',
+          policy_authority_url: 'https://www.gov.kr/',
+          source_mode: 'mock',
+          search_hint: '정부24 주민등록등본 민원 신청 발급 제출',
+          llm_description: 'Mock Government24 civil petition submission adapter.',
+          input_schema_json: {
+            type: 'object',
+            properties: {
+              form_code: { type: 'string' },
+              delegation_token: { type: 'string' },
+            },
+            required: ['form_code', 'delegation_token'],
+            additionalProperties: false,
+          },
+        },
+      ],
+      manifest_hash: 'a'.repeat(64),
+      emitter_pid: 12345,
+    } satisfies AdapterManifestSyncFrame)
+
+    const checkTool = getAdapterToolByName('mock_verify_module_simple_auth')
+    expect(checkTool).toBeDefined()
+    expect(checkTool?.isReadOnly({ scope_list: ['gov24.resident_registration'] })).toBe(
+      false,
+    )
+    expect(
+      checkTool?.isDestructive?.({ scope_list: ['gov24.resident_registration'] }),
+    ).toBe(true)
+    const checkPermission = await checkTool!.checkPermissions(
+      { scope_list: ['gov24.resident_registration'] },
+      {} as any,
+    )
+    expect(checkPermission.behavior).toBe('ask')
+    expect(checkPermission.message).toContain('권한 위임 필요')
+
+    const sendTool = getAdapterToolByName('mock_submit_module_gov24_minwon')
+    expect(sendTool).toBeDefined()
+    const sendPermission = await sendTool!.checkPermissions(
+      { form_code: 'resident-registration', delegation_token: 'mock-token' },
+      {} as any,
+    )
+    expect(sendPermission.behavior).toBe('ask')
+    expect(sendPermission.message).toContain('제출 요청')
   })
 
   test('protected certificate wording suppresses further tools after a check attempt', () => {


### PR DESCRIPTION
## Summary
- Replace brittle scattered adapter selection with route-decision backed projection, retrieval policy, and explicit intent/target labels.
- Add backend/TUI route diagnostics for adapter selection, dispatch, result, and permission-prompt boundaries.
- Harden permission-sensitive Gov24/verify paths so real TUI evidence stops at the permission prompt before execution.

## Canonical references
- docs/vision.md
- docs/requirements/ummaya-migration-tree.md
- .references/claude-code-sourcemap/restored-src/

## Verification
- uv run ruff check src tests
- uv run ruff format --check src tests
- uv run mypy src
- git diff --check
- uv run pytest tests/evidence tests/ci -q
- uv run python -m ummaya.evidence --source-ref local --dataset-ref ummaya/national-ax-core@local --out .evidence/run.json
- cd tui && bun run typecheck
- cd tui && bun run test
- uv run pytest -m "not live"

## Evidence
- C002 v10 real TUI Gov24 edge: route_tool_dispatch -> route_tool_permission ask/prompted, route_tool_call_start_count=0.
- C003 v10: TUI 337 pass / 0 fail; backend non-live 4592 passed, 6 skipped, 51 deselected, 2 xfailed.
- Final code review: APPROVE. Final ULW review: APPROVE.